### PR TITLE
fix(qa): tolerate non-dict JSON from QA LLM instead of crashing

### DIFF
--- a/api/services/workflow/qa/analysis.py
+++ b/api/services/workflow/qa/analysis.py
@@ -210,6 +210,11 @@ async def run_per_node_qa_analysis(
             # top-level JSON array); coerce non-dict results so the .get()
             # lookups below don't raise AttributeError.
             if not isinstance(parsed, dict):
+                logger.warning(
+                    f"QA LLM returned non-object JSON for node '{node_name}' "
+                    f"on run {workflow_run_id}; got {type(parsed).__name__}, "
+                    "using empty QA result"
+                )
                 parsed = {}
             node_result["tags"] = parsed.get("tags", [])
             node_result["summary"] = parsed.get("summary", "")
@@ -305,6 +310,11 @@ async def _run_whole_call_qa_analysis(
         # top-level JSON array); coerce non-dict results so the .get()
         # lookups below don't raise AttributeError.
         if not isinstance(parsed, dict):
+            logger.warning(
+                f"QA LLM returned non-object JSON for whole-call QA on run "
+                f"{workflow_run_id}; got {type(parsed).__name__}, using empty "
+                "QA result"
+            )
             parsed = {}
         node_result["tags"] = parsed.get("tags", [])
         node_result["summary"] = parsed.get("summary", "")

--- a/api/services/workflow/qa/analysis.py
+++ b/api/services/workflow/qa/analysis.py
@@ -206,6 +206,11 @@ async def run_per_node_qa_analysis(
         }
         try:
             parsed = parse_llm_json(raw_response)
+            # parse_llm_json can return a list (e.g. when the model emits a
+            # top-level JSON array); coerce non-dict results so the .get()
+            # lookups below don't raise AttributeError.
+            if not isinstance(parsed, dict):
+                parsed = {}
             node_result["tags"] = parsed.get("tags", [])
             node_result["summary"] = parsed.get("summary", "")
             node_result["score"] = parsed.get("call_quality_score")
@@ -296,6 +301,11 @@ async def _run_whole_call_qa_analysis(
     }
     try:
         parsed = parse_llm_json(raw_response)
+        # parse_llm_json can return a list (e.g. when the model emits a
+        # top-level JSON array); coerce non-dict results so the .get()
+        # lookups below don't raise AttributeError.
+        if not isinstance(parsed, dict):
+            parsed = {}
         node_result["tags"] = parsed.get("tags", [])
         node_result["summary"] = parsed.get("summary", "")
         node_result["score"] = parsed.get("call_quality_score")

--- a/api/tests/test_qa_analysis_non_dict_response.py
+++ b/api/tests/test_qa_analysis_non_dict_response.py
@@ -1,0 +1,64 @@
+"""Regression test for QA analysis when the LLM returns a non-dict JSON value.
+
+``parse_llm_json`` is explicitly designed to return a list when the model emits
+a top-level JSON array (see ``test_json_parser.py``). The QA analyzers then call
+``parsed.get(...)`` on the result. For a list that raises ``AttributeError``,
+which is NOT caught by the surrounding ``except (json.JSONDecodeError, ValueError)``
+— so a stray array response crashed the whole QA run instead of degrading to
+empty results.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.services.workflow.qa import analysis as qa_analysis
+
+
+@pytest.mark.asyncio
+async def test_whole_call_qa_tolerates_array_llm_response():
+    """A top-level JSON array from the QA LLM degrades to empty results."""
+    qa_data = SimpleNamespace(qa_system_prompt="Summarize: {transcript}")
+    workflow_run = SimpleNamespace(
+        logs={
+            "realtime_feedback_events": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi there"},
+            ]
+        },
+        usage_info={"call_duration_seconds": 12},
+    )
+
+    with (
+        patch.object(
+            qa_analysis, "build_conversation_structure", return_value=[{"x": 1}]
+        ),
+        patch.object(qa_analysis, "format_transcript", return_value="user: hello"),
+        patch.object(qa_analysis, "compute_call_metrics", return_value={}),
+        patch.object(
+            qa_analysis,
+            "resolve_llm_config",
+            new=AsyncMock(return_value=("openai", "gpt-4o", "sk-test", {})),
+        ),
+        patch.object(qa_analysis, "create_llm_service_from_provider", return_value=object()),
+        patch.object(
+            qa_analysis,
+            "_run_llm_inference",
+            new=AsyncMock(return_value='["tag1", "tag2"]'),
+        ),
+        patch.object(
+            qa_analysis, "setup_langfuse_parent_context", return_value=None
+        ),
+        patch.object(qa_analysis, "add_qa_span_to_trace", return_value=None),
+    ):
+        # Before the fix this raised AttributeError: 'list' object has no
+        # attribute 'get'.
+        result = await qa_analysis._run_whole_call_qa_analysis(
+            qa_data, workflow_run, workflow_run_id=99
+        )
+
+    node_result = result["node_results"]["whole_call"]
+    assert node_result["tags"] == []
+    assert node_result["summary"] == ""
+    assert node_result["score"] is None

--- a/api/tests/test_qa_analysis_non_dict_response.py
+++ b/api/tests/test_qa_analysis_non_dict_response.py
@@ -9,7 +9,7 @@ empty results.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -29,6 +29,7 @@ async def test_whole_call_qa_tolerates_array_llm_response():
         },
         usage_info={"call_duration_seconds": 12},
     )
+    warning_mock = Mock()
 
     with (
         patch.object(
@@ -51,6 +52,7 @@ async def test_whole_call_qa_tolerates_array_llm_response():
             qa_analysis, "setup_langfuse_parent_context", return_value=None
         ),
         patch.object(qa_analysis, "add_qa_span_to_trace", return_value=None),
+        patch.object(qa_analysis.logger, "warning", warning_mock),
     ):
         # Before the fix this raised AttributeError: 'list' object has no
         # attribute 'get'.
@@ -62,3 +64,9 @@ async def test_whole_call_qa_tolerates_array_llm_response():
     assert node_result["tags"] == []
     assert node_result["summary"] == ""
     assert node_result["score"] is None
+    warning_mock.assert_called_once()
+    warning_message = warning_mock.call_args.args[0]
+    assert "non-object JSON" in warning_message
+    assert "run 99" in warning_message
+    assert "list" in warning_message
+    assert "tag1" not in warning_message


### PR DESCRIPTION
## Bug

`parse_llm_json` (`api/services/gen_ai/json_parser.py`) is **explicitly designed to return a list** when the model emits a top-level JSON array — it has a dedicated unit test for `"[1, 2, 3]"`, and `_extract_json_array` is one of its parse strategies.

The QA analyzers in `api/services/workflow/qa/analysis.py` (both `_run_qa_analysis` per-node and the `_run_whole_call_qa_analysis` fallback) call `.get()` directly on the result:

```python
try:
    parsed = parse_llm_json(raw_response)
    node_result["tags"] = parsed.get("tags", [])      # AttributeError if parsed is a list
    node_result["summary"] = parsed.get("summary", "")
    ...
except (json.JSONDecodeError, ValueError):
    ...
```

When `parsed` is a list, `parsed.get(...)` raises `AttributeError`, which is **not** caught by the surrounding `except (json.JSONDecodeError, ValueError)`. So a single stray array response from the QA model crashes the entire QA analysis run instead of degrading to empty results.

Notably, the live variable-extraction path already guards this exact case (`api/services/workflow/pipecat_engine.py`: `if not isinstance(extracted_data, dict): ... skip`), so this is an inconsistency — the same defensive check is present in one consumer of LLM-parsed JSON but missing in the QA consumers.

## Reproduce

```python
from api.services.gen_ai.json_parser import parse_llm_json
import json

raw_response = '["tag1", "tag2"]'   # model returned a top-level array
node_result = {}
try:
    parsed = parse_llm_json(raw_response)
    node_result["tags"] = parsed.get("tags", [])     # boom
except (json.JSONDecodeError, ValueError):
    node_result["tags"] = []
# AttributeError: 'list' object has no attribute 'get'
```

## Fix

Mirror the existing engine guard in both QA call sites: coerce a non-dict parse result to `{}` so the `.get()` lookups produce empty defaults instead of crashing.

```python
parsed = parse_llm_json(raw_response)
if not isinstance(parsed, dict):
    parsed = {}
```

## Regression test

`api/tests/test_qa_analysis_non_dict_response.py` drives `_run_whole_call_qa_analysis` with an array LLM response (mocking the LLM seams) and asserts empty results (`tags == []`, `summary == ""`, `score is None`) rather than an exception. The core parse-block behavior was verified directly: it raises `AttributeError` on the old code and degrades to empty defaults on the new code, while the normal dict path still maps correctly.
