### PR TITLE
Feat/litellm provider

### DIFF
--- a/api/services/configuration/check_validity.py
+++ b/api/services/configuration/check_validity.py
@@ -58,6 +58,7 @@ class UserConfigurationValidator:
             ServiceProviders.GLADIA.value: self._check_gladia_api_key,
             ServiceProviders.RIME.value: self._check_rime_api_key,
             ServiceProviders.MINIMAX.value: self._check_minimax_api_key,
+            ServiceProviders.LITELLM.value: self._check_litellm_api_key,
         }
 
     async def validate(
@@ -118,6 +119,20 @@ class UserConfigurationValidator:
                     )
                 except ValueError as e:
                     return [{"model": service_name, "message": str(e)}]
+
+        # LiteLLM doesn't require an API key (proxy may be unauthenticated)
+        if provider == ServiceProviders.LITELLM.value:
+            try:
+                if not self._check_litellm_api_key(provider, service_config):
+                    return [
+                        {
+                            "model": service_name,
+                            "message": f"Invalid {provider} configuration",
+                        }
+                    ]
+            except ValueError as e:
+                return [{"model": service_name, "message": str(e)}]
+            return []
 
         # Speaches doesn't require an API key
         if provider == ServiceProviders.SPEACHES.value:
@@ -383,4 +398,9 @@ class UserConfigurationValidator:
     def _check_minimax_api_key(self, model: str, api_key: str) -> bool:
         # MiniMax doesn't publish a cheap key-validation endpoint; trust the key
         # at save time and surface auth errors at first call (same as Rime/Sarvam).
+        return True
+
+    def _check_litellm_api_key(self, model: str, service_config) -> bool:
+        if not getattr(service_config, "base_url", None):
+            raise ValueError("base_url is required for LiteLLM proxy")
         return True

--- a/api/services/configuration/check_validity.py
+++ b/api/services/configuration/check_validity.py
@@ -58,7 +58,6 @@ class UserConfigurationValidator:
             ServiceProviders.GLADIA.value: self._check_gladia_api_key,
             ServiceProviders.RIME.value: self._check_rime_api_key,
             ServiceProviders.MINIMAX.value: self._check_minimax_api_key,
-            ServiceProviders.LITELLM.value: self._check_litellm_api_key,
         }
 
     async def validate(
@@ -120,18 +119,9 @@ class UserConfigurationValidator:
                 except ValueError as e:
                     return [{"model": service_name, "message": str(e)}]
 
-        # LiteLLM doesn't require an API key (proxy may be unauthenticated)
+        # LiteLLM reads provider API keys from env vars; neither api_key
+        # nor base_url is required for direct SDK usage.
         if provider == ServiceProviders.LITELLM.value:
-            try:
-                if not self._check_litellm_api_key(provider, service_config):
-                    return [
-                        {
-                            "model": service_name,
-                            "message": f"Invalid {provider} configuration",
-                        }
-                    ]
-            except ValueError as e:
-                return [{"model": service_name, "message": str(e)}]
             return []
 
         # Speaches doesn't require an API key
@@ -400,7 +390,3 @@ class UserConfigurationValidator:
         # at save time and surface auth errors at first call (same as Rime/Sarvam).
         return True
 
-    def _check_litellm_api_key(self, model: str, service_config) -> bool:
-        if not getattr(service_config, "base_url", None):
-            raise ValueError("base_url is required for LiteLLM proxy")
-        return True

--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -68,6 +68,7 @@ class ServiceProviders(str, Enum):
     ULTRAVOX_REALTIME = "ultravox_realtime"
     GOOGLE_REALTIME = "google_realtime"
     GOOGLE_VERTEX_REALTIME = "google_vertex_realtime"
+    LITELLM = "litellm"
 
 
 class BaseServiceConfiguration(BaseModel):
@@ -93,6 +94,7 @@ class BaseServiceConfiguration(BaseModel):
         ServiceProviders.GOOGLE_REALTIME,
         ServiceProviders.GOOGLE_VERTEX_REALTIME,
         ServiceProviders.SARVAM,
+        ServiceProviders.LITELLM,
     ]
     api_key: str | list[str]
 
@@ -498,6 +500,53 @@ class SarvamLLMConfiguration(BaseLLMConfiguration):
     )
 
 
+LITELLM_PROVIDER_MODEL_CONFIG = provider_model_config(
+    "LiteLLM",
+    description=(
+        "LiteLLM AI gateway proxy. Routes requests to 100+ LLM providers "
+        "(OpenAI, Anthropic, Bedrock, Vertex, HuggingFace, etc.) through a "
+        "single OpenAI-compatible endpoint."
+    ),
+    provider_docs_url="https://docs.litellm.ai/",
+)
+
+LITELLM_MODELS = [
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "claude-sonnet-4-20250514",
+    "claude-haiku-4-5-20251001",
+    "gemini/gemini-2.5-flash",
+    "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+    "vertex_ai/gemini-2.5-flash",
+]
+
+
+@register_llm
+class LiteLLMLLMConfiguration(BaseLLMConfiguration):
+    model_config = LITELLM_PROVIDER_MODEL_CONFIG
+    provider: Literal[ServiceProviders.LITELLM] = ServiceProviders.LITELLM
+    model: str = Field(
+        default="gpt-4.1",
+        description=(
+            "LiteLLM model identifier. Use the LiteLLM model name format "
+            "(e.g. 'gpt-4.1', 'claude-sonnet-4-20250514', 'bedrock/anthropic.claude-sonnet-4-20250514-v1:0'). "
+            "See https://docs.litellm.ai/docs/providers for the full list."
+        ),
+        json_schema_extra={"examples": LITELLM_MODELS, "allow_custom_input": True},
+    )
+    base_url: str = Field(
+        default="http://localhost:4000",
+        description="Base URL of your LiteLLM proxy server (e.g. http://localhost:4000).",
+    )
+    api_key: str | list[str] | None = Field(
+        default=None,
+        description=(
+            "LiteLLM proxy master key or virtual key. If your proxy doesn't "
+            "require authentication, leave blank."
+        ),
+    )
+
+
 OPENAI_REALTIME_MODELS = ["gpt-realtime-2"]
 OPENAI_REALTIME_VOICES = [
     "alloy",
@@ -688,6 +737,7 @@ LLMConfig = Annotated[
         SpeachesLLMConfiguration,
         MiniMaxLLMConfiguration,
         SarvamLLMConfiguration,
+        LiteLLMLLMConfiguration,
     ],
     Field(discriminator="provider"),
 ]

--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -534,15 +534,20 @@ class LiteLLMLLMConfiguration(BaseLLMConfiguration):
         ),
         json_schema_extra={"examples": LITELLM_MODELS, "allow_custom_input": True},
     )
-    base_url: str = Field(
-        default="http://localhost:4000",
-        description="Base URL of your LiteLLM proxy server (e.g. http://localhost:4000).",
+    base_url: str | None = Field(
+        default=None,
+        description=(
+            "Optional API base URL. Only needed when routing through a "
+            "LiteLLM proxy server. Leave blank for direct SDK usage "
+            "(provider API keys are read from environment variables)."
+        ),
     )
     api_key: str | list[str] | None = Field(
         default=None,
         description=(
-            "LiteLLM proxy master key or virtual key. If your proxy doesn't "
-            "require authentication, leave blank."
+            "Optional API key. For direct SDK usage, provider keys are read "
+            "from environment variables (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY). "
+            "Set this only when using a LiteLLM proxy that requires a master/virtual key."
         ),
     )
 

--- a/api/services/pipecat/litellm_llm.py
+++ b/api/services/pipecat/litellm_llm.py
@@ -1,0 +1,128 @@
+import asyncio
+from dataclasses import dataclass
+
+from loguru import logger
+
+try:
+    import litellm
+except ImportError:
+    raise ImportError(
+        "Missing module: litellm. Install with: pip install litellm"
+    )
+
+from pipecat.services.openai.base_llm import BaseOpenAILLMService, OpenAILLMSettings
+from pipecat.services.settings import assert_given
+
+
+@dataclass
+class LiteLLMSettings(OpenAILLMSettings):
+    pass
+
+
+class LiteLLMLLMService(BaseOpenAILLMService):
+    """LLM service that routes requests through the LiteLLM SDK.
+
+    Uses litellm.acompletion() to call 100+ providers (OpenAI, Anthropic,
+    Bedrock, Vertex, Groq, etc.) with a unified model string format.
+    Provider API keys are read from environment variables.
+    """
+
+    Settings = LiteLLMSettings
+    _settings: Settings
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        drop_params: bool = True,
+        settings: Settings | None = None,
+        **kwargs,
+    ):
+        default_settings = self.Settings(model="gpt-4.1")
+
+        if model is not None:
+            default_settings.model = model
+
+        if settings is not None:
+            default_settings.apply_update(settings)
+
+        self._litellm_api_key = api_key
+        self._litellm_api_base = api_base
+        self._litellm_drop_params = drop_params
+
+        super().__init__(
+            api_key=api_key or "not-used",
+            settings=default_settings,
+            **kwargs,
+        )
+
+    def create_client(self, api_key=None, base_url=None, **kwargs):
+        return None
+
+    async def get_chat_completions(self, context):
+        adapter = self.get_llm_adapter()
+        logger.debug(
+            f"{self}: Generating chat via LiteLLM SDK: model={self._settings.model}"
+        )
+
+        params_from_context = adapter.get_llm_invocation_params(
+            context,
+            system_instruction=assert_given(self._settings.system_instruction),
+            convert_developer_to_user=not self.supports_developer_role,
+        )
+
+        params = self.build_chat_completion_params(params_from_context)
+
+        if self._litellm_api_key:
+            params["api_key"] = self._litellm_api_key
+        if self._litellm_api_base:
+            params["api_base"] = self._litellm_api_base
+
+        params["drop_params"] = self._litellm_drop_params
+
+        if self._retry_on_timeout:
+            try:
+                chunks = await asyncio.wait_for(
+                    litellm.acompletion(**params),
+                    timeout=self._retry_timeout_secs,
+                )
+                return chunks
+            except (TimeoutError, Exception) as e:
+                if "timeout" in str(e).lower() or isinstance(e, TimeoutError):
+                    logger.debug(f"{self}: Retrying LiteLLM completion due to timeout")
+                    chunks = await litellm.acompletion(**params)
+                    return chunks
+                raise
+        else:
+            chunks = await litellm.acompletion(**params)
+            return chunks
+
+    async def run_inference(self, context, max_tokens=None, system_instruction=None):
+        effective_instruction = system_instruction or self._settings.system_instruction
+        adapter = self.get_llm_adapter()
+        invocation_params = adapter.get_llm_invocation_params(
+            context,
+            system_instruction=effective_instruction,
+            convert_developer_to_user=not self.supports_developer_role,
+        )
+
+        params = self.build_chat_completion_params(invocation_params)
+        params["stream"] = False
+        params.pop("stream_options", None)
+
+        if max_tokens is not None:
+            if "max_completion_tokens" in params:
+                params["max_completion_tokens"] = max_tokens
+            else:
+                params["max_tokens"] = max_tokens
+
+        if self._litellm_api_key:
+            params["api_key"] = self._litellm_api_key
+        if self._litellm_api_base:
+            params["api_base"] = self._litellm_api_base
+        params["drop_params"] = self._litellm_drop_params
+
+        response = await litellm.acompletion(**params)
+        return response.choices[0].message.content

--- a/api/services/pipecat/litellm_llm.py
+++ b/api/services/pipecat/litellm_llm.py
@@ -2,6 +2,7 @@ import asyncio
 from dataclasses import dataclass
 
 from loguru import logger
+from openai import NOT_GIVEN
 
 try:
     import litellm
@@ -11,7 +12,17 @@ except ImportError:
     )
 
 from pipecat.services.openai.base_llm import BaseOpenAILLMService, OpenAILLMSettings
+from pipecat.services.settings import NOT_GIVEN as _PIPECAT_NOT_GIVEN
 from pipecat.services.settings import assert_given
+
+
+def _strip_not_given(params: dict) -> dict:
+    """Remove OpenAI/pipecat NOT_GIVEN sentinels that litellm can't handle."""
+    return {
+        k: v
+        for k, v in params.items()
+        if v is not NOT_GIVEN and v is not _PIPECAT_NOT_GIVEN
+    }
 
 
 @dataclass
@@ -73,7 +84,7 @@ class LiteLLMLLMService(BaseOpenAILLMService):
             convert_developer_to_user=not self.supports_developer_role,
         )
 
-        params = self.build_chat_completion_params(params_from_context)
+        params = _strip_not_given(self.build_chat_completion_params(params_from_context))
 
         if self._litellm_api_key:
             params["api_key"] = self._litellm_api_key
@@ -108,7 +119,7 @@ class LiteLLMLLMService(BaseOpenAILLMService):
             convert_developer_to_user=not self.supports_developer_role,
         )
 
-        params = self.build_chat_completion_params(invocation_params)
+        params = _strip_not_given(self.build_chat_completion_params(invocation_params))
         params["stream"] = False
         params.pop("stream_options", None)
 

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -622,6 +622,14 @@ def create_llm_service_from_provider(
                 temperature=temperature if temperature is not None else 0.5,
             ),
         )
+    elif provider == ServiceProviders.LITELLM.value:
+        base_url = base_url or "http://localhost:4000"
+        _validate_runtime_service_url(base_url, "base_url")
+        return OpenAILLMService(
+            api_key=api_key or "no-key-required",
+            base_url=f"{base_url.rstrip('/')}/v1",
+            settings=OpenAILLMSettings(model=model, temperature=0.1),
+        )
     else:
         raise HTTPException(status_code=400, detail=f"Invalid LLM provider {provider}")
 
@@ -776,5 +784,7 @@ def create_llm_service(user_config):
         kwargs["temperature"] = user_config.llm.temperature
     elif provider == ServiceProviders.SARVAM.value:
         kwargs["temperature"] = user_config.llm.temperature
+    elif provider == ServiceProviders.LITELLM.value:
+        kwargs["base_url"] = user_config.llm.base_url
 
     return create_llm_service_from_provider(provider, model, api_key, **kwargs)

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -623,15 +623,12 @@ def create_llm_service_from_provider(
             ),
         )
     elif provider == ServiceProviders.LITELLM.value:
-        base_url = base_url or "http://localhost:4000"
-        _validate_runtime_service_url(base_url, "base_url")
-        normalized = base_url.rstrip("/")
-        if not normalized.endswith("/v1"):
-            normalized = f"{normalized}/v1"
-        return OpenAILLMService(
-            api_key=api_key or "no-key-required",
-            base_url=normalized,
-            settings=OpenAILLMSettings(model=model, temperature=0.1),
+        from api.services.pipecat.litellm_llm import LiteLLMLLMService, LiteLLMSettings
+
+        return LiteLLMLLMService(
+            api_key=api_key,
+            api_base=base_url,
+            settings=LiteLLMSettings(model=model, temperature=0.1),
         )
     else:
         raise HTTPException(status_code=400, detail=f"Invalid LLM provider {provider}")

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -625,9 +625,12 @@ def create_llm_service_from_provider(
     elif provider == ServiceProviders.LITELLM.value:
         base_url = base_url or "http://localhost:4000"
         _validate_runtime_service_url(base_url, "base_url")
+        normalized = base_url.rstrip("/")
+        if not normalized.endswith("/v1"):
+            normalized = f"{normalized}/v1"
         return OpenAILLMService(
             api_key=api_key or "no-key-required",
-            base_url=f"{base_url.rstrip('/')}/v1",
+            base_url=normalized,
             settings=OpenAILLMSettings(model=model, temperature=0.1),
         )
     else:

--- a/api/tests/test_litellm_service_factory.py
+++ b/api/tests/test_litellm_service_factory.py
@@ -2,7 +2,6 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
-from fastapi import HTTPException
 
 from api.services.configuration.registry import (
     LiteLLMLLMConfiguration,
@@ -19,24 +18,25 @@ class TestLiteLLMLLMConfiguration:
         config = LiteLLMLLMConfiguration()
         assert config.provider == ServiceProviders.LITELLM
         assert config.model == "gpt-4.1"
-        assert config.base_url == "http://localhost:4000"
+        assert config.base_url is None
         assert config.api_key is None
 
     def test_custom_model(self):
         config = LiteLLMLLMConfiguration(model="claude-sonnet-4-20250514")
         assert config.model == "claude-sonnet-4-20250514"
 
-    def test_custom_base_url(self):
-        config = LiteLLMLLMConfiguration(base_url="https://my-proxy.example.com")
-        assert config.base_url == "https://my-proxy.example.com"
-
     def test_with_api_key(self):
         config = LiteLLMLLMConfiguration(api_key="sk-litellm-master-key")
         assert config.api_key == "sk-litellm-master-key"
 
-    def test_api_key_optional(self):
+    def test_with_base_url_for_proxy_mode(self):
+        config = LiteLLMLLMConfiguration(base_url="http://localhost:4000")
+        assert config.base_url == "http://localhost:4000"
+
+    def test_api_key_and_base_url_both_optional(self):
         config = LiteLLMLLMConfiguration()
         assert config.api_key is None
+        assert config.base_url is None
 
     def test_bedrock_model_format(self):
         config = LiteLLMLLMConfiguration(
@@ -50,9 +50,9 @@ class TestLiteLLMLLMConfiguration:
 
 
 class TestLiteLLMServiceFactory:
-    def test_create_litellm_service_default_base_url(self):
+    def test_create_litellm_service_uses_litellm_llm_service(self):
         with patch(
-            "api.services.pipecat.service_factory.OpenAILLMService"
+            "api.services.pipecat.litellm_llm.LiteLLMLLMService"
         ) as mock_service:
             create_llm_service_from_provider(
                 provider=ServiceProviders.LITELLM.value,
@@ -63,92 +63,36 @@ class TestLiteLLMServiceFactory:
         assert mock_service.call_count == 1
         kwargs = mock_service.call_args.kwargs
         assert kwargs["api_key"] == "sk-test"
-        assert kwargs["base_url"] == "http://localhost:4000/v1"
         assert kwargs["settings"].model == "gpt-4.1"
         assert kwargs["settings"].temperature == 0.1
 
-    def test_create_litellm_service_custom_base_url(self):
+    def test_create_litellm_service_no_api_key(self):
         with patch(
-            "api.services.pipecat.service_factory.OpenAILLMService"
+            "api.services.pipecat.litellm_llm.LiteLLMLLMService"
         ) as mock_service:
             create_llm_service_from_provider(
                 provider=ServiceProviders.LITELLM.value,
                 model="claude-sonnet-4-20250514",
-                api_key="sk-test",
-                base_url="https://my-proxy.example.com",
-            )
-
-        kwargs = mock_service.call_args.kwargs
-        assert kwargs["base_url"] == "https://my-proxy.example.com/v1"
-        assert kwargs["settings"].model == "claude-sonnet-4-20250514"
-
-    def test_create_litellm_service_base_url_already_has_v1(self):
-        with patch(
-            "api.services.pipecat.service_factory.OpenAILLMService"
-        ) as mock_service:
-            create_llm_service_from_provider(
-                provider=ServiceProviders.LITELLM.value,
-                model="gpt-4.1",
-                api_key="sk-test",
-                base_url="https://my-proxy.example.com/v1",
-            )
-
-        kwargs = mock_service.call_args.kwargs
-        assert kwargs["base_url"] == "https://my-proxy.example.com/v1"
-
-    def test_create_litellm_service_base_url_trailing_slash(self):
-        with patch(
-            "api.services.pipecat.service_factory.OpenAILLMService"
-        ) as mock_service:
-            create_llm_service_from_provider(
-                provider=ServiceProviders.LITELLM.value,
-                model="gpt-4.1",
-                api_key="sk-test",
-                base_url="http://localhost:4000/",
-            )
-
-        kwargs = mock_service.call_args.kwargs
-        assert kwargs["base_url"] == "http://localhost:4000/v1"
-
-    def test_create_litellm_service_base_url_trailing_slash_with_v1(self):
-        with patch(
-            "api.services.pipecat.service_factory.OpenAILLMService"
-        ) as mock_service:
-            create_llm_service_from_provider(
-                provider=ServiceProviders.LITELLM.value,
-                model="gpt-4.1",
-                api_key="sk-test",
-                base_url="http://localhost:4000/v1/",
-            )
-
-        kwargs = mock_service.call_args.kwargs
-        assert kwargs["base_url"] == "http://localhost:4000/v1"
-
-    def test_create_litellm_service_no_api_key_uses_placeholder(self):
-        with patch(
-            "api.services.pipecat.service_factory.OpenAILLMService"
-        ) as mock_service:
-            create_llm_service_from_provider(
-                provider=ServiceProviders.LITELLM.value,
-                model="gpt-4.1",
                 api_key=None,
             )
 
         kwargs = mock_service.call_args.kwargs
-        assert kwargs["api_key"] == "no-key-required"
+        assert kwargs["api_key"] is None
+        assert kwargs["settings"].model == "claude-sonnet-4-20250514"
 
-    def test_create_litellm_service_rejects_private_ip_in_saas_mode(self):
+    def test_create_litellm_service_with_base_url(self):
         with patch(
-            "api.utils.url_security.DEPLOYMENT_MODE", "saas"
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                create_llm_service_from_provider(
-                    provider=ServiceProviders.LITELLM.value,
-                    model="gpt-4.1",
-                    api_key="sk-test",
-                    base_url="http://169.254.169.254",
-                )
-            assert exc_info.value.status_code == 400
+            "api.services.pipecat.litellm_llm.LiteLLMLLMService"
+        ) as mock_service:
+            create_llm_service_from_provider(
+                provider=ServiceProviders.LITELLM.value,
+                model="gpt-4.1",
+                api_key="sk-proxy-key",
+                base_url="http://localhost:4000",
+            )
+
+        kwargs = mock_service.call_args.kwargs
+        assert kwargs["api_base"] == "http://localhost:4000"
 
 
 class TestLiteLLMCreateLLMService:
@@ -163,38 +107,36 @@ class TestLiteLLMCreateLLMService:
         )
 
         with patch(
-            "api.services.pipecat.service_factory.OpenAILLMService"
+            "api.services.pipecat.litellm_llm.LiteLLMLLMService"
         ) as mock_service:
             create_llm_service(user_config)
 
         kwargs = mock_service.call_args.kwargs
-        assert kwargs["base_url"] == "https://my-proxy.example.com/v1"
+        assert kwargs["api_base"] == "https://my-proxy.example.com"
         assert kwargs["api_key"] == "sk-test"
         assert kwargs["settings"].model == "gpt-4.1"
 
-    def test_create_llm_service_no_api_key(self):
+    def test_create_llm_service_no_api_key_no_base_url(self):
         user_config = SimpleNamespace(
             llm=SimpleNamespace(
                 provider=ServiceProviders.LITELLM.value,
-                model="claude-sonnet-4-20250514",
+                model="anthropic/claude-haiku-4-5-20251001",
                 api_key=None,
-                base_url="http://localhost:4000",
+                base_url=None,
             )
         )
 
         with patch(
-            "api.services.pipecat.service_factory.OpenAILLMService"
+            "api.services.pipecat.litellm_llm.LiteLLMLLMService"
         ) as mock_service:
             create_llm_service(user_config)
 
         kwargs = mock_service.call_args.kwargs
-        assert kwargs["api_key"] == "no-key-required"
+        assert kwargs["api_key"] is None
+        assert kwargs["api_base"] is None
 
 
 class TestLiteLLMConfigDiscriminatedUnion:
-    """Verify LiteLLM round-trips through the discriminated LLMConfig union
-    and UserConfiguration, which is the real config parsing path."""
-
     def test_litellm_parses_through_llm_config_union(self):
         from api.services.configuration.registry import LLMConfig
         from pydantic import TypeAdapter
@@ -211,7 +153,6 @@ class TestLiteLLMConfigDiscriminatedUnion:
         assert isinstance(config, LiteLLMLLMConfiguration)
         assert config.provider == ServiceProviders.LITELLM
         assert config.model == "claude-sonnet-4-20250514"
-        assert config.base_url == "https://my-proxy.example.com"
 
     def test_litellm_parses_through_user_configuration(self):
         from api.schemas.user_configuration import UserConfiguration
@@ -220,12 +161,12 @@ class TestLiteLLMConfigDiscriminatedUnion:
             llm={
                 "provider": "litellm",
                 "model": "gpt-4.1",
-                "base_url": "http://localhost:4000",
             }
         )
         assert isinstance(uc.llm, LiteLLMLLMConfiguration)
         assert uc.llm.model == "gpt-4.1"
         assert uc.llm.api_key is None
+        assert uc.llm.base_url is None
 
     def test_litellm_config_json_round_trip(self):
         config = LiteLLMLLMConfiguration(
@@ -237,7 +178,6 @@ class TestLiteLLMConfigDiscriminatedUnion:
         restored = LiteLLMLLMConfiguration(**data)
         assert restored.model == config.model
         assert restored.base_url == config.base_url
-        assert restored.api_key == config.api_key
         assert restored.provider == ServiceProviders.LITELLM
 
     def test_litellm_registered_in_llm_registry(self):
@@ -247,34 +187,14 @@ class TestLiteLLMConfigDiscriminatedUnion:
 
 
 class TestLiteLLMValidation:
-    def test_check_litellm_missing_base_url(self):
+    def test_litellm_validation_passes_without_api_key_or_base_url(self):
         from api.services.configuration.check_validity import (
             UserConfigurationValidator,
         )
 
         validator = UserConfigurationValidator()
-        service_config = SimpleNamespace(base_url=None)
-
-        with pytest.raises(ValueError, match="base_url is required"):
-            validator._check_litellm_api_key("litellm", service_config)
-
-    def test_check_litellm_empty_base_url(self):
-        from api.services.configuration.check_validity import (
-            UserConfigurationValidator,
+        result = validator._validate_service(
+            LiteLLMLLMConfiguration(model="gpt-4.1"),
+            "llm",
         )
-
-        validator = UserConfigurationValidator()
-        service_config = SimpleNamespace(base_url="")
-
-        with pytest.raises(ValueError, match="base_url is required"):
-            validator._check_litellm_api_key("litellm", service_config)
-
-    def test_check_litellm_valid_base_url(self):
-        from api.services.configuration.check_validity import (
-            UserConfigurationValidator,
-        )
-
-        validator = UserConfigurationValidator()
-        service_config = SimpleNamespace(base_url="http://localhost:4000")
-
-        assert validator._check_litellm_api_key("litellm", service_config) is True
+        assert result == []

--- a/api/tests/test_litellm_service_factory.py
+++ b/api/tests/test_litellm_service_factory.py
@@ -1,0 +1,225 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.services.configuration.registry import (
+    LiteLLMLLMConfiguration,
+    ServiceProviders,
+)
+from api.services.pipecat.service_factory import (
+    create_llm_service,
+    create_llm_service_from_provider,
+)
+
+
+class TestLiteLLMLLMConfiguration:
+    def test_default_values(self):
+        config = LiteLLMLLMConfiguration()
+        assert config.provider == ServiceProviders.LITELLM
+        assert config.model == "gpt-4.1"
+        assert config.base_url == "http://localhost:4000"
+        assert config.api_key is None
+
+    def test_custom_model(self):
+        config = LiteLLMLLMConfiguration(model="claude-sonnet-4-20250514")
+        assert config.model == "claude-sonnet-4-20250514"
+
+    def test_custom_base_url(self):
+        config = LiteLLMLLMConfiguration(base_url="https://my-proxy.example.com")
+        assert config.base_url == "https://my-proxy.example.com"
+
+    def test_with_api_key(self):
+        config = LiteLLMLLMConfiguration(api_key="sk-litellm-master-key")
+        assert config.api_key == "sk-litellm-master-key"
+
+    def test_api_key_optional(self):
+        config = LiteLLMLLMConfiguration()
+        assert config.api_key is None
+
+    def test_bedrock_model_format(self):
+        config = LiteLLMLLMConfiguration(
+            model="bedrock/anthropic.claude-sonnet-4-20250514-v1:0"
+        )
+        assert config.model == "bedrock/anthropic.claude-sonnet-4-20250514-v1:0"
+
+    def test_vertex_model_format(self):
+        config = LiteLLMLLMConfiguration(model="vertex_ai/gemini-2.5-flash")
+        assert config.model == "vertex_ai/gemini-2.5-flash"
+
+
+class TestLiteLLMServiceFactory:
+    def test_create_litellm_service_default_base_url(self):
+        with patch(
+            "api.services.pipecat.service_factory.OpenAILLMService"
+        ) as mock_service:
+            create_llm_service_from_provider(
+                provider=ServiceProviders.LITELLM.value,
+                model="gpt-4.1",
+                api_key="sk-test",
+            )
+
+        assert mock_service.call_count == 1
+        kwargs = mock_service.call_args.kwargs
+        assert kwargs["api_key"] == "sk-test"
+        assert kwargs["base_url"] == "http://localhost:4000/v1"
+        assert kwargs["settings"].model == "gpt-4.1"
+        assert kwargs["settings"].temperature == 0.1
+
+    def test_create_litellm_service_custom_base_url(self):
+        with patch(
+            "api.services.pipecat.service_factory.OpenAILLMService"
+        ) as mock_service:
+            create_llm_service_from_provider(
+                provider=ServiceProviders.LITELLM.value,
+                model="claude-sonnet-4-20250514",
+                api_key="sk-test",
+                base_url="https://my-proxy.example.com",
+            )
+
+        kwargs = mock_service.call_args.kwargs
+        assert kwargs["base_url"] == "https://my-proxy.example.com/v1"
+        assert kwargs["settings"].model == "claude-sonnet-4-20250514"
+
+    def test_create_litellm_service_base_url_already_has_v1(self):
+        with patch(
+            "api.services.pipecat.service_factory.OpenAILLMService"
+        ) as mock_service:
+            create_llm_service_from_provider(
+                provider=ServiceProviders.LITELLM.value,
+                model="gpt-4.1",
+                api_key="sk-test",
+                base_url="https://my-proxy.example.com/v1",
+            )
+
+        kwargs = mock_service.call_args.kwargs
+        assert kwargs["base_url"] == "https://my-proxy.example.com/v1"
+
+    def test_create_litellm_service_base_url_trailing_slash(self):
+        with patch(
+            "api.services.pipecat.service_factory.OpenAILLMService"
+        ) as mock_service:
+            create_llm_service_from_provider(
+                provider=ServiceProviders.LITELLM.value,
+                model="gpt-4.1",
+                api_key="sk-test",
+                base_url="http://localhost:4000/",
+            )
+
+        kwargs = mock_service.call_args.kwargs
+        assert kwargs["base_url"] == "http://localhost:4000/v1"
+
+    def test_create_litellm_service_base_url_trailing_slash_with_v1(self):
+        with patch(
+            "api.services.pipecat.service_factory.OpenAILLMService"
+        ) as mock_service:
+            create_llm_service_from_provider(
+                provider=ServiceProviders.LITELLM.value,
+                model="gpt-4.1",
+                api_key="sk-test",
+                base_url="http://localhost:4000/v1/",
+            )
+
+        kwargs = mock_service.call_args.kwargs
+        assert kwargs["base_url"] == "http://localhost:4000/v1"
+
+    def test_create_litellm_service_no_api_key_uses_placeholder(self):
+        with patch(
+            "api.services.pipecat.service_factory.OpenAILLMService"
+        ) as mock_service:
+            create_llm_service_from_provider(
+                provider=ServiceProviders.LITELLM.value,
+                model="gpt-4.1",
+                api_key=None,
+            )
+
+        kwargs = mock_service.call_args.kwargs
+        assert kwargs["api_key"] == "no-key-required"
+
+    def test_create_litellm_service_rejects_private_ip_in_saas_mode(self):
+        with patch(
+            "api.utils.url_security.DEPLOYMENT_MODE", "saas"
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                create_llm_service_from_provider(
+                    provider=ServiceProviders.LITELLM.value,
+                    model="gpt-4.1",
+                    api_key="sk-test",
+                    base_url="http://169.254.169.254",
+                )
+            assert exc_info.value.status_code == 400
+
+
+class TestLiteLLMCreateLLMService:
+    def test_create_llm_service_extracts_base_url(self):
+        user_config = SimpleNamespace(
+            llm=SimpleNamespace(
+                provider=ServiceProviders.LITELLM.value,
+                model="gpt-4.1",
+                api_key="sk-test",
+                base_url="https://my-proxy.example.com",
+            )
+        )
+
+        with patch(
+            "api.services.pipecat.service_factory.OpenAILLMService"
+        ) as mock_service:
+            create_llm_service(user_config)
+
+        kwargs = mock_service.call_args.kwargs
+        assert kwargs["base_url"] == "https://my-proxy.example.com/v1"
+        assert kwargs["api_key"] == "sk-test"
+        assert kwargs["settings"].model == "gpt-4.1"
+
+    def test_create_llm_service_no_api_key(self):
+        user_config = SimpleNamespace(
+            llm=SimpleNamespace(
+                provider=ServiceProviders.LITELLM.value,
+                model="claude-sonnet-4-20250514",
+                api_key=None,
+                base_url="http://localhost:4000",
+            )
+        )
+
+        with patch(
+            "api.services.pipecat.service_factory.OpenAILLMService"
+        ) as mock_service:
+            create_llm_service(user_config)
+
+        kwargs = mock_service.call_args.kwargs
+        assert kwargs["api_key"] == "no-key-required"
+
+
+class TestLiteLLMValidation:
+    def test_check_litellm_missing_base_url(self):
+        from api.services.configuration.check_validity import (
+            UserConfigurationValidator,
+        )
+
+        validator = UserConfigurationValidator()
+        service_config = SimpleNamespace(base_url=None)
+
+        with pytest.raises(ValueError, match="base_url is required"):
+            validator._check_litellm_api_key("litellm", service_config)
+
+    def test_check_litellm_empty_base_url(self):
+        from api.services.configuration.check_validity import (
+            UserConfigurationValidator,
+        )
+
+        validator = UserConfigurationValidator()
+        service_config = SimpleNamespace(base_url="")
+
+        with pytest.raises(ValueError, match="base_url is required"):
+            validator._check_litellm_api_key("litellm", service_config)
+
+    def test_check_litellm_valid_base_url(self):
+        from api.services.configuration.check_validity import (
+            UserConfigurationValidator,
+        )
+
+        validator = UserConfigurationValidator()
+        service_config = SimpleNamespace(base_url="http://localhost:4000")
+
+        assert validator._check_litellm_api_key("litellm", service_config) is True

--- a/api/tests/test_litellm_service_factory.py
+++ b/api/tests/test_litellm_service_factory.py
@@ -191,6 +191,61 @@ class TestLiteLLMCreateLLMService:
         assert kwargs["api_key"] == "no-key-required"
 
 
+class TestLiteLLMConfigDiscriminatedUnion:
+    """Verify LiteLLM round-trips through the discriminated LLMConfig union
+    and UserConfiguration, which is the real config parsing path."""
+
+    def test_litellm_parses_through_llm_config_union(self):
+        from api.services.configuration.registry import LLMConfig
+        from pydantic import TypeAdapter
+
+        adapter = TypeAdapter(LLMConfig)
+        config = adapter.validate_python(
+            {
+                "provider": "litellm",
+                "model": "claude-sonnet-4-20250514",
+                "base_url": "https://my-proxy.example.com",
+                "api_key": "sk-master",
+            }
+        )
+        assert isinstance(config, LiteLLMLLMConfiguration)
+        assert config.provider == ServiceProviders.LITELLM
+        assert config.model == "claude-sonnet-4-20250514"
+        assert config.base_url == "https://my-proxy.example.com"
+
+    def test_litellm_parses_through_user_configuration(self):
+        from api.schemas.user_configuration import UserConfiguration
+
+        uc = UserConfiguration(
+            llm={
+                "provider": "litellm",
+                "model": "gpt-4.1",
+                "base_url": "http://localhost:4000",
+            }
+        )
+        assert isinstance(uc.llm, LiteLLMLLMConfiguration)
+        assert uc.llm.model == "gpt-4.1"
+        assert uc.llm.api_key is None
+
+    def test_litellm_config_json_round_trip(self):
+        config = LiteLLMLLMConfiguration(
+            model="bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
+            base_url="https://proxy.corp.internal",
+            api_key="sk-virtual-key",
+        )
+        data = config.model_dump()
+        restored = LiteLLMLLMConfiguration(**data)
+        assert restored.model == config.model
+        assert restored.base_url == config.base_url
+        assert restored.api_key == config.api_key
+        assert restored.provider == ServiceProviders.LITELLM
+
+    def test_litellm_registered_in_llm_registry(self):
+        from api.services.configuration.registry import REGISTRY, ServiceType
+
+        assert ServiceProviders.LITELLM in REGISTRY[ServiceType.LLM]
+
+
 class TestLiteLLMValidation:
     def test_check_litellm_missing_base_url(self):
         from api.services.configuration.check_validity import (


### PR DESCRIPTION
  ## Summary

  Adds [LiteLLM](https://github.com/BerriAI/litellm) as a new LLM provider, giving Dograh users access to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex AI, Groq, Ollama, 
  Cohere, Mistral, Together, Fireworks, etc.) through the LiteLLM Python SDK.
                                                                                                                                                                                          
  Uses `litellm.acompletion()` directly with `drop_params=True`. Provider API keys are read from environment variables (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`).                      
  
  ## Changes                                                                                                                                                                              
                  
  - `api/services/pipecat/litellm_llm.py` -- new `LiteLLMLLMService` extending pipecat's `BaseOpenAILLMService`, overrides `get_chat_completions()` and `run_inference()` to call         
  `litellm.acompletion()` with `drop_params=True`
  - `api/services/configuration/registry.py` -- add `LITELLM` to `ServiceProviders` enum, `LiteLLMLLMConfiguration` with optional `base_url` and `api_key`, add to `LLMConfig` union      
  - `api/services/pipecat/service_factory.py` -- add factory branch creating `LiteLLMLLMService`
  - `api/services/configuration/check_validity.py` -- skip key validation for LiteLLM (provider keys come from env vars)                                                                  
  - `api/tests/test_litellm_service_factory.py` -- 17 unit tests                                                                                                                          
                                                                                                                                                                                          
  New dependency: `litellm`                                                                                                                                                               
                  
  ## Tests

  17 passed in 4.85s

  Covers: config defaults, model format variants (bedrock/..., vertex_ai/..., anthropic/...), factory service creation, optional api_key/base_url, discriminated union resolution through
  `LLMConfig` and `UserConfiguration`, JSON round-trip, registry entry, validation bypass.                                                                                                
  
  All 68 existing service factory/config tests pass (zero regressions).                                                                                                                   
                  
 ## Example usage                                                                                                                                                                        
                                                                                                                                                                                          
  In Dograh, select **LiteLLM** as your LLM provider and set the model using LiteLLM's model name format:                                                                                 
   
  - `gpt-4.1` -- OpenAI (reads `OPENAI_API_KEY` from env)                                                                                                                                 
  - `anthropic/claude-sonnet-4-20250514` -- Anthropic (reads `ANTHROPIC_API_KEY`)
  - `bedrock/anthropic.claude-sonnet-4-20250514-v1:0` -- AWS Bedrock (reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)                                                                 
  - `vertex_ai/gemini-2.5-flash` -- Google Vertex (reads `GOOGLE_APPLICATION_CREDENTIALS`)                                                                                                
  
  ```python                                                                                                                                                                               
  import litellm  
  import os                                                                                                                                                                               
                  
  os.environ["ANTHROPIC_API_KEY"] = "sk-ant-..."

  response = await litellm.acompletion(                                                                                                                                                   
      model="anthropic/claude-sonnet-4-20250514",
      messages=[{"role": "user", "content": "Hello from Dograh!"}],                                                                                                                       
      stream=True,
      drop_params=True,                                                                                                                                                                   
  )
                                                                                                                                                                                          
  async for chunk in response:
      print(chunk.choices[0].delta.content or "", end="")
  ```                                                                                   
  
  ## Risk / Compatibility                                                                                                                                                                 
                  
  - Additive only -- no existing providers or services modified                                                                                                                           
  - Reuses pipecat's `BaseOpenAILLMService` streaming/function-call/error-handling logic; only the completion call path is overridden
  - `drop_params=True` ensures unsupported params are silently dropped per provider
