### PR TITLE
feat: allow overriding base URL of OpenAI STT and TTS

### DIFF
--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -803,6 +803,10 @@ class OpenAITTSService(BaseTTSConfiguration):
         default="alloy",
         description="OpenAI TTS voice name.",
     )
+    base_url: str = Field(
+        default="https://api.openai.com/v1",
+        description="Override only if using an OpenAI-compatible API (e.g. local TTS, proxy).",
+    )
 
 
 DOGRAH_TTS_MODELS = ["default"]
@@ -1060,6 +1064,10 @@ class OpenAISTTConfiguration(BaseSTTConfiguration):
         default="gpt-4o-transcribe",
         description="OpenAI transcription model.",
         json_schema_extra={"examples": OPENAI_STT_MODELS},
+    )
+    base_url: str = Field(
+        default="https://api.openai.com/v1",
+        description="Override only if using an OpenAI-compatible API (e.g. local STT, proxy).",
     )
 
 

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -118,9 +118,15 @@ def create_stt_service(
             sample_rate=audio_config.transport_in_sample_rate,
         )
     elif user_config.stt.provider == ServiceProviders.OPENAI.value:
+        kwargs = {}
+        base_url = getattr(user_config.stt, "base_url", None)
+        if base_url:
+            _validate_runtime_service_url(base_url, "base_url")
+            kwargs["base_url"] = base_url
         return OpenAISTTService(
             api_key=user_config.stt.api_key,
             settings=OpenAISTTSettings(model=user_config.stt.model),
+            **kwargs,
         )
     elif user_config.stt.provider == ServiceProviders.GOOGLE.value:
         language = getattr(user_config.stt, "language", None) or "en-US"
@@ -273,12 +279,18 @@ def create_tts_service(user_config, audio_config: "AudioConfig"):
             silence_time_s=1.0,
         )
     elif user_config.tts.provider == ServiceProviders.OPENAI.value:
+        kwargs = {}
+        base_url = getattr(user_config.tts, "base_url", None)
+        if base_url:
+            _validate_runtime_service_url(base_url, "base_url")
+            kwargs["base_url"] = base_url
         return OpenAITTSService(
             api_key=user_config.tts.api_key,
             settings=OpenAITTSSettings(model=user_config.tts.model),
             text_filters=[xml_function_tag_filter],
             skip_aggregator_types=["recording_router", "recording"],
             silence_time_s=1.0,
+            **kwargs,
         )
     elif user_config.tts.provider == ServiceProviders.GOOGLE.value:
         model = getattr(user_config.tts, "model", None) or "chirp_3_hd"

--- a/api/tests/test_user_configured_service_url_security.py
+++ b/api/tests/test_user_configured_service_url_security.py
@@ -11,6 +11,7 @@ from api.services.configuration.registry import (
 from api.services.gen_ai.embedding.openai_service import OpenAIEmbeddingService
 from api.services.pipecat.service_factory import (
     create_llm_service_from_provider,
+    create_stt_service,
     create_tts_service,
 )
 from api.utils.url_security import validate_user_configured_service_url
@@ -204,6 +205,80 @@ def test_runtime_blocks_elevenlabs_local_tts_base_url_in_saas(monkeypatch):
             voice="voice-id",
             speed=1.0,
             base_url="http://localhost:8000",
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        create_tts_service(user_config, audio_config=None)
+
+    assert exc_info.value.status_code == 400
+    assert "localhost" in exc_info.value.detail
+
+
+def test_runtime_blocks_openai_stt_private_base_url_in_saas(monkeypatch):
+    monkeypatch.setattr("api.utils.url_security.DEPLOYMENT_MODE", "saas")
+    user_config = SimpleNamespace(
+        stt=SimpleNamespace(
+            provider=ServiceProviders.OPENAI.value,
+            api_key="test-key",
+            model="gpt-4o-transcribe",
+            base_url="http://10.0.0.10/v1",
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        create_stt_service(user_config, audio_config=None)
+
+    assert exc_info.value.status_code == 400
+    assert "public IP" in exc_info.value.detail
+
+
+def test_runtime_blocks_openai_stt_localhost_base_url_in_saas(monkeypatch):
+    monkeypatch.setattr("api.utils.url_security.DEPLOYMENT_MODE", "saas")
+    user_config = SimpleNamespace(
+        stt=SimpleNamespace(
+            provider=ServiceProviders.OPENAI.value,
+            api_key="test-key",
+            model="gpt-4o-transcribe",
+            base_url="http://localhost:8000/v1",
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        create_stt_service(user_config, audio_config=None)
+
+    assert exc_info.value.status_code == 400
+    assert "localhost" in exc_info.value.detail
+
+
+def test_runtime_blocks_openai_tts_private_base_url_in_saas(monkeypatch):
+    monkeypatch.setattr("api.utils.url_security.DEPLOYMENT_MODE", "saas")
+    user_config = SimpleNamespace(
+        tts=SimpleNamespace(
+            provider=ServiceProviders.OPENAI.value,
+            api_key="test-key",
+            model="gpt-4o-mini-tts",
+            voice="alloy",
+            base_url="http://10.0.0.10/v1",
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        create_tts_service(user_config, audio_config=None)
+
+    assert exc_info.value.status_code == 400
+    assert "public IP" in exc_info.value.detail
+
+
+def test_runtime_blocks_openai_tts_localhost_base_url_in_saas(monkeypatch):
+    monkeypatch.setattr("api.utils.url_security.DEPLOYMENT_MODE", "saas")
+    user_config = SimpleNamespace(
+        tts=SimpleNamespace(
+            provider=ServiceProviders.OPENAI.value,
+            api_key="test-key",
+            model="gpt-4o-mini-tts",
+            voice="alloy",
+            base_url="http://localhost:8000/v1",
         )
     )
 


### PR DESCRIPTION
## What

Mirrors the LLM treatment from #368 for the OpenAI **STT** and OpenAI **TTS** providers. Users running OpenAI-compatible self-hosted services (vLLM, llama.cpp, custom proxies) can now point Dograh at them via the OpenAI provider with `base_url`, instead of being forced onto the Speaches provider as a workaround.

## Why

#368 added `base_url` for OpenAI **LLM**. Self-hosted operators who run their own STT/TTS on the same OpenAI-compatible API surface (it's the same convention pipecat already supports — both `OpenAISTTService` and `OpenAITTSService` constructors accept `base_url`) have to keep using the Speaches provider as a sidecar. With this change, the OpenAI provider becomes a clean, uniform path for all three service types.

## Changes

- **`registry.py`** — adds `base_url` field (default `https://api.openai.com/v1`) to `OpenAISTTConfiguration` and `OpenAITTSService`, identical in shape to the `OpenAILLMService.base_url` from #368.
- **`service_factory.py`** — in the OPENAI branches of `create_stt_service` and `create_tts_service`, lift `base_url` off `user_config`, run it through `_validate_runtime_service_url`, and forward it as a kwarg. Same pattern as the LLM branch from #368.
- **`test_user_configured_service_url_security.py`** — adds 4 runtime tests covering private-IP rejection and localhost rejection in SaaS mode for both STT and TTS.

`check_validity.py` requires no edit — the existing per-service URL validation loop already iterates `("base_url", "endpoint")` via `getattr`, and `_check_openai_api_key` already routes OPENAI providers through the base_url-aware code path (also from #368).

## Compatibility

- No schema migration. Existing configurations without `base_url` keep their default and continue to talk to `api.openai.com`.
- OSS-mode behaviour unchanged (URL validator is a no-op when `DEPLOYMENT_MODE=oss`).
- SaaS-mode tightening matches LLM: private/localhost/CGNAT IPs rejected with the same `validate_user_configured_service_url` helper.

## Tests

```
$ pytest api/tests/test_user_configured_service_url_security.py
23 passed in 4.80s   (19 existing + 4 new)
```

## Related

Pattern source: #368 (LLM base_url support). This PR completes the STT + TTS legs.