### PR TITLE
docs: clarify Asterisk ARI WebSocket URI for Dograh Cloud vs self-hosted

### DIFF
--- a/docs/integrations/telephony/asterisk-ari.mdx
+++ b/docs/integrations/telephony/asterisk-ari.mdx
@@ -73,12 +73,32 @@ Replace `dograh` with the app name you configured in `ari.conf` and in Dograh.
 
 Dograh uses Asterisk's external media streaming to send and receive audio over WebSocket. Configure a WebSocket client connection that points to your Dograh instance:
 
-```ini
-[dograh]
-type = websocket_client
-uri = ws://your-dograh-host:port/api/v1/telephony/ws/ari
-protocols = media
-```
+<Tabs>
+  <Tab title="Dograh Cloud">
+    ```ini
+    [dograh]
+    type = websocket_client
+    uri = wss://api.dograh.com/api/v1/telephony/ws/ari
+    protocols = media
+    ```
+
+    <Note>
+    Dograh Cloud requires a secure WebSocket connection (`wss://`). Make sure your Asterisk build includes TLS support for `chan_websocket`. The ARI credentials (**Stasis App Name** and **App Password**) must match what you configure in the Dograh dashboard under Telephony Settings.
+    </Note>
+  </Tab>
+  <Tab title="Self-hosted">
+    ```ini
+    [dograh]
+    type = websocket_client
+    uri = ws://your-dograh-host:port/api/v1/telephony/ws/ari
+    protocols = media
+    ```
+
+    <Note>
+    Self-hosted deployments on an internal network may use an unencrypted WebSocket (`ws://`). If your Dograh instance is exposed over HTTPS, use `wss://` and the corresponding hostname instead.
+    </Note>
+  </Tab>
+</Tabs>
 
 <Note>
 The section name (e.g., `dograh`) is the **WebSocket Client Name** you'll enter in the Dograh telephony configuration. This name tells Asterisk which WebSocket connection to use for external media streaming during calls.


### PR DESCRIPTION
## Summary

Users setting up the Asterisk ARI integration with Dograh Cloud were confused about the correct `uri` in `websocket_client.conf`. The existing docs only showed the self-hosted pattern (`ws://your-dograh-host:port/...`), leaving cloud users to guess whether `wss://api.dograh.com/api/v1/telephony/ws/ari` was correct and why connections were being refused.

This PR replaces the single code block with a tabbed example covering both deployment targets, and adds notes explaining the TLS requirement for cloud and the flexibility for self-hosted.

## Changes

- `docs/integrations/telephony/asterisk-ari.mdx`: Replace single `websocket_client.conf` example with Dograh Cloud / Self-hosted tabs, each with an explanatory note

## Testing

Reviewed against existing Mintlify tab component usage in the docs. No functional code changed.

Closes #350