### PR TITLE
feat: add copy-to-clipboard button for inbound webhook URL

### DIFF
--- a/ui/src/app/telephony-configurations/[configId]/page.tsx
+++ b/ui/src/app/telephony-configurations/[configId]/page.tsx
@@ -57,6 +57,15 @@ import {
 } from "@/components/ui/table";
 import { useAuth } from "@/lib/auth";
 
+const INBOUND_WEBHOOK_PATH = "/api/v1/telephony/inbound/run";
+
+function getInboundWebhookUrl(): string {
+  const backendUrl =
+    process.env.NEXT_PUBLIC_BACKEND_URL ||
+    (typeof window !== "undefined" ? window.location.origin : "");
+  return `${backendUrl}${INBOUND_WEBHOOK_PATH}`;
+}
+
 export default function TelephonyConfigurationDetailPage() {
   const router = useRouter();
   const params = useParams<{ configId: string }>();
@@ -255,16 +264,17 @@ export default function TelephonyConfigurationDetailPage() {
             <button
               type="button"
               onClick={() => {
-                const url = `${typeof window !== "undefined" ? window.location.origin : ""}/api/v1/telephony/inbound/run`;
+                const url = getInboundWebhookUrl();
                 navigator.clipboard
                   .writeText(url)
                   .then(() => toast.success("Inbound webhook URL copied"))
                   .catch(() => toast.error("Failed to copy URL"));
               }}
               title="Click to copy inbound webhook URL"
+              aria-label="Copy inbound webhook URL"
               className="inline-flex items-center gap-1 self-start rounded font-mono text-xs text-muted-foreground hover:text-foreground"
             >
-              <span className="truncate">/api/v1/telephony/inbound/run</span>
+              <span className="truncate">{getInboundWebhookUrl()}</span>
               <Copy className="h-3 w-3 shrink-0" />
             </button>
           </div>

--- a/ui/src/app/telephony-configurations/[configId]/page.tsx
+++ b/ui/src/app/telephony-configurations/[configId]/page.tsx
@@ -239,7 +239,7 @@ export default function TelephonyConfigurationDetailPage() {
             </Button>
           </div>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-4">
           <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
             {Object.entries(config.credentials ?? {}).map(([k, v]) => (
               <div key={k} className="flex justify-between gap-3">
@@ -250,6 +250,24 @@ export default function TelephonyConfigurationDetailPage() {
               </div>
             ))}
           </dl>
+          <div className="space-y-1">
+            <p className="text-xs text-muted-foreground">Inbound webhook URL</p>
+            <button
+              type="button"
+              onClick={() => {
+                const url = `${typeof window !== "undefined" ? window.location.origin : ""}/api/v1/telephony/inbound/run`;
+                navigator.clipboard
+                  .writeText(url)
+                  .then(() => toast.success("Inbound webhook URL copied"))
+                  .catch(() => toast.error("Failed to copy URL"));
+              }}
+              title="Click to copy inbound webhook URL"
+              className="inline-flex items-center gap-1 self-start rounded font-mono text-xs text-muted-foreground hover:text-foreground"
+            >
+              <span className="truncate">/api/v1/telephony/inbound/run</span>
+              <Copy className="h-3 w-3 shrink-0" />
+            </button>
+          </div>
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary

Users configuring inbound telephony had no easy way to retrieve the webhook URL they need to enter into their provider dashboard (Telnyx, Twilio, Plivo, etc.). They had to construct it manually from docs or guess. This adds a copyable inbound webhook URL display — `/api/v1/telephony/inbound/run` — to the telephony configuration detail page, so users can copy it with one click and paste it into their provider's webhook settings.

## Changes

- `ui/src/app/telephony-configurations/[configId]/page.tsx`: Add inbound webhook URL display with copy-to-clipboard button to the configuration detail card, following the existing Configuration ID copy button pattern

## Testing

- Verified the component renders correctly and follows existing copy-button patterns (`Copy` icon from lucide-react, `toast.success`/`toast.error` feedback)
- URL is constructed from `window.location.origin + /api/v1/telephony/inbound/run` (correct for nginx-proxied deployments where UI and API share an origin)
- `typeof window !== "undefined"` guard added for SSR safety

Closes #133