### PR TITLE
feat: inline rename of workflow on the editor page

### DIFF
--- a/ui/src/app/workflow/[workflowId]/RenderWorkflow.tsx
+++ b/ui/src/app/workflow/[workflowId]/RenderWorkflow.tsx
@@ -15,7 +15,7 @@ import type { DocumentResponseSchema, RecordingResponseSchema, ToolResponse } fr
 import { FlowEdge, FlowNode, NodeType } from "@/components/flow/types";
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { DEFAULT_WORKFLOW_CONFIGURATIONS, WorkflowConfigurations } from '@/types/workflow-configurations';
+import { WorkflowConfigurations } from '@/types/workflow-configurations';
 
 import AddNodePanel from "../../../components/flow/AddNodePanel";
 import CustomEdge from "../../../components/flow/edges/CustomEdge";
@@ -315,10 +315,14 @@ function RenderWorkflow({ initialWorkflowName, workflowId, workflowUuid, initial
     }, [saveWorkflow, isViewingHistoricalVersion, fetchVersions]);
 
     const renameWorkflow = useCallback(async (newName: string) => {
-        await saveWorkflowConfigurations(
-            workflowConfigurations ?? DEFAULT_WORKFLOW_CONFIGURATIONS,
-            newName,
-        );
+        // The header doesn't render the pencil until the page has mounted with
+        // initial data, so workflowConfigurations is non-null by the time this
+        // runs. Throw rather than silently sending DEFAULT_WORKFLOW_CONFIGURATIONS,
+        // which would overwrite the saved server-side config.
+        if (!workflowConfigurations) {
+            throw new Error("Workflow configurations not loaded");
+        }
+        await saveWorkflowConfigurations(workflowConfigurations, newName);
     }, [saveWorkflowConfigurations, workflowConfigurations]);
 
     // Memoize the context value to prevent unnecessary re-renders

--- a/ui/src/app/workflow/[workflowId]/RenderWorkflow.tsx
+++ b/ui/src/app/workflow/[workflowId]/RenderWorkflow.tsx
@@ -15,7 +15,7 @@ import type { DocumentResponseSchema, RecordingResponseSchema, ToolResponse } fr
 import { FlowEdge, FlowNode, NodeType } from "@/components/flow/types";
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { WorkflowConfigurations } from '@/types/workflow-configurations';
+import { DEFAULT_WORKFLOW_CONFIGURATIONS, WorkflowConfigurations } from '@/types/workflow-configurations';
 
 import AddNodePanel from "../../../components/flow/AddNodePanel";
 import CustomEdge from "../../../components/flow/edges/CustomEdge";
@@ -92,6 +92,8 @@ function RenderWorkflow({ initialWorkflowName, workflowId, workflowUuid, initial
         setIsAddNodePanelOpen,
         handleNodeSelect,
         saveWorkflow,
+        workflowConfigurations,
+        saveWorkflowConfigurations,
         onConnect,
         onEdgesChange,
         onNodesChange,
@@ -312,6 +314,13 @@ function RenderWorkflow({ initialWorkflowName, workflowId, workflowUuid, initial
         }
     }, [saveWorkflow, isViewingHistoricalVersion, fetchVersions]);
 
+    const renameWorkflow = useCallback(async (newName: string) => {
+        await saveWorkflowConfigurations(
+            workflowConfigurations ?? DEFAULT_WORKFLOW_CONFIGURATIONS,
+            newName,
+        );
+    }, [saveWorkflowConfigurations, workflowConfigurations]);
+
     // Memoize the context value to prevent unnecessary re-renders
     const workflowContextValue = useMemo(() => ({
         saveWorkflow: guardedSaveWorkflow,
@@ -342,6 +351,7 @@ function RenderWorkflow({ initialWorkflowName, workflowId, workflowUuid, initial
                     onBackToDraft={handleBackToDraft}
                     hasDraft={hasDraft}
                     onPublished={handlePublished}
+                    renameWorkflow={renameWorkflow}
                 />
 
                 {/* Workflow Canvas */}

--- a/ui/src/app/workflow/[workflowId]/components/WorkflowEditorHeader.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/WorkflowEditorHeader.tsx
@@ -74,10 +74,16 @@ export const WorkflowEditorHeader = ({
     const [savingWorkflow, setSavingWorkflow] = useState(false);
     const [duplicating, setDuplicating] = useState(false);
     const [publishing, setPublishing] = useState(false);
-    const [isEditingName, setIsEditingName] = useState(false);
-    const [nameDraft, setNameDraft] = useState('');
-    const [nameError, setNameError] = useState<string | null>(null);
-    const [isRenaming, setIsRenaming] = useState(false);
+    // One discriminated-union state instead of (isEditingName, nameDraft,
+    // nameError, isRenaming): they're not independent — error and saving are
+    // mutually exclusive, and both are meaningless in the display state. The
+    // union makes the bad combinations unrepresentable and structurally
+    // prevents the Enter→disable-input→blur→re-fire race.
+    type RenameState =
+        | { kind: "display" }
+        | { kind: "editing"; draft: string; error: string | null }
+        | { kind: "saving"; draft: string };
+    const [rename, setRename] = useState<RenameState>({ kind: "display" });
     const nameInputRef = useRef<HTMLInputElement>(null);
     const renameButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -168,24 +174,23 @@ export const WorkflowEditorHeader = ({
     };
 
     const enterEditMode = () => {
-        setNameDraft(workflowName);
-        setNameError(null);
-        setIsEditingName(true);
+        setRename({ kind: "editing", draft: workflowName, error: null });
     };
 
     const exitEditMode = () => {
-        setIsEditingName(false);
-        setNameError(null);
+        setRename({ kind: "display" });
         // Return focus to the pencil button so keyboard users aren't stranded.
         // Defer to next tick so React commits the input unmount first.
         setTimeout(() => renameButtonRef.current?.focus(), 0);
     };
 
     const attemptSave = async () => {
-        if (isRenaming) return;
-        const trimmed = nameDraft.trim();
+        // Only "editing" can initiate a save. This also guards against the
+        // blur fired when disabling the input transitions us to "saving".
+        if (rename.kind !== "editing") return;
+        const trimmed = rename.draft.trim();
         if (trimmed.length === 0) {
-            setNameError("Name cannot be empty");
+            setRename({ ...rename, error: "Name cannot be empty" });
             return;
         }
         if (trimmed === workflowName) {
@@ -193,18 +198,16 @@ export const WorkflowEditorHeader = ({
             exitEditMode();
             return;
         }
-        setIsRenaming(true);
-        setNameError(null);
+        setRename({ kind: "saving", draft: rename.draft });
         try {
             await renameWorkflow(trimmed);
             // Success: store update already propagated workflowName. Exit edit mode.
-            setIsRenaming(false);
             exitEditMode();
         } catch {
             // Roll back: keep user's typed value, reopen the input, focus it,
             // surface a sonner toast (matches existing duplicate/publish failure pattern).
-            setIsRenaming(false);
             toast.error("Failed to rename workflow");
+            setRename({ kind: "editing", draft: trimmed, error: null });
             setTimeout(() => nameInputRef.current?.focus(), 0);
         }
     };
@@ -220,9 +223,10 @@ export const WorkflowEditorHeader = ({
     };
 
     const handleRenameBlur = () => {
+        // Ignore the blur fired when the input is disabled during save.
+        if (rename.kind !== "editing") return;
         // On blur with empty/whitespace, revert silently to display mode so the user is never trapped.
-        const trimmed = nameDraft.trim();
-        if (trimmed.length === 0) {
+        if (rename.draft.trim().length === 0) {
             exitEditMode();
             return;
         }
@@ -248,26 +252,29 @@ export const WorkflowEditorHeader = ({
                 </button>
 
                 <div className="flex items-center gap-2">
-                    {isEditingName ? (
+                    {rename.kind !== "display" ? (
                         <div className="flex flex-col gap-1">
                             <Input
                                 ref={nameInputRef}
-                                value={nameDraft}
+                                value={rename.draft}
                                 onChange={(e) => {
-                                    setNameDraft(e.target.value);
-                                    if (nameError) setNameError(null);
+                                    // onChange can't fire while disabled (kind === "saving"),
+                                    // but the type guard is needed for the discriminated union.
+                                    if (rename.kind === "editing") {
+                                        setRename({ ...rename, draft: e.target.value, error: null });
+                                    }
                                 }}
                                 onKeyDown={handleRenameKeyDown}
                                 onBlur={handleRenameBlur}
-                                disabled={isRenaming}
+                                disabled={rename.kind === "saving"}
                                 autoFocus
                                 onFocus={(e) => e.currentTarget.select()}
                                 aria-label="Workflow name"
-                                aria-invalid={nameError !== null}
+                                aria-invalid={rename.kind === "editing" && rename.error !== null}
                                 className="h-8 max-w-xs bg-[#2a2a2a] border-[#3a3a3a] text-white text-base font-medium"
                             />
-                            {nameError && (
-                                <span className="text-xs text-red-500" role="alert">{nameError}</span>
+                            {rename.kind === "editing" && rename.error && (
+                                <span className="text-xs text-red-500" role="alert">{rename.error}</span>
                             )}
                         </div>
                     ) : (

--- a/ui/src/app/workflow/[workflowId]/components/WorkflowEditorHeader.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/WorkflowEditorHeader.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { ReactFlowInstance } from "@xyflow/react";
-import { AlertCircle, ArrowLeft, ChevronDown, Clipboard, Copy, Download, Eye, History, LoaderCircle, Menu, MoreVertical, Phone, Rocket } from "lucide-react";
+import { AlertCircle, ArrowLeft, ChevronDown, Clipboard, Copy, Download, Eye, History, LoaderCircle, Menu, MoreVertical, Pencil, Phone, Rocket } from "lucide-react";
 import { useRouter } from "next/navigation";
 import posthog from "posthog-js";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 
 import {
@@ -21,6 +21,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import {
     Popover,
     PopoverContent,
@@ -47,6 +48,7 @@ interface WorkflowEditorHeaderProps {
     onBackToDraft: () => void;
     hasDraft: boolean;
     onPublished: () => void;
+    renameWorkflow: (newName: string) => Promise<void>;
 }
 
 export const WorkflowEditorHeader = ({
@@ -65,12 +67,19 @@ export const WorkflowEditorHeader = ({
     onPublished,
     workflowId,
     workflowUuid,
+    renameWorkflow,
 }: WorkflowEditorHeaderProps) => {
     const router = useRouter();
     const { toggleSidebar } = useSidebar();
     const [savingWorkflow, setSavingWorkflow] = useState(false);
     const [duplicating, setDuplicating] = useState(false);
     const [publishing, setPublishing] = useState(false);
+    const [isEditingName, setIsEditingName] = useState(false);
+    const [nameDraft, setNameDraft] = useState('');
+    const [nameError, setNameError] = useState<string | null>(null);
+    const [isRenaming, setIsRenaming] = useState(false);
+    const nameInputRef = useRef<HTMLInputElement>(null);
+    const renameButtonRef = useRef<HTMLButtonElement>(null);
 
     const hasValidationErrors = workflowValidationErrors.length > 0;
     const isCallDisabled = isDirty || hasValidationErrors;
@@ -158,6 +167,68 @@ export const WorkflowEditorHeader = ({
         URL.revokeObjectURL(url);
     };
 
+    const enterEditMode = () => {
+        setNameDraft(workflowName);
+        setNameError(null);
+        setIsEditingName(true);
+    };
+
+    const exitEditMode = () => {
+        setIsEditingName(false);
+        setNameError(null);
+        // Return focus to the pencil button so keyboard users aren't stranded.
+        // Defer to next tick so React commits the input unmount first.
+        setTimeout(() => renameButtonRef.current?.focus(), 0);
+    };
+
+    const attemptSave = async () => {
+        if (isRenaming) return;
+        const trimmed = nameDraft.trim();
+        if (trimmed.length === 0) {
+            setNameError("Name cannot be empty");
+            return;
+        }
+        if (trimmed === workflowName) {
+            // No-op: exit cleanly with no API call.
+            exitEditMode();
+            return;
+        }
+        setIsRenaming(true);
+        setNameError(null);
+        try {
+            await renameWorkflow(trimmed);
+            // Success: store update already propagated workflowName. Exit edit mode.
+            setIsRenaming(false);
+            exitEditMode();
+        } catch {
+            // Roll back: keep user's typed value, reopen the input, focus it,
+            // surface a sonner toast (matches existing duplicate/publish failure pattern).
+            setIsRenaming(false);
+            toast.error("Failed to rename workflow");
+            setTimeout(() => nameInputRef.current?.focus(), 0);
+        }
+    };
+
+    const handleRenameKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            void attemptSave();
+        } else if (event.key === "Escape") {
+            event.preventDefault();
+            exitEditMode();
+        }
+    };
+
+    const handleRenameBlur = () => {
+        // On blur with empty/whitespace, revert silently to display mode so the user is never trapped.
+        const trimmed = nameDraft.trim();
+        if (trimmed.length === 0) {
+            exitEditMode();
+            return;
+        }
+        void attemptSave();
+    };
+
     return (
         <div className="flex items-center justify-between w-full h-14 px-4 bg-[#1a1a1a] border-b border-[#2a2a2a]">
             {/* Left section: Mobile menu + Back button + Workflow name */}
@@ -177,12 +248,49 @@ export const WorkflowEditorHeader = ({
                 </button>
 
                 <div className="flex items-center gap-2">
-                    <h1 className="text-base font-medium text-white whitespace-nowrap">
-                        <span className="md:hidden">
-                            {workflowName.length > 8 ? `${workflowName.slice(0, 8)}…` : workflowName}
-                        </span>
-                        <span className="hidden md:inline">{workflowName}</span>
-                    </h1>
+                    {isEditingName ? (
+                        <div className="flex flex-col gap-1">
+                            <Input
+                                ref={nameInputRef}
+                                value={nameDraft}
+                                onChange={(e) => {
+                                    setNameDraft(e.target.value);
+                                    if (nameError) setNameError(null);
+                                }}
+                                onKeyDown={handleRenameKeyDown}
+                                onBlur={handleRenameBlur}
+                                disabled={isRenaming}
+                                autoFocus
+                                onFocus={(e) => e.currentTarget.select()}
+                                aria-label="Workflow name"
+                                aria-invalid={nameError !== null}
+                                className="h-8 max-w-xs bg-[#2a2a2a] border-[#3a3a3a] text-white text-base font-medium"
+                            />
+                            {nameError && (
+                                <span className="text-xs text-red-500" role="alert">{nameError}</span>
+                            )}
+                        </div>
+                    ) : (
+                        <>
+                            <h1 className="text-base font-medium text-white whitespace-nowrap truncate max-w-[14rem] md:max-w-md">
+                                <span className="md:hidden">
+                                    {workflowName.length > 8 ? `${workflowName.slice(0, 8)}…` : workflowName}
+                                </span>
+                                <span className="hidden md:inline">{workflowName}</span>
+                            </h1>
+                            {!isViewingHistoricalVersion && (
+                                <button
+                                    ref={renameButtonRef}
+                                    type="button"
+                                    onClick={enterEditMode}
+                                    aria-label="Rename workflow"
+                                    className="flex items-center justify-center w-8 h-8 rounded-lg hover:bg-[#2a2a2a] transition-colors"
+                                >
+                                    <Pencil className="w-4 h-4 text-gray-400" />
+                                </button>
+                            )}
+                        </>
+                    )}
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

Adds inline rename of the workflow name on the Workflow Editor page (`/workflow/[workflowId]`). A pencil icon appears next to the workflow name in the header — clicking it (or pressing Enter/Space when focused) opens an inline `<Input>` pre-filled with the current name. Pressing Enter or blurring saves the new name; pressing Esc cancels without saving. Reuses the existing `saveWorkflowConfigurations` path (the same one the Settings page Agent Name field uses), so the new name propagates to every consumer of the Zustand workflow store with no parallel API call.

Closes https://github.com/dograh-hq/dograh/issues/252.

Thanks @chewwbaka for the detailed spec, reviewer expectations, and the file pointers — they made the scope unambiguous.

## What changed

- **`ui/src/app/workflow/[workflowId]/components/WorkflowEditorHeader.tsx`** — pencil button next to the workflow name; inline `Input` with `autoFocus` + select-all on focus; Enter/Blur save; Esc cancel; empty/whitespace-only validation with inline error message; in-flight saving guard (`isRenaming`) against double-submit; API-error rollback with `sonner` toast preserving the user's typed value; focus management between the pencil button and the input (keyboard users are never stranded); historical-version guard (pencil not rendered when `isViewingHistoricalVersion === true`); long-name handling (`truncate max-w-[14rem] md:max-w-md` on the `h1`, `max-w-xs` on the `Input`).
- **`ui/src/app/workflow/[workflowId]/RenderWorkflow.tsx`** — extended `useWorkflowState` destructuring to pull `workflowConfigurations` and `saveWorkflowConfigurations`; added a thin `renameWorkflow(newName)` `useCallback` wrapper; passed it as a new prop to `<WorkflowEditorHeader />`.

## What did NOT change

- No backend / `api/` changes — the `updateWorkflowApiV1WorkflowWorkflowIdPut` contract is unchanged.
- No edits to `settings/page.tsx` — the Settings-page rename path is untouched and continues to work.
- No new npm dependencies — only `Pencil` (lucide-react), `Input` (shadcn/ui), `sonner.toast`, all already in `package.json`.
- No raw CSS — Tailwind utility classes only, matching existing header tokens (`bg-[#1a1a1a]`, `border-[#2a2a2a]`, `text-gray-400`, `text-white`, `hover:bg-[#2a2a2a]`, `text-base font-medium`).
- No refactor of unrelated code in the header.

## Demo

> Before screenshot:

<img width="3356" height="2160" alt="CleanShot 2026-05-11 at 13 50 31@2x" src="https://github.com/user-attachments/assets/5dc507ad-db5b-40eb-97e9-53d140cfbd42" />

> After

<img width="800" height="468" alt="PR_Demo" src="https://github.com/user-attachments/assets/58ce9852-1953-45c7-be3a-d6d308bdbbf1" />

The GIF demonstrates:

- **Edit mode** — clicking the pencil swaps the workflow name `<h1>` for an inline `<Input>` pre-filled with the current name and auto-selected, styled to match the header's height and dark tokens.
- **Validation error** — clearing the input and pressing Enter shows `"Name cannot be empty"` inline in `text-red-500` with `role="alert"`; the input stays open until a valid value is entered or Esc is pressed.
- **Long name handling** — display mode uses `truncate max-w-[14rem] md:max-w-md` so the name truncates with an ellipsis without pushing the right-hand action buttons (Call / Save / Publish / menu) off-screen.

## Test plan

> Checked items verified locally on 2026-05-11:

- [x] **AC1** — Pencil icon is visible next to the workflow name in the header; color is `text-gray-400`; `aria-label="Rename workflow"` is present (verify via DevTools).
- [x] **AC2** — Click pencil → input appears pre-filled with current name, focused, text selected; styling matches header height.
- [x] **AC3** — Type a new name → press Enter → exactly ONE PUT to `/api/v1/workflow/{id}` (Network tab); header updates; Settings page reflects new name.
- [x] **AC4** — Type a new name → click outside (blur) → exactly ONE PUT; header updates.
- [x] **AC5** — In edit mode, change value → press Esc → no PUT, original name retained, focus returns to pencil button.
- [x] **AC6a** — Clear input → press Enter → inline error `"Name cannot be empty"` appears, input stays open, no PUT.
- [x] **AC6b** — Enter only spaces → press Enter → same as AC6a.
- [x] **AC6c** — Clear input → blur → input closes, original name shown, no PUT.
- [x] **AC7a** — Open edit → press Enter without changing anything → input closes, no PUT.
- [x] **AC7b** — Add trailing space → press Enter → no PUT (trim-before-compare).
- [x] **AC8** — Set Network to Offline → type new name → press Enter → toast `"Failed to rename workflow"` appears, input reopens with attempted value, header still shows original name.
- [x] **AC9** — Set Network to Slow 3G → type new name → press Enter then quickly Enter again → exactly ONE PUT in Network tab; input visibly disabled during in-flight save.
- [x] **AC10a** — Rename to 250-char string via Settings → navigate to editor → desktop: name truncates with ellipsis, right-side buttons remain visible; mobile: 8-char slice renders.
- [x] **AC10b** — Open edit mode with 250-char name → Input capped at `max-w-xs`, right-side buttons remain visible.
- [x] **AC11a** — Keyboard-only: Tab to pencil button (focus ring visible) → Enter → input focused with text selected → Esc → focus returns to pencil button.
- [x] **AC11b** — Screen reader (VoiceOver/NVDA): pencil announced as `"Rename workflow, button"`; input announced as `"Workflow name, edit text"`; validation error announced via `role="alert"`.
- [x] **AC12** — View a historical version → pencil NOT in DOM (verify via DevTools) → click name does nothing → Back to Draft → pencil reappears.
- [x] **AC13** — Settings-page rename still works: open `/settings` → change Agent Name → save → navigate back to editor → new name in header.
- [x] **AC14** — `git diff --name-only main -- .` outputs ONLY `WorkflowEditorHeader.tsx` and `RenderWorkflow.tsx`.
- [x] **AC15a** — `cd ui && npm run fix-lint` exits 0, no errors on changed files.
- [x] **AC15b** — `cd ui && npx tsc --noEmit -p .` exits 0, no type diagnostics.
- [x] **AC15c** — `grep -nE '(\bany\b|@ts-ignore|as unknown as)' WorkflowEditorHeader.tsx RenderWorkflow.tsx` returns nothing in new lines.

## Follow-ups (not in this PR)

- **Unused `user` prop on `WorkflowEditorHeader`** — the `user: { id: string; email?: string }` prop in `WorkflowEditorHeaderProps` (line ~43) is passed from `RenderWorkflow.tsx` but not consumed by the component body. This is pre-existing and out of scope for an atomic inline-rename PR. Can be cleaned up in a separate housekeeping PR.
- **Live sidebar refresh on rename** — the sidebar reads workflow names from its own mount-time API fetch. Inline rename (and the existing Settings-page rename) both have this behavior. Introducing a live sidebar refresh on rename would be a follow-up feature, not a regression.