### PR TITLE
fix(gemini-live): seed conversation history on node-transition reconnect

### DIFF
--- a/api/services/pipecat/realtime/gemini_live.py
+++ b/api/services/pipecat/realtime/gemini_live.py
@@ -82,6 +82,15 @@ class DograhGeminiLiveLLMService(GeminiLiveLLMService):
             # cut the bot off mid-utterance.
             self._reconnect_pending = True
         else:
+            # Discard session_resumption_handle before a node-transition
+            # reconnect. The handle is issued periodically by Gemini, not
+            # after every transcription — so resuming to it restores state
+            # from BEFORE the user's most recent message. The new session's
+            # LLM then doesn't see what the user just said and replies with
+            # "I haven't heard anything from you yet". Clearing the handle
+            # forces a fresh server-side session that _handle_session_ready
+            # will fully seed from self._context.
+            self._session_resumption_handle = None
             await self._reconnect()
         return {"system_instruction"}
 
@@ -110,6 +119,10 @@ class DograhGeminiLiveLLMService(GeminiLiveLLMService):
             await self._run_pending_function_calls()
             if self._reconnect_pending:
                 self._reconnect_pending = False
+                # Same rationale as in _handle_changed_settings: discard the
+                # handle so the deferred node-transition reconnect uses a
+                # fresh session that we can fully seed.
+                self._session_resumption_handle = None
                 await self._reconnect()
 
     async def _run_pending_function_calls(self):
@@ -200,12 +213,20 @@ class DograhGeminiLiveLLMService(GeminiLiveLLMService):
             # initial response now.
             self._run_llm_when_session_ready = False
             await self._create_initial_response()
+        elif self._handled_initial_context and not self._session_resumption_handle:
+            # Reconnect without a session_resumption_handle (e.g. quick node
+            # transition before the server issued any handle): the new
+            # server-side session has zero conversation history. Seed it from
+            # self._context — otherwise the LLM thinks "I haven't heard
+            # anything from you yet" because the user's last message lives
+            # only client-side. Use for_reconnect=True so Gemini 3.x seeds
+            # without forcing inference; the function-call-result frame that
+            # follows in _handle_context will trigger the LLM's first turn
+            # against history-aware context.
+            await self._create_initial_response(for_reconnect=True)
         await self._drain_pending_tool_results()
-        # Otherwise: no automatic seed. Reconnect after a session-resumption
-        # update relies on the server-side restored state; reconnects without
-        # a handle (e.g. node transitions before any handle was issued) are
-        # followed by a function-call-result LLMContextFrame which feeds the
-        # updated-context branch in _handle_context.
+        # Reconnect after a session-resumption update relies on the
+        # server-side restored state and falls through both branches above.
 
     # ------------------------------------------------------------------
     # Transcription: broadcast (so downstream voicemail detector and

--- a/api/tests/test_gemini_live_reconnect_history_seed.py
+++ b/api/tests/test_gemini_live_reconnect_history_seed.py
@@ -1,0 +1,146 @@
+"""Regression tests for the reconnect-history-seed patch in
+DograhGeminiLiveLLMService._handle_session_ready.
+
+When a node transition swaps system_instruction, pipecat triggers a Gemini
+Live reconnect. If the new session has no session_resumption_handle (common
+for quick transitions before the server has issued one), the server-side
+session has zero conversation history. Without seeding, the LLM in the new
+node has no idea what the user just said and responds with things like
+"I haven't heard anything from you yet".
+
+These tests cover the patch in `gemini_live.py:_handle_session_ready` that
+calls `_create_initial_response(for_reconnect=True)` to seed the new session
+with the client-side conversation history.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pipecat.processors.aggregators.llm_context import LLMContext
+
+from api.services.pipecat.realtime.gemini_live import DograhGeminiLiveLLMService
+
+
+class _TestDograhGeminiLiveLLMService(DograhGeminiLiveLLMService):
+    """Dograh Gemini service with client creation stubbed for unit tests."""
+
+    def create_client(self):
+        self._client = SimpleNamespace(
+            aio=SimpleNamespace(live=SimpleNamespace(connect=None))
+        )
+
+
+class _FakeSession:
+    def __init__(self):
+        self.send_tool_response = AsyncMock()
+        self.send_realtime_input = AsyncMock()
+        self.send_client_content = AsyncMock()
+        self.close = AsyncMock()
+
+
+def _make_service() -> _TestDograhGeminiLiveLLMService:
+    service = _TestDograhGeminiLiveLLMService(api_key="test-key")
+    service.stop_all_metrics = AsyncMock()
+    service.start_ttfb_metrics = AsyncMock()
+    service.cancel_task = AsyncMock()
+    service.push_error = AsyncMock()
+    service._create_initial_response = AsyncMock()
+    service._drain_pending_tool_results = AsyncMock()
+    return service
+
+
+def _make_user_context(user_text: str) -> LLMContext:
+    return LLMContext(
+        messages=[
+            {"role": "user", "content": user_text},
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconnect_without_resumption_handle_seeds_history():
+    """The bug: a reconnect with no session_resumption_handle leaves the
+    new Gemini Live session with no history, so the LLM doesn't see the
+    user's last message. The fix: call _create_initial_response(for_reconnect=True)
+    on session-ready to seed the history."""
+    service = _make_service()
+    service._handled_initial_context = True
+    service._session_resumption_handle = None
+    service._run_llm_when_session_ready = False
+    service._context = _make_user_context("Can you tell me more about Isaiah?")
+
+    await service._handle_session_ready(_FakeSession())
+
+    service._create_initial_response.assert_awaited_once_with(for_reconnect=True)
+
+
+@pytest.mark.asyncio
+async def test_handle_changed_settings_discards_resumption_handle_before_reconnect():
+    """Node-transition reconnects must clear session_resumption_handle so the
+    new session is fresh (and _handle_session_ready can fully seed it).
+
+    Without this, the handle restores state from BEFORE the user's last
+    message — the LLM in the new node then says "I haven't heard anything".
+    """
+    service = _make_service()
+    service._session = _FakeSession()
+    service._bot_is_responding = False
+    service._session_resumption_handle = "stale-handle-from-before-user-spoke"
+    service._reconnect = AsyncMock()
+
+    await service._handle_changed_settings({"system_instruction": "new prompt"})
+
+    assert service._session_resumption_handle is None
+    service._reconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_deferred_reconnect_also_discards_resumption_handle():
+    """When system_instruction changes mid-bot-turn, the reconnect is deferred
+    until _set_bot_is_responding(False) fires. That deferred reconnect must
+    also clear the handle for the same reason."""
+    service = _make_service()
+    service._bot_is_responding = True
+    service._reconnect_pending = True
+    service._session_resumption_handle = "stale-handle"
+    service._reconnect = AsyncMock()
+    service._run_pending_function_calls = AsyncMock()
+
+    # Simulate bot finishing its turn
+    await service._set_bot_is_responding(False)
+
+    assert service._session_resumption_handle is None
+    service._reconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_first_connect_uses_queued_initial_response_not_reconnect_seed():
+    """On the very first connect (not a reconnect), the queued initial
+    response path runs — not the new reconnect-seed branch."""
+    service = _make_service()
+    service._handled_initial_context = False
+    service._run_llm_when_session_ready = True
+    service._session_resumption_handle = None
+    service._context = LLMContext(messages=[])
+
+    await service._handle_session_ready(_FakeSession())
+
+    # First-connect path: _create_initial_response() with no kwargs
+    service._create_initial_response.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_session_ready_without_initial_context_or_queue_does_nothing_extra():
+    """Defensive: if neither the queued-response flag nor the reconnect
+    condition apply, _create_initial_response must not be called."""
+    service = _make_service()
+    service._handled_initial_context = False
+    service._run_llm_when_session_ready = False
+    service._session_resumption_handle = None
+    service._context = LLMContext(messages=[])
+
+    await service._handle_session_ready(_FakeSession())
+
+    service._create_initial_response.assert_not_awaited()
+    service._drain_pending_tool_results.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Multi-node workflows on Gemini Live often produce "Sorry, I didn't catch that" / "I haven't heard anything from you yet" on the LLM's first turn after a node transition, even when the user clearly spoke.
- Root cause: the reconnect triggered by a `system_instruction` change passes a stale `session_resumption_handle` (issued before the user's most recent message), so the new server-side session restores state from before the user spoke.
- Fix: discard the handle on node-transition reconnects in both `_handle_changed_settings` (sync) and `_set_bot_is_responding` (deferred), then seed history from `self._context` in `_handle_session_ready` via `_create_initial_response(for_reconnect=True)`.

See the commit message for the full root-cause writeup and the rationale for the seed-shape choice (Gemini 3.x `turn_complete=False` + reliance on the function-call-result frame to trigger the first turn).

## Repro before this fix

Any two-node workflow on Gemini Live 3.x (e.g. `startCall` → `agentNode`). Caller hears the greeting, says something substantive, and the first turn in the second node is "Sorry, didn't catch that" — confirmed by inspecting `rtf-bot-text` events on the run record (the user's transcription is final and present, but the LLM in the new session doesn't see it).

Reproduced in production on `gemini-3.1-flash-live-preview` across ~6 consecutive runs with different workflow shapes.

## Test plan

- [x] `pytest api/tests/test_gemini_live_reconnect_history_seed.py` — 5 new cases (handle-discard in sync + deferred paths, seed-on-reconnect-without-handle, first-connect path unchanged, defensive no-op)
- [x] `pytest api/tests/test_gemini_live_reconnect_tool_results.py` — existing tests still pass
- [x] End-to-end on a deployed Dograh instance against `gemini-3.1-flash-live-preview`: pre-fix → "I haven't heard anything from you yet"; post-fix → LLM engages directly with the user's pre-transition message.
- [ ] Reviewer to spot-check that real-resumption-handle reconnects (network blip recovery) are unaffected — those still fall through both branches in `_handle_session_ready`.

## What this doesn't touch

- `_create_initial_response` itself is unchanged. The seed shape (turn_complete=False for Gemini 3.x reconnect) was already the documented intended behavior; we just weren't reaching it.
- Tool-result delivery on reconnect (covered by `test_gemini_live_reconnect_tool_results.py`) is unaffected.
- The fix is scoped to `DograhGeminiLiveLLMService` — pipecat's upstream `GeminiLiveLLMService` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)