### PR TITLE
fix(telephony/ari): force softmix bridge to fix chan_websocket one-way audio

### DIFF
--- a/api/services/telephony/ari_manager.py
+++ b/api/services/telephony/ari_manager.py
@@ -490,7 +490,11 @@ class ARIConnection:
             "POST",
             "/bridges",
             params={
-                "type": "mixing,dtmf_events,proxy_media",
+                # Force softmix selection by including video_sfu — simple_bridge
+                # cannot satisfy video routing capabilities, so the bridging core
+                # picks softmix. Required because simple_bridge + chan_websocket
+                # has a known asymmetry where PJSIP->WS frames don't flow.
+                "type": "mixing,dtmf_events,proxy_media,video_sfu",
                 "name": f"bridge-{channel_ids[0]}",
             },
         )

--- a/api/services/telephony/ari_manager.py
+++ b/api/services/telephony/ari_manager.py
@@ -489,7 +489,10 @@ class ARIConnection:
         bridge_result = await self._ari_request(
             "POST",
             "/bridges",
-            params={"type": "mixing", "name": f"bridge-{channel_ids[0]}"},
+            params={
+                "type": "mixing,dtmf_events,proxy_media",
+                "name": f"bridge-{channel_ids[0]}",
+            },
         )
         bridge_id = bridge_result.get("id", "")
         if not bridge_id:


### PR DESCRIPTION
## Summary

Fixes one-way audio (agent → user works, user → agent does not) on outbound calls using the **Asterisk ARI provider with `chan_websocket`** external media. Verified end-to-end with Asterisk 20.19 + PJSIP trunk: after this change, user audio finally reaches the Dograh VAD/pipeline.

Closes the symptoms described in #307.

## Root cause

`_create_bridge_and_add_channels` creates the bridge with only `type=mixing` and then adds exactly 2 channels (PJSIP caller + chan_websocket external media), both ulaw, no framehook, no recording. Under those conditions Asterisk's bridging core selects `simple_bridge` (P2P native) as the bridge technology.

`simple_bridge` + `chan_websocket` has a well-known asymmetry: frames flow from the WebSocket leg to the PJSIP leg (the agent's TTS reaches the user) but **not** in the reverse direction. The user can hear the agent; the agent never hears the user.

Verified at the wire level: `pjsip show channelstats` showed `Receive Count` growing at ~50pps while the user spoke (audio reaching Asterisk's PJSIP leg) but Dograh's VAD only logged `no audio received while speaking`.

Confirmed it is specific to `simple_bridge` + `chan_websocket`: the same Asterisk container with `chan_audiosocket` instead worked bidirectionally without changes.

## Fix

Add `dtmf_events,proxy_media,video_sfu` to the bridge `type`. The `video_sfu` capability is the decisive one — `simple_bridge` cannot satisfy video routing, so the bridging core has no choice but to pick `softmix`, which handles both audio directions correctly.

Verified with `asterisk -rx "bridge show all"`:

**Before:**
```
Bridge-ID  Name                Chans Type    Technology      Duration
2bb73ecc.. bridge-1779138763.3     2 stasis  simple_bridge   00:00:53
```

**After:**
```
Bridge-ID  Name                Chans Type    Technology      Duration
5d2b631b.. bridge-1779138944.5     2 stasis  softmix         00:00:01
```

User audio now reaches the agent pipeline, conversation is fully bidirectional.

## Trade-offs

`softmix` is heavier than `simple_bridge` (it actually mixes frames in software instead of relaying them P2P), so there's a small CPU cost per call. For the 2-channel case it's marginal and worth it given that simple_bridge is fundamentally broken with chan_websocket. Native bridge was never an intentional optimization for this code path — it was incidental, the result of not specifying any other capability.

## Things I considered but did not do

- **Forcing transcoding via codec asymmetry** — fragile, depends on trunk configuration.
- **Adding a silent 3rd channel** — more invasive, needs originating a Local channel.
- **Installing a framehook (JITTERBUFFER, MixMonitor)** — side effects on the call leg.

The single-line change to the bridge `type` parameter is the minimal, side-effect-free fix.

## Test plan

- [x] Tested against Asterisk 20.19 + PJSIP ulaw trunk + chan_websocket external media on a real outbound call.
- [x] Verified bridge technology is `softmix` after the change (was `simple_bridge`).
- [x] Verified bidirectional audio (user speech reaches VAD, agent responds).
- [x] No regression on agent → user direction (TTS still reaches the user).

Happy to add automated coverage if there's an existing test pattern for ARI bridge creation — I didn't find one in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)