### PR TITLE
fix(security): bump python-multipart 0.0.20 -> 0.0.27

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -9,7 +9,7 @@ arq==0.26.3
 twilio==9.8.0
 minio==7.2.16
 alembic-postgresql-enum==1.8.0
-python-multipart==0.0.20
+python-multipart==0.0.27
 sentry-sdk[fastapi]==2.38.0
 sqlalchemy[asyncio]==2.0.43
 msgpack==1.1.2


### PR DESCRIPTION
## Summary

Bumps `python-multipart` in `api/requirements.txt` from `0.0.20` to `0.0.27` to pick up the fixes for three known advisories that affect the multipart form parser FastAPI uses on every endpoint accepting `UploadFile` / `Form` input.

## Impact

The pinned `0.0.20` is reachable from request-handling code paths including:

- `api/routes/workflow_recording.py::transcribe_audio` (`UploadFile = File(...)`)
- the presigned-upload coordination endpoints (`/s3/presigned-upload-url`, `/workflow-recordings/upload-url`, `/knowledge-base/upload-url`)
- any FastAPI form endpoint that parses `multipart/form-data` in the server (the listed presigned flows hand off the actual upload to S3/MinIO, but the request-side parser still runs on metadata posts)

The three advisories:

| Advisory | Severity | Class | Fixed in |
|---|---|---|---|
| [GHSA-wp53-j4wj-2cfg](https://github.com/advisories/GHSA-wp53-j4wj-2cfg) | HIGH | CWE-22 — arbitrary file write via non-default configuration | 0.0.22 |
| [GHSA-pp6c-gr5w-3c5g](https://github.com/advisories/GHSA-pp6c-gr5w-3c5g) | HIGH | CWE-400 — DoS via unbounded multipart part headers | 0.0.27 |
| [GHSA-mj87-hwqh-73pj](https://github.com/advisories/GHSA-mj87-hwqh-73pj) | MOD | CWE-400 — DoS via large multipart preamble / epilogue | 0.0.26 |

The header-DoS one is the most interesting — an unauthenticated attacker can stream an unbounded part-header section against any multipart endpoint and exhaust memory. Backend has no length cap on its own; the parser bound is the only defense, so the bump is the actual fix rather than defense-in-depth.

## Location

`api/requirements.txt:12`

## Fix

```diff
-python-multipart==0.0.20
+python-multipart==0.0.27
```

0.0.27 is a patch-level bump within the same `0.0.x` line — no public API changes. `fastapi==0.135.3` only requires `python-multipart>=0.0.7`, so the upper bound is unaffected.

## Detected by

Aeon + `osv-scanner` (3 advisories confirmed via OSV affected-range comparison against the pinned `0.0.20`).

## Verification

- Diff is one line in `api/requirements.txt`; no code paths change.
- OSV re-check against the new pin: 0 findings for `python-multipart`.
- Could **not** run the project's pytest suite from the scan sandbox (no live Postgres/Redis/MinIO available, and `api/.env.test` per `api/AGENTS.md` is the intended path). CI is the right gate; happy to amend if anything regresses.

## Out of scope for this PR, called out for follow-up

A handful of larger bumps surfaced in the same scan but are intentionally left for separate review because the diff/blast-radius is much bigger and patch ranges aren't compatible-clean the way this one is:

- `ui/package-lock.json`: `next@15.5.14` (14 CVEs, several HIGH including App-Router middleware bypass and WebSocket SSRF) and `axios@1.13.5` (16 CVEs incl. prototype-pollution chain) — these want a dedicated frontend bump PR with a build + smoke pass.
- `evals/visualizer/{package-lock.json,pnpm-lock.yaml}`: `next@16.1.4` with the same advisory family — evals tool, not the production frontend.
- Transitive `minimatch`/`picomatch`/`brace-expansion`/`postcss`/`flatted` (multiple ReDoS + prototype-pollution) — these are downstream of the `next` bump and resolve naturally with a frontend lockfile regen.

Also intentionally **not** included: a CORS-tightening change against `api/app.py`. The repo's `.agents/skills/review-pr/SKILL.md` explicitly notes that "Dograh relies on cross-origin embedding; endpoint auth is the real control" — defer to maintainer policy on that one.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
