### PR TITLE
feat: add Smartflo (Tata Tele) bi-directional voice streaming

### DIFF
--- a/api/enums.py
+++ b/api/enums.py
@@ -26,6 +26,7 @@ class WorkflowRunMode(Enum):
     TELNYX = "telnyx"
     WEBRTC = "webrtc"
     SMALLWEBRTC = "smallwebrtc"
+    SMARTFLO = "smartflo"
 
     # Historical, not used anymore. Don't
     # use and don't remove

--- a/api/routes/telephony.py
+++ b/api/routes/telephony.py
@@ -1857,3 +1857,112 @@ async def complete_transfer_function_call(transfer_id: str, request: Request):
         logger.error(f"Error completing transfer {transfer_id}: {e}")
 
     return {"status": "completed", "result": result}
+
+
+# ── Smartflo (Tata Tele Business) bi-directional voice streaming ──────────────
+
+@router.websocket("/ws/smartflo/{workflow_id}/{user_id}")
+async def smartflo_websocket_endpoint(
+    websocket: WebSocket,
+    workflow_id: int,
+    user_id: int,
+) -> None:
+    """
+    Smartflo bi-directional voice streaming WebSocket endpoint.
+
+    No authentication required — Smartflo connects directly from their platform.
+    Configure the streaming URL in the Smartflo portal as:
+        ws://<host>/api/v1/telephony/ws/smartflo/<workflow_id>/<user_id>
+
+    Protocol: Dograh sends {"event":"connected"} first, then Smartflo sends
+    "start" with call metadata, followed by bidirectional "media" frames.
+    Failure to send the connected ACK immediately causes Smartflo to disconnect
+    with code 1005 (no status received).
+
+    Reference:
+        https://docs.smartflo.tatatelebusiness.com/docs/bi-directional-audio-streaming-integration-document
+    """
+    import uuid as _uuid
+
+    from api.db import db_client
+    from api.services.pipecat.run_pipeline import run_pipeline_twilio
+    from api.services.telephony.providers.smartflo_provider import SmartfloTransport
+
+    await websocket.accept()
+    logger.info(f"[Smartflo] WS accepted | workflow_id={workflow_id} user_id={user_id}")
+
+    transport = SmartfloTransport(websocket)
+
+    # Handshake: send connected ACK, receive start event with call metadata
+    if not await transport.handshake():
+        logger.error("[Smartflo] Handshake failed — closing connection")
+        await transport.close()
+        return
+
+    ci = transport.call_info
+    logger.info(
+        f"[Smartflo] Handshake complete | callSid={ci['call_sid']} "
+        f"from={ci['from_number']} to={ci['to_number']}"
+    )
+
+    # Create workflow run record
+    numeric_suffix = int(str(_uuid.uuid4()).replace("-", "")[:8], 16) % 100_000_000
+    run_name = f"WR-SFLO-IN-{numeric_suffix:08d}"
+
+    workflow_run = None
+    try:
+        workflow_run = await db_client.create_workflow_run(
+            run_name,
+            workflow_id,
+            "smartflo",
+            user_id=user_id,
+            call_type="inbound",
+            initial_context={
+                "caller_number": ci.get("from_number", ""),
+                "called_number": ci.get("to_number", ""),
+                "direction":     "inbound",
+                "provider":      "smartflo",
+                "stream_sid":    ci.get("stream_sid", ""),
+                "call_sid":      ci.get("call_sid", ""),
+                "account_sid":   ci.get("account_sid", ""),
+            },
+            gathered_context={
+                "call_id":    ci.get("call_sid", ""),
+                "stream_sid": ci.get("stream_sid", ""),
+            },
+        )
+        logger.info(f"[Smartflo] Created workflow run id={workflow_run.id} name={run_name}")
+        await db_client.update_workflow_run(
+            run_id=workflow_run.id,
+            state="running",
+        )
+    except Exception as exc:
+        logger.error(f"[Smartflo] Failed to create workflow run: {exc}")
+        await transport.close()
+        return
+
+    # Run Pipecat pipeline (Smartflo and Twilio both use \u03bc-law 8kHz)
+    try:
+        await run_pipeline_twilio(
+            websocket,
+            ci.get("stream_sid", ""),
+            ci.get("call_sid", ""),
+            workflow_id,
+            workflow_run.id,
+            user_id,
+        )
+    except WebSocketDisconnect:
+        logger.info(f"[Smartflo] Call ended cleanly | run_id={workflow_run.id}")
+    except Exception as exc:
+        logger.error(f"[Smartflo] Pipeline error | run_id={workflow_run.id} error={exc}")
+    finally:
+        await transport.close()
+        try:
+            await db_client.update_workflow_run(
+                run_id=workflow_run.id,
+                is_completed=True,
+                state="completed",
+            )
+            logger.info(f"[Smartflo] Run {workflow_run.id} marked completed")
+        except Exception as exc:
+            logger.warning(f"[Smartflo] Could not mark run completed: {exc}")

--- a/api/services/telephony/providers/smartflo_provider.py
+++ b/api/services/telephony/providers/smartflo_provider.py
@@ -1,0 +1,298 @@
+"""
+Smartflo (Tata Tele Business) bi-directional voice streaming provider.
+
+This module implements the Smartflo WebSocket streaming protocol for the
+Dograh voice AI platform. It handles the full call lifecycle:
+
+  Connection Establishment:
+    1. Dograh accepts the WebSocket connection (HTTP 101).
+    2. Dograh immediately sends {"event": "connected"} — Smartflo REQUIRES
+       this ACK before it will send the "start" event. Without it, Smartflo
+       closes the connection with code 1005 (no status received).
+
+  Stream Initialization:
+    3. Smartflo sends {"event": "start", "start": {...}, "streamSid": "MZ..."}
+       containing call metadata (callSid, from/to numbers, media format).
+
+  Audio Streaming:
+    4. Smartflo streams {"event": "media", "media": {"payload": "<base64>"}}
+       frames containing μ-law 8kHz audio from the caller (~every 100ms).
+    5. Dograh sends back {"event": "media", "media": {"payload": "<base64>"}}
+       frames containing μ-law 8kHz TTS audio to play to the caller.
+       Payloads MUST be multiples of 160 bytes (= 20ms of μ-law @ 8kHz).
+
+  Stream Termination:
+    6. Smartflo sends {"event": "stop"} when the call ends.
+    7. Dograh can send {"event": "clear"} to flush the audio buffer.
+    8. Dograh can send {"event": "mark"} to track when audio playback ends.
+
+Reference:
+  https://docs.smartflo.tatatelebusiness.com/docs/bi-directional-audio-streaming-integration-document
+"""
+
+import asyncio
+import base64
+import json
+import uuid
+from typing import Optional
+
+from fastapi import WebSocket, WebSocketDisconnect
+from loguru import logger
+from starlette.websockets import WebSocketState
+
+# ── Protocol constants ─────────────────────────────────────────────────────────
+# Smartflo requires this to be sent immediately after WS upgrade.
+CONNECTED_ACK = json.dumps({"event": "connected"})
+
+# μ-law @ 8 kHz: 8000 samples/sec × 1 byte/sample = 8000 bytes/sec.
+# 20ms frame = 160 bytes. Smartflo requires payloads to be multiples of 160.
+MULAW_CHUNK_BYTES = 160
+MULAW_SILENCE_BYTE = 0x7F  # μ-law silence value
+
+
+# ── Frame builders ─────────────────────────────────────────────────────────────
+
+def _build_media_frame(stream_sid: str, audio: bytes, chunk_num: int) -> str:
+    """Build a Smartflo media event frame containing base64-encoded μ-law audio."""
+    return json.dumps({
+        "event": "media",
+        "streamSid": stream_sid,
+        "media": {
+            "payload": base64.b64encode(audio).decode("utf-8"),
+            "chunk": chunk_num,
+        },
+    })
+
+
+def _build_mark_frame(stream_sid: str, name: str) -> str:
+    """Build a mark event to be notified when audio playback ends."""
+    return json.dumps({
+        "event": "mark",
+        "streamSid": stream_sid,
+        "mark": {"name": name},
+    })
+
+
+def _build_clear_frame(stream_sid: str) -> str:
+    """Build a clear event to flush Smartflo's audio buffer (for barge-in)."""
+    return json.dumps({
+        "event": "clear",
+        "streamSid": stream_sid,
+    })
+
+
+# ── Transport ──────────────────────────────────────────────────────────────────
+
+class SmartfloTransport:
+    """
+    High-level WebSocket transport for the Smartflo voice streaming protocol.
+
+    Wraps a FastAPI WebSocket connection and provides:
+      - handshake()    — sends connected ACK, receives start event
+      - recv_audio()   — receives one frame; returns raw μ-law bytes or None
+      - send_audio()   — sends TTS μ-law audio back to the caller
+      - send_mark()    — notifies when bot audio playback ends
+      - send_clear()   — interrupts buffered audio (e.g. on barge-in)
+      - close()        — gracefully closes the connection
+
+    Usage::
+
+        transport = SmartfloTransport(websocket)
+        ok = await transport.handshake()
+        if not ok:
+            return
+
+        call_info = transport.call_info  # callSid, streamSid, from/to numbers
+
+        while True:
+            audio = await transport.recv_audio()  # raises WebSocketDisconnect on stop
+            if audio:
+                response = await ai_pipeline(audio)
+                await transport.send_audio(response)
+    """
+
+    def __init__(self, ws: WebSocket) -> None:
+        self._ws = ws
+        self._stream_sid: str = ""
+        self._chunk_out: int = 0
+        # Populated after a successful handshake()
+        self.call_info: dict = {}
+
+    # ── Handshake ──────────────────────────────────────────────────────────────
+
+    async def handshake(self) -> bool:
+        """
+        Execute the Smartflo connection handshake.
+
+        Sends the mandatory ``{"event": "connected"}`` ACK, then waits for
+        Smartflo's ``{"event": "start"}`` message that carries call metadata.
+
+        Returns:
+            True  — handshake succeeded; ``self.call_info`` is populated.
+            False — handshake failed (timeout, wrong event, bad JSON, etc.).
+                    Caller should close the connection and return.
+        """
+        # Step 2: Send connected ACK — MUST happen before anything else.
+        await self._ws.send_text(CONNECTED_ACK)
+        logger.info("[Smartflo] → sent connected ACK")
+
+        # Step 3: Wait for start event (Smartflo sends this after our ACK).
+        try:
+            raw = await asyncio.wait_for(self._ws.receive_text(), timeout=15.0)
+        except asyncio.TimeoutError:
+            logger.error("[Smartflo] Timed out waiting for 'start' event (15s)")
+            return False
+        except Exception as exc:
+            logger.error(f"[Smartflo] Error receiving start event: {exc}")
+            return False
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.error(f"[Smartflo] Invalid JSON in start message: {exc}. raw={raw[:200]}")
+            return False
+
+        event = data.get("event")
+        if event != "start":
+            logger.error(f"[Smartflo] Expected 'start' event, got '{event}'")
+            return False
+
+        start = data.get("start", {})
+        self._stream_sid = (
+            data.get("streamSid")
+            or start.get("streamSid")
+            or str(uuid.uuid4())
+        )
+        self.call_info = {
+            "stream_sid":  self._stream_sid,
+            "call_sid":    start.get("callSid", ""),
+            "account_sid": start.get("accountSid", ""),
+            "from_number": start.get("from", ""),
+            "to_number":   start.get("to", ""),
+            "direction":   start.get("direction", "inbound"),
+            "media_format": start.get("mediaFormat", {
+                "encoding":  "audio/x-mulaw",
+                "sampleRate": 8000,
+            }),
+        }
+        logger.info(
+            f"[Smartflo] ← start received | "
+            f"callSid={self.call_info['call_sid']} "
+            f"from={self.call_info['from_number']} "
+            f"to={self.call_info['to_number']} "
+            f"streamSid={self._stream_sid}"
+        )
+        return True
+
+    # ── Inbound frames ─────────────────────────────────────────────────────────
+
+    async def recv_audio(self) -> Optional[bytes]:
+        """
+        Receive one frame from Smartflo.
+
+        Returns:
+            bytes — raw μ-law audio from the caller (for ``media`` events).
+            None  — non-audio frame (e.g. ``dtmf``, ``mark``); caller can ignore.
+
+        Raises:
+            WebSocketDisconnect — when Smartflo sends ``{"event": "stop"}``
+                                  or the connection drops.
+        """
+        raw = await self._ws.receive_text()
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning(f"[Smartflo] Non-JSON frame (ignored): {raw[:100]}")
+            return None
+
+        event = data.get("event")
+
+        if event == "media":
+            try:
+                return base64.b64decode(data["media"]["payload"])
+            except (KeyError, Exception) as exc:
+                logger.warning(f"[Smartflo] Failed to decode media payload: {exc}")
+                return None
+
+        if event == "stop":
+            reason = data.get("stop", {}).get("reason", "unknown")
+            logger.info(f"[Smartflo] ← stop received | reason={reason}")
+            raise WebSocketDisconnect(code=1000, reason="call stopped")
+
+        if event == "dtmf":
+            digit = data.get("dtmf", {}).get("digit", "?")
+            logger.info(f"[Smartflo] ← dtmf | digit={digit}")
+            return None
+
+        if event == "mark":
+            name = data.get("mark", {}).get("name", "")
+            logger.debug(f"[Smartflo] ← mark | name={name}")
+            return None
+
+        logger.debug(f"[Smartflo] ← unhandled event: {event}")
+        return None
+
+    # ── Outbound frames ────────────────────────────────────────────────────────
+
+    async def send_audio(self, mulaw_bytes: bytes) -> None:
+        """
+        Send μ-law 8kHz TTS audio to be played to the caller.
+
+        Args:
+            mulaw_bytes: Raw μ-law audio bytes (any length). Automatically
+                         padded to the next multiple of MULAW_CHUNK_BYTES
+                         (160 bytes = 20ms) and sent in 160-byte chunks.
+        """
+        if not self._stream_sid:
+            logger.warning("[Smartflo] send_audio called before handshake")
+            return
+
+        # Pad to nearest multiple of MULAW_CHUNK_BYTES (Smartflo requirement).
+        remainder = len(mulaw_bytes) % MULAW_CHUNK_BYTES
+        if remainder:
+            mulaw_bytes += bytes([MULAW_SILENCE_BYTE] * (MULAW_CHUNK_BYTES - remainder))
+
+        # Send in MULAW_CHUNK_BYTES chunks.
+        for i in range(0, len(mulaw_bytes), MULAW_CHUNK_BYTES):
+            self._chunk_out += 1
+            frame = _build_media_frame(
+                self._stream_sid,
+                mulaw_bytes[i : i + MULAW_CHUNK_BYTES],
+                self._chunk_out,
+            )
+            await self._ws.send_text(frame)
+
+    async def send_mark(self, name: str = "end") -> None:
+        """
+        Send a mark event so Smartflo notifies us when TTS playback ends.
+
+        Args:
+            name: Arbitrary label; Smartflo echoes it back with the same name
+                  once the corresponding audio has finished playing.
+        """
+        if self._stream_sid:
+            await self._ws.send_text(_build_mark_frame(self._stream_sid, name))
+            logger.debug(f"[Smartflo] → mark | name={name}")
+
+    async def send_clear(self) -> None:
+        """
+        Flush Smartflo's audio buffer immediately.
+
+        Use this to interrupt the bot's speech when the caller starts talking
+        (barge-in / interruption detection). Smartflo will echo back any
+        pending mark events once the buffer is cleared.
+        """
+        if self._stream_sid:
+            await self._ws.send_text(_build_clear_frame(self._stream_sid))
+            logger.debug("[Smartflo] → clear (audio buffer flushed)")
+
+    # ── Lifecycle ──────────────────────────────────────────────────────────────
+
+    async def close(self) -> None:
+        """Gracefully close the WebSocket if still open."""
+        if self._ws.client_state != WebSocketState.DISCONNECTED:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass  # Already closed


### PR DESCRIPTION
## Summary

Adds support for [Smartflo (Tata Tele Business)](https://smartflo.tatatelebusiness.com/) bi-directional voice streaming to the Dograh voice AI platform.

### Root Cause Fixed
Smartflo was disconnecting all inbound calls with **WebSocket close code 1005** (no status received). The root cause: Dograh wasn't sending the mandatory `{"event":"connected"}` ACK after the WebSocket upgrade. Smartflo requires this immediately before it will send the `start` event.

### Changes

| File | Change |
|------|--------|
| `api/services/telephony/providers/smartflo_provider.py` | **NEW** — SmartfloTransport class |
| `api/routes/telephony.py` | Added `/ws/smartflo/{workflow_id}/{user_id}` route |
| `api/enums.py` | Added `SMARTFLO = "smartflo"` to WorkflowRunMode |

### Protocol Implemented (per Smartflo SOP)
```
1. Dograh accepts WebSocket (HTTP 101)
2. Dograh → {"event":"connected"}        ← sent first (mandatory)
3. Smartflo → {"event":"start",...}       ← call metadata
4. Smartflo ↔ Dograh → {"event":"media"} ← bidirectional audio (μ-law 8kHz)
5. Smartflo → {"event":"stop"}            ← call ended
```

### Endpoint
Configure in Smartflo portal:
```
ws://<host>/api/v1/telephony/ws/smartflo/<workflow_id>/<user_id>
```

### Verified
Protocol compliance test passes end-to-end on `13.233.23.12`:
- ✅ HTTP 101 WebSocket Upgrade
- ✅ `{"event":"connected"}` ACK sent immediately  
- ✅ `start` event accepted
- ✅ Pipeline exits cleanly (code 1000, not 1005)

Ref: https://docs.smartflo.tatatelebusiness.com/docs/bi-directional-audio-streaming-integration-document