### PR TITLE
fix(workflow): detect duplicate trigger paths when first node has no id

### DIFF
--- a/api/services/workflow/trigger_paths.py
+++ b/api/services/workflow/trigger_paths.py
@@ -127,8 +127,7 @@ def validate_trigger_paths(
                 )
             )
 
-        first_node_id = seen_paths.get(trigger_path)
-        if first_node_id is None:
+        if trigger_path not in seen_paths:
             seen_paths[trigger_path] = node_id
         else:
             issues.append(

--- a/api/tests/test_trigger_path_validation.py
+++ b/api/tests/test_trigger_path_validation.py
@@ -54,3 +54,37 @@ def test_validate_trigger_paths_rejects_long_and_duplicate_paths():
         in messages
     )
     assert "Trigger path is duplicated in this workflow." in messages
+
+
+def test_validate_trigger_paths_detects_duplicate_when_first_node_has_no_id():
+    """A duplicate trigger path must be flagged even when the first node sharing
+    that path has no ``id`` (``node.get("id")`` is None).
+
+    Regression: the duplicate check previously used ``seen_paths.get(path)`` and
+    treated a ``None`` result as "not seen yet", so a first node with a missing
+    id (stored as None) made every later node with the same path slip through
+    undetected.
+    """
+    workflow_definition = {
+        "nodes": [
+            # No "id" key -> node_id resolves to None.
+            {"type": "trigger", "data": {"trigger_path": "sales_agent"}},
+            {
+                "id": "trigger-2",
+                "type": "trigger",
+                "data": {"trigger_path": "sales_agent"},
+            },
+        ],
+        "edges": [],
+    }
+
+    issues = validate_trigger_paths(workflow_definition)
+    messages = [issue.message for issue in issues]
+
+    assert "Trigger path is duplicated in this workflow." in messages
+    duplicate_issue = next(
+        issue
+        for issue in issues
+        if issue.message == "Trigger path is duplicated in this workflow."
+    )
+    assert duplicate_issue.node_id == "trigger-2"


### PR DESCRIPTION
## Bug

`validate_trigger_paths` (`api/services/workflow/trigger_paths.py`) detects duplicate trigger paths so two trigger nodes can't claim the same inbound URL segment. The duplicate check used `None` both as the "not seen yet" sentinel **and** as a legitimately stored value:

```python
seen_paths: dict[str, str | None] = {}
...
node_id = node.get("id")          # None when a node has no "id"
...
first_node_id = seen_paths.get(trigger_path)   # None means "unseen" OR "first node_id was None"
if first_node_id is None:
    seen_paths[trigger_path] = node_id          # stores None
else:
    issues.append(... "duplicated" ...)
```

If the first trigger node sharing a path has no `id` (so `node.get("id")` is `None`), it's stored as `None`. When a later node with the **same** path arrives, `seen_paths.get(path)` returns `None`, the code treats it as "not seen yet", and the duplicate is **silently accepted**. `validate_trigger_paths` runs on raw workflow-definition dicts "before they reach persistence/runtime", so a malformed/partial definition can push duplicate trigger paths past validation.

## Reproduce

```python
from api.services.workflow.trigger_paths import validate_trigger_paths

wf = {"nodes": [
    {"type": "trigger", "data": {"trigger_path": "sales"}},               # no id -> node_id None
    {"id": "t2", "type": "trigger", "data": {"trigger_path": "sales"}},   # duplicate
], "edges": []}

print([i.message for i in validate_trigger_paths(wf)])
# []  -> duplicate NOT detected

# Control: give the first node an id and the duplicate IS detected.
```

## Fix

Use a membership test so "first occurrence" and "node_id happens to be None" are no longer conflated:

```python
if trigger_path not in seen_paths:
    seen_paths[trigger_path] = node_id
else:
    issues.append(... "duplicated" ...)
```

Behavior is unchanged for nodes that have ids.

## Regression test

Added `test_validate_trigger_paths_detects_duplicate_when_first_node_has_no_id` to `api/tests/test_trigger_path_validation.py`. **Verified it fails (AssertionError) on the original code and passes after the fix.** The two existing trigger-path tests still pass, and I additionally checked: unique paths produce no false positive, and a triple-duplicate correctly flags both repeats (node ids `t2`, `t3`).
