### PR TITLE
fix: abort docker compose when OSS_JWT_SECRET is unset

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -173,7 +173,7 @@ services:
       TURN_SECRET: "${TURN_SECRET:-}"
       FORCE_TURN_RELAY: "${FORCE_TURN_RELAY:-false}"
 
-      OSS_JWT_SECRET: "${OSS_JWT_SECRET:-ChangeMeInProduction}"
+      OSS_JWT_SECRET: "${OSS_JWT_SECRET:?OSS_JWT_SECRET must be set to a strong secret}"
 
       # Telemetry
       ENABLE_TELEMETRY: "${ENABLE_TELEMETRY:-true}"


### PR DESCRIPTION
## Summary

`docker-compose.yaml` used `${OSS_JWT_SECRET:-ChangeMeInProduction}` which silently starts the stack with a publicly-known JWT signing key when `OSS_JWT_SECRET` is not set. Any attacker aware of this default can forge valid JWTs against any self-hosted deployment. Switching to `:?` causes `docker compose up` to abort with a clear error message instead, forcing operators to explicitly set a secret before starting.

## Changes

- `docker-compose.yaml`: Replace `:-ChangeMeInProduction` with `:?OSS_JWT_SECRET must be set to a strong secret`

## Testing

Tested locally by running `docker compose config` with and without `OSS_JWT_SECRET` set:
- Without the variable: compose exits with `required variable OSS_JWT_SECRET is missing a value`
- With the variable set: compose proceeds normally

Closes #338