### PR TITLE
fix(devcontainer): expose UI/API ports for host access

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -30,8 +30,8 @@ services:
       - dograh-ui-node_modules:/workspaces/dograh/ui/node_modules
       - dograh-ts-validator-node_modules:/workspaces/dograh/api/mcp_server/ts_validator/node_modules
     ports:
-      - "3000:3000"
-      - "8000:8000"
+      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:8000:8000"
 volumes:
   dograh-venv:
   dograh-ui-node_modules:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -29,7 +29,9 @@ services:
       - dograh-venv:/workspaces/dograh/venv
       - dograh-ui-node_modules:/workspaces/dograh/ui/node_modules
       - dograh-ts-validator-node_modules:/workspaces/dograh/api/mcp_server/ts_validator/node_modules
-
+    ports:
+      - "3000:3000"
+      - "8000:8000"
 volumes:
   dograh-venv:
   dograh-ui-node_modules:


### PR DESCRIPTION
## Summary

Fixes host access to the Dograh UI and API in the devcontainer. Services bind correctly inside the container, but `localhost:3000` / `:8000` on the Mac were unreachable without manual port forwarding.

Fixes #404

## Changes

- Publish ports `3000` and `8000` on the `workspace` service in `.devcontainer/docker-compose.yml`
- (Optional) Document host access in contributor setup docs

## Why

Setup docs tell contributors to open `http://localhost:3000`, but `devcontainer.json` only auto-forwards infra ports and sets `onAutoForward: ignore` for 3000/8000. See #1234.

## Test plan

- [x] Rebuild devcontainer after compose change
- [x] `bash scripts/start_services_dev.sh` succeeds (migrations + API up)
- [x] `cd ui && npm run dev -- --hostname 0.0.0.0`
- [x] Host: `curl http://localhost:8000/api/v1/health` returns OK
- [x] Host browser: `http://localhost:3000` loads