### PR TITLE
fix: run api container as non-root dograh user

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -71,7 +71,9 @@ FROM python:3.13-slim AS runner
 
 WORKDIR /app
 
-RUN groupadd --system dograh && useradd --system --gid dograh --home-dir /app dograh
+RUN groupadd --system dograh \
+ && useradd --system --gid dograh --no-log-init --home-dir /app --shell /usr/sbin/nologin dograh \
+ && chown dograh:dograh /app
 
 # Static ffmpeg + ffprobe (used by audio_converter, audio_file_cache, etc.)
 COPY --from=ffmpeg-static /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
@@ -95,24 +97,24 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # Unbuffered output for better container logging
 ENV PYTHONUNBUFFERED=1
 
-# Copy application code
-COPY ./api ./api
-COPY ./scripts/start_services_docker.sh ./scripts/start_services_docker.sh
+# Copy application code (chown at copy-time avoids a duplicate /app layer
+# from a later `RUN chown -R`, which would double the on-disk size of /app).
+COPY --chown=dograh:dograh ./api ./api
+COPY --chown=dograh:dograh ./scripts/start_services_docker.sh ./scripts/start_services_docker.sh
 
 # ts_validator Node deps (built in ts-deps stage with full node:22-slim image).
 # The validator runs as a short-lived subprocess from api/mcp_server/ts_bridge.py.
-COPY --from=ts-deps /ts_validator/node_modules ./api/mcp_server/ts_validator/node_modules
+COPY --from=ts-deps --chown=dograh:dograh /ts_validator/node_modules ./api/mcp_server/ts_validator/node_modules
 
 # Product documentation — read at runtime by the MCP docs tools
 # (search_dograh_docs / fetch_dograh_doc) so agents can learn Dograh.
-COPY ./docs ./docs
+COPY --chown=dograh:dograh ./docs ./docs
 
 ENV PYTHONPATH=/app
 
 # Disable file logging in Docker - logs go to stdout for docker logs
 ENV LOG_TO_FILE=false
 
-RUN chown -R dograh:dograh /app
 USER dograh
 
 # Expose the port FastAPI will run on

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -71,6 +71,8 @@ FROM python:3.13-slim AS runner
 
 WORKDIR /app
 
+RUN groupadd --system dograh && useradd --system --gid dograh --home-dir /app dograh
+
 # Static ffmpeg + ffprobe (used by audio_converter, audio_file_cache, etc.)
 COPY --from=ffmpeg-static /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
 COPY --from=ffmpeg-static /usr/local/bin/ffprobe /usr/local/bin/ffprobe
@@ -109,6 +111,9 @@ ENV PYTHONPATH=/app
 
 # Disable file logging in Docker - logs go to stdout for docker logs
 ENV LOG_TO_FILE=false
+
+RUN chown -R dograh:dograh /app
+USER dograh
 
 # Expose the port FastAPI will run on
 EXPOSE 8000


### PR DESCRIPTION
## Summary

The `api/Dockerfile` runner stage had no `USER` directive, so the FastAPI process (uvicorn, arq workers, and the ARI manager) ran as root inside the container. Running as root unnecessarily increases the blast radius of any container escape or RCE vulnerability. This adds a `dograh` system user/group, transfers ownership of `/app` to that user, and switches to it before `CMD`.

## Changes

- `api/Dockerfile`: Add `groupadd`/`useradd` for a `dograh` system user in the runner stage, `chown -R dograh:dograh /app`, and `USER dograh` before `EXPOSE`/`CMD`

## Testing

- Verified no application code writes to paths outside `/app` or `/tmp` (both writable by the new user)
- The venv at `/opt/venv` is world-readable/executable so it remains usable
- `alembic upgrade head`, uvicorn, and arq all operate over the network and do not require elevated privileges
- ffmpeg and node binaries at `/usr/local/bin/` remain executable by all users (default permissions)

Closes #338