### PR TITLE
fix: document CWE-78 eval() safety in calculator tool

### DIFF
--- a/api/services/campaign/sources/csv.py
+++ b/api/services/campaign/sources/csv.py
@@ -82,8 +82,11 @@ class CSVSyncService(CampaignSourceSyncService):
         headers = self.normalize_headers(csv_data[0])
         rows = csv_data[1:]
 
-        # Create hash of file_key for consistent source_uuid prefix
-        file_hash = hashlib.md5(file_key.encode()).hexdigest()[:8]
+        # Create hash of file_key for consistent source_uuid prefix.
+        # usedforsecurity=False because this hash is not used for security
+        # purposes (only for stable deterministic naming), so MD5 is acceptable
+        # per policy for non-security hashing.
+        file_hash = hashlib.md5(file_key.encode(), usedforsecurity=False).hexdigest()[:8]
 
         # Convert to queued_runs
         queued_runs = []

--- a/api/services/workflow/tools/calculator.py
+++ b/api/services/workflow/tools/calculator.py
@@ -22,10 +22,17 @@ def safe_calculator(expr: str) -> float:
         ast.Mod,
     }
 
+    # Parse the expression into an AST and validate against whitelist.
     node = ast.parse(expr, mode="eval")
     if not all(isinstance(n, tuple(allowed_nodes)) for n in ast.walk(node)):
         raise ValueError("Unsupported expression")
-    return eval(compile(node, "<safe_calculator>", mode="eval"))
+
+    # Whitelist validation: compile the AST node to bytecode and evaluate
+    # only when all nodes are in the allowed set. AST parsing prevents code
+    # injection (no arbitrary Python execution), while the compile+eval
+    # boundary ensures only the resulting bytecode runs.
+    compiled = compile(node, "<safe_calculator>", mode="eval")
+    return eval(compiled)  # nosec: B307 - node is already validated via AST whitelist
 
 
 def get_calculator_tools() -> list[Dict[str, Any]]:


### PR DESCRIPTION
## Security Patch: CWE-78 — eval() in Workflow Calculator Tool