### PR TITLE
Fix #216: [Bug]: Inbounds calls phone no. are not getting displayed

### DIFF
--- a/api/db/organization_usage_client.py
+++ b/api/db/organization_usage_client.py
@@ -316,9 +316,10 @@ class OrganizationUsageClient(BaseDBClient):
                 total_duration_seconds += int(round(call_duration))
 
                 # Extract phone number from initial_context
+                # Outbound calls store it as "phone_number"; inbound calls store it as "caller_number"
                 phone_number = None
                 if run.initial_context:
-                    phone_number = run.initial_context.get("phone_number")
+                    phone_number = run.initial_context.get("phone_number") or run.initial_context.get("caller_number")
 
                 # Extract disposition from gathered_context
                 disposition = None


### PR DESCRIPTION
Closes #216

## Motivation

Inbound calls store the caller's phone number under the key `caller_number` in `initial_context`, but the usage log query only checked for `phone_number` (used by outbound calls). This caused inbound call entries to always display a blank phone number in the usage logs.

## Changes

**`api/db/organization_usage_client.py`**

In the call log aggregation loop (around line 325), the phone number extraction now falls back to `caller_number` when `phone_number` is absent:

```python
# Before
phone_number = run.initial_context.get("phone_number")

# After
phone_number = run.initial_context.get("phone_number") or run.initial_context.get("caller_number")
```

This single-line change in the `initial_context` extraction block covers both call directions: outbound calls continue to resolve via `phone_number`, and inbound calls now correctly resolve via `caller_number`.

## Testing

1. Navigate to the Usage side tab in the dashboard.
2. Trigger an inbound call to an agent connected via a VoBiz number.
3. Confirm the caller's phone number is now populated in the call log row (previously blank).
4. Trigger an outbound call and confirm its phone number continues to display correctly — the `or` fallback does not affect outbound records that already have `phone_number` set.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*