### PR TITLE
feat(workflow): seed Lead Qualification template for self-hosted users

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ curl -o docker-compose.yaml https://raw.githubusercontent.com/dograh-hq/dograh/m
 2. Pick **Inbound** or **Outbound**, name your bot (e.g. _Lead Qualification_), and describe the use case in 5–10 words (e.g. _Screen insurance form submissions for purchase intent_).
 3. Click **Web Call** — you're talking to your bot.
 
+> 🚀 **Starter template included.** Every fresh install seeds a
+> **Lead Qualification (Inbound)** workflow template — the same flow shown
+> in the [Better Stack walkthrough](https://www.youtube.com/watch?v=xD9JEvfCH9k).
+> From the **Workflows** page, click **New from Template** to materialise
+> it. See the
+> [template docs](https://docs.dograh.com/voice-agent/lead-qualification-template)
+> for details.
+
 > 🔑 **No API keys needed.** Dograh ships with auto-generated keys and its own LLM / TTS / STT stack. Connect your own keys for LLM, TTS, STT, or Telephony (e.g. Twilio, Vonage, Telnyx) anytime.
 
 ## Features

--- a/api/.env.example
+++ b/api/.env.example
@@ -45,3 +45,27 @@ TURN_SECRET=dograh-turn-secret-change-in-production
 # TURN_PORT=3478  # Default: 3478
 # TURN_TLS_PORT=5349  # Default: 5349
 # TURN_CREDENTIAL_TTL=86400  # Default: 24 hours in seconds
+
+# ─────────────────────────────────────────────────────────────────────────
+# Provider credentials (LLM / STT / TTS / Telephony)
+# ─────────────────────────────────────────────────────────────────────────
+# Dograh stores provider credentials per-organization in the database, not
+# as environment variables. After the stack is running:
+#   1. Open http://localhost:3010 and sign in.
+#   2. Go to Settings → Provider Configuration to attach your own keys for
+#      LLM (OpenAI / Groq / OpenRouter / Google / Azure / AWS Bedrock / etc.),
+#      STT (Deepgram / AssemblyAI / Gladia / Speechmatics / Speaches / etc.),
+#      and TTS (ElevenLabs / Cartesia / Deepgram / OpenAI / Rime / Camb / etc.).
+#   3. Telephony providers (Twilio, Telnyx, Vonage, Vobiz, Cloudonix, Plivo)
+#      are configured under Settings → Telephony.
+#
+# Out of the box, OSS deployments proxy to Dograh's hosted Model Proxy
+# Service (MPS) so the first "Web Call" works without any keys.
+
+# Optional: override the hosted MPS endpoint (advanced — leave unset for the
+# default https://services.dograh.com).
+# MPS_API_URL=
+
+# Deployment mode: "oss" (default — self-hosted, no auth provider) or
+# "managed" (Dograh-hosted with auth provider).
+# DEPLOYMENT_MODE=oss

--- a/api/alembic/versions/c41a9b2e7d10_seed_lead_qualification_template.py
+++ b/api/alembic/versions/c41a9b2e7d10_seed_lead_qualification_template.py
@@ -1,0 +1,63 @@
+"""seed lead qualification workflow template
+
+Idempotently inserts the built-in starter templates defined in
+``api.services.workflow.seed_templates`` into ``workflow_templates``.
+
+Self-hosted users can then create a working voice agent from the template
+without needing the hosted MPS workflow generator. The migration is safe
+to run repeatedly: it skips rows whose ``template_name`` already exists.
+
+Revision ID: c41a9b2e7d10
+Revises: 4c1f1e3e8ef2
+Create Date: 2026-05-16 18:50:00.000000
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from api.services.workflow.seed_templates import BUILTIN_TEMPLATES
+
+# revision identifiers, used by Alembic.
+revision: str = "c41a9b2e7d10"
+down_revision: Union[str, None] = "4c1f1e3e8ef2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    for tmpl in BUILTIN_TEMPLATES:
+        existing = bind.execute(
+            sa.text(
+                "SELECT 1 FROM workflow_templates WHERE template_name = :name LIMIT 1"
+            ),
+            {"name": tmpl["template_name"]},
+        ).first()
+        if existing:
+            continue
+        bind.execute(
+            sa.text(
+                "INSERT INTO workflow_templates "
+                "(template_name, template_description, template_json, created_at) "
+                "VALUES (:name, :description, CAST(:json AS JSON), NOW())"
+            ),
+            {
+                "name": tmpl["template_name"],
+                "description": tmpl["template_description"],
+                "json": json.dumps(tmpl["template_json"]),
+            },
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    for tmpl in BUILTIN_TEMPLATES:
+        bind.execute(
+            sa.text("DELETE FROM workflow_templates WHERE template_name = :name"),
+            {"name": tmpl["template_name"]},
+        )

--- a/api/services/workflow/seed_templates.py
+++ b/api/services/workflow/seed_templates.py
@@ -1,0 +1,225 @@
+"""Built-in workflow templates seeded into the database on startup.
+
+Each entry produces a row in `workflow_templates` so self-hosted users get
+working starter flows without needing the hosted MPS workflow generator.
+
+The shapes mirror what `/api/v1/workflow/templates/duplicate` consumes —
+ReactFlow JSON with nodes (startCall / agentNode / endCall) and edges
+keyed by `condition`. Keep these in sync with `api/services/workflow/dto.py`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _node(
+    node_id: str,
+    node_type: str,
+    x: float,
+    y: float,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "id": node_id,
+        "type": node_type,
+        "position": {"x": x, "y": y},
+        "data": data,
+    }
+
+
+def _edge(
+    edge_id: str,
+    source: str,
+    target: str,
+    label: str,
+    condition: str,
+) -> dict[str, Any]:
+    return {
+        "id": edge_id,
+        "source": source,
+        "target": target,
+        "data": {"label": label, "condition": condition},
+    }
+
+
+def lead_qualification_template() -> dict[str, Any]:
+    """Inbound lead-qualification agent matching the Better Stack demo.
+
+    Greets the caller, collects what they want to build, asks about
+    company size, industry, and approximate call volume / budget, then
+    routes qualified leads to a human handoff and politely closes
+    unqualified leads.
+    """
+
+    nodes = [
+        _node(
+            "start",
+            "startCall",
+            x=0,
+            y=0,
+            data={
+                "name": "Greeting",
+                "is_start": True,
+                "greeting_type": "text",
+                "greeting": (
+                    "Hi, this is Sarah from Dograh AI. Thanks for reaching out — "
+                    "how can I help you today?"
+                ),
+                "prompt": (
+                    "You are Sarah, a friendly inbound voice agent for Dograh AI. "
+                    "Open the call warmly. Ask the caller what they're looking to "
+                    "build or solve with a voice AI agent. Listen for the high-"
+                    "level use case and acknowledge it before moving on."
+                ),
+                "allow_interrupt": True,
+                "add_global_prompt": True,
+                "extraction_enabled": True,
+                "extraction_prompt": (
+                    "Capture the caller's stated use case in one short phrase."
+                ),
+                "extraction_variables": [
+                    {
+                        "name": "use_case",
+                        "type": "string",
+                        "prompt": (
+                            "Short phrase describing what the caller wants to "
+                            "build, e.g. 'inbound demo qualification'."
+                        ),
+                    }
+                ],
+            },
+        ),
+        _node(
+            "qualify",
+            "agentNode",
+            x=420,
+            y=0,
+            data={
+                "name": "Qualify Lead",
+                "prompt": (
+                    "Qualify the lead. Ask, in order:\n"
+                    "  1. Their company name and industry.\n"
+                    "  2. Approximate company size (employees).\n"
+                    "  3. Estimated monthly voice-agent minutes or rough budget.\n"
+                    "Acknowledge each answer briefly. Do not pitch product."
+                ),
+                "allow_interrupt": True,
+                "add_global_prompt": True,
+                "extraction_enabled": True,
+                "extraction_prompt": (
+                    "Extract the qualification fields from the caller's answers."
+                ),
+                "extraction_variables": [
+                    {
+                        "name": "company_name",
+                        "type": "string",
+                        "prompt": "Company name stated by the caller.",
+                    },
+                    {
+                        "name": "industry",
+                        "type": "string",
+                        "prompt": "Industry or vertical (e.g. healthcare, fintech).",
+                    },
+                    {
+                        "name": "company_size",
+                        "type": "number",
+                        "prompt": "Approximate employee count.",
+                    },
+                    {
+                        "name": "monthly_minutes",
+                        "type": "number",
+                        "prompt": (
+                            "Estimated monthly call minutes the caller expects "
+                            "to run through a voice agent. Convert phrases like "
+                            "'around twenty thousand minutes' to 20000."
+                        ),
+                    },
+                ],
+            },
+        ),
+        _node(
+            "qualified_handoff",
+            "endCall",
+            x=900,
+            y=-160,
+            data={
+                "name": "Qualified — Hand Off",
+                "is_end": True,
+                "prompt": (
+                    "Tell {{company_name}} that they qualify and that a Dograh "
+                    "specialist will reach out by email within one business day "
+                    "to schedule a demo. Confirm the best email address, thank "
+                    "the caller, and end the call politely."
+                ),
+                "allow_interrupt": False,
+                "add_global_prompt": True,
+            },
+        ),
+        _node(
+            "unqualified_close",
+            "endCall",
+            x=900,
+            y=160,
+            data={
+                "name": "Unqualified — Polite Close",
+                "is_end": True,
+                "prompt": (
+                    "Thank the caller for their time, mention that Dograh's "
+                    "open-source self-hosted option may be a great fit for them, "
+                    "and point them to docs.dograh.com. End the call politely."
+                ),
+                "allow_interrupt": False,
+                "add_global_prompt": True,
+            },
+        ),
+    ]
+
+    edges = [
+        _edge(
+            "e1",
+            "start",
+            "qualify",
+            label="Caller shared a use case",
+            condition=(
+                "The caller has described what they want to build with a voice "
+                "AI agent at any level of detail."
+            ),
+        ),
+        _edge(
+            "e2",
+            "qualify",
+            "qualified_handoff",
+            label="Qualified lead",
+            condition=(
+                "The caller works at a company with at least 20 employees AND "
+                "either monthly_minutes is 5000 or higher OR they indicated a "
+                "non-trivial budget."
+            ),
+        ),
+        _edge(
+            "e3",
+            "qualify",
+            "unqualified_close",
+            label="Not qualified",
+            condition=(
+                "The caller does not meet the qualification bar (very small "
+                "team, no budget, or no concrete use case)."
+            ),
+        ),
+    ]
+
+    return {"nodes": nodes, "edges": edges, "viewport": {"x": 0, "y": 0, "zoom": 1}}
+
+
+BUILTIN_TEMPLATES: list[dict[str, Any]] = [
+    {
+        "template_name": "Lead Qualification (Inbound)",
+        "template_description": (
+            "Inbound voice agent that greets callers, asks what they want to "
+            "build, qualifies on company size and call volume, and routes "
+            "qualified leads to a human handoff."
+        ),
+        "template_json": lead_qualification_template(),
+    },
+]

--- a/api/tests/test_seed_templates.py
+++ b/api/tests/test_seed_templates.py
@@ -1,0 +1,98 @@
+"""Tests for built-in workflow templates seeded into ``workflow_templates``.
+
+The seed migration must produce templates that:
+  - Validate as ``ReactFlowDTO`` (so the UI/API will accept them)
+  - Build a legal ``WorkflowGraph`` (so they actually run end-to-end)
+  - Have at least one start node and one end node
+  - Carry non-empty name / description so the picker shows something useful
+
+If any of these fail, the seed migration would create a workflow no one
+can run — a worse experience than having no template at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from api.services.workflow.dto import NodeType, ReactFlowDTO
+from api.services.workflow.seed_templates import (
+    BUILTIN_TEMPLATES,
+    lead_qualification_template,
+)
+from api.services.workflow.workflow_graph import WorkflowGraph
+
+
+@pytest.mark.parametrize(
+    "tmpl",
+    BUILTIN_TEMPLATES,
+    ids=lambda t: t["template_name"],
+)
+def test_builtin_template_validates_against_dto(tmpl):
+    """Each seeded template must validate as ReactFlowDTO without errors."""
+    ReactFlowDTO.model_validate(tmpl["template_json"])
+
+
+@pytest.mark.parametrize(
+    "tmpl",
+    BUILTIN_TEMPLATES,
+    ids=lambda t: t["template_name"],
+)
+def test_builtin_template_builds_workflow_graph(tmpl):
+    """Each seeded template must satisfy WorkflowGraph's invariants."""
+    dto = ReactFlowDTO.model_validate(tmpl["template_json"])
+    graph = WorkflowGraph(dto)
+    assert graph.start_node_id is not None
+
+
+@pytest.mark.parametrize(
+    "tmpl",
+    BUILTIN_TEMPLATES,
+    ids=lambda t: t["template_name"],
+)
+def test_builtin_template_has_name_and_description(tmpl):
+    assert tmpl["template_name"].strip()
+    assert len(tmpl["template_description"].strip()) >= 30, (
+        "Template description should describe the flow to users picking it."
+    )
+
+
+@pytest.mark.parametrize(
+    "tmpl",
+    BUILTIN_TEMPLATES,
+    ids=lambda t: t["template_name"],
+)
+def test_builtin_template_has_start_and_end(tmpl):
+    nodes = tmpl["template_json"]["nodes"]
+    types = [n["type"] for n in nodes]
+    assert NodeType.startNode.value in types, "missing startCall node"
+    assert NodeType.endNode.value in types, "missing endCall node"
+
+
+def test_lead_qualification_has_qualified_and_unqualified_branches():
+    """The lead-qualification template should fan out from the qualification
+    step to at least two end states — one for qualified handoff and one for
+    a polite close. Otherwise it's not really a qualification flow."""
+    tmpl = lead_qualification_template()
+
+    # Find the qualification agent node (only agentNode in this template).
+    agent_ids = [
+        n["id"] for n in tmpl["nodes"] if n["type"] == NodeType.agentNode.value
+    ]
+    assert agent_ids, "lead qualification template must have an agent node"
+    qualify_id = agent_ids[0]
+
+    outgoing = [e for e in tmpl["edges"] if e["source"] == qualify_id]
+    assert len(outgoing) >= 2, (
+        "Qualification node should branch to at least qualified and "
+        "unqualified outcomes."
+    )
+
+    targets = {e["target"] for e in outgoing}
+    end_ids = {
+        n["id"]
+        for n in tmpl["nodes"]
+        if n["type"] == NodeType.endNode.value and n["id"] in targets
+    }
+    assert len(end_ids) >= 2, (
+        "Each qualification branch should resolve to a distinct endCall node."
+    )

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -53,6 +53,7 @@
             "group": "Voice Agent Builder",
             "pages": [
               "voice-agent/introduction",
+              "voice-agent/lead-qualification-template",
               "voice-agent/editing-a-workflow",
               "voice-agent/pre-recorded-audio",
               "voice-agent/template-variables",

--- a/docs/voice-agent/lead-qualification-template.mdx
+++ b/docs/voice-agent/lead-qualification-template.mdx
@@ -1,0 +1,69 @@
+---
+title: Lead Qualification Template
+description: Built-in starter workflow that greets callers, qualifies them, and routes the qualified ones to a handoff.
+---
+
+Dograh ships with a built-in **Lead Qualification (Inbound)** workflow
+template so you can go from a fresh install to a working voice agent in a
+single click — no MPS access required.
+
+## What the template does
+
+The template implements the inbound lead-qualification flow shown in the
+[Better Stack walkthrough](https://www.youtube.com/watch?v=xD9JEvfCH9k):
+
+1. **Greeting** (`startCall`) — Sarah introduces herself and asks what the
+   caller is looking to build. Extracts a `use_case` variable.
+2. **Qualify Lead** (`agentNode`) — Collects company name, industry,
+   approximate size, and monthly call-minutes / budget. Extracts
+   `company_name`, `industry`, `company_size`, and `monthly_minutes`.
+3. **Branching** — From the qualification node:
+   - **Qualified handoff** (`endCall`) → confirms email, promises a
+     specialist will reach out, ends the call.
+   - **Polite close** (`endCall`) → thanks the caller and points them at
+     the self-hosted docs.
+
+The qualification edge condition fires when the company has ≥ 20 employees
+**and** non-trivial monthly minutes or budget. Tune the threshold by
+editing the edge's `condition` text after duplicating the template.
+
+## Using the template
+
+1. Open `http://localhost:3010` after running `docker compose up`.
+2. From the **Workflows** page, choose **New from Template**.
+3. Pick **Lead Qualification (Inbound)** and give it a name.
+4. Click **Web Call** to talk to the bot directly — no telephony setup
+   required.
+
+The template seeds on first migration (Alembic revision
+`c41a9b2e7d10_seed_lead_qualification_template`) and is loaded via
+`GET /api/v1/workflow/templates`. You can also call
+`POST /api/v1/workflow/templates/duplicate` with the template id to
+materialise a workflow programmatically.
+
+## What you still need
+
+- **Provider credentials.** Out of the box, OSS deployments proxy to
+  Dograh's hosted MPS so the first Web Call works without keys. To bring
+  your own LLM / STT / TTS, configure them in **Settings → Provider
+  Configuration**. For an end-to-end live phone call, attach Twilio /
+  Telnyx / Vonage / Vobiz / Cloudonix / Plivo credentials under
+  **Settings → Telephony**.
+- **Optional global system prompt.** The template's three call nodes all
+  have `add_global_prompt: true`. If you add a Global node to the
+  workflow, its prompt is prepended at runtime — handy for compliance
+  language or persona reinforcement.
+
+## Extending the template
+
+The template is just a starting point. After duplicating it you can:
+
+- Add an **API tool** to write the qualified lead to your CRM. Wire it
+  into the `Qualify Lead` agent node's tools list.
+- Replace the qualified-handoff `endCall` with a **call transfer** to a
+  human queue.
+- Add a **QA** node to score post-call transcripts against your script.
+
+See [Voice Agent Builder → Introduction](/voice-agent/introduction) for the
+node catalogue and [Tools → HTTP API](/voice-agent/tools/http-api) for
+hooking up an external CRM.


### PR DESCRIPTION
## Summary
- Adds a built-in **Lead Qualification (Inbound)** workflow template for self-hosted Dograh installs
- Seeds the template via an idempotent Alembic migration
- Documents how to use the template and clarifies provider credential configuration

## Details
This closes the gap between the existing Docker-based self-host setup and the lead-qualification demo shown in the Better Stack Dograh walkthrough. The seeded template includes a greeting, qualification step, qualified handoff branch, and polite close branch.

## Testing
- `python3 -m pytest api/tests/test_seed_templates.py api/tests/test_node_specs.py api/tests/test_dto.py -x -q` — 65 passed
- `ruff check api/services/workflow/seed_templates.py api/tests/test_seed_templates.py api/alembic/versions/c41a9b2e7d10_*.py` — passed
- `ruff format --check api/services/workflow/seed_templates.py api/tests/test_seed_templates.py api/alembic/versions/c41a9b2e7d10_*.py` — passed
- `python3 -m py_compile api/alembic/versions/c41a9b2e7d10_*.py` — passed

## Notes
Live telephony testing still requires real provider credentials such as Twilio/Telnyx/Vonage/Plivo plus optional STT/LLM/TTS provider keys configured in the Dograh UI.