### PR TITLE
Feature: enable variables in endpoints

### DIFF
--- a/api/schemas/tool.py
+++ b/api/schemas/tool.py
@@ -147,7 +147,6 @@ class HttpApiConfig(BaseModel):
         description="When to run variable extraction relative to the tool call (before, after, or both)",
     )
 
-
     @field_validator("method", mode="before")
     @classmethod
     def validate_method(cls, v: Any) -> str:

--- a/api/schemas/tool.py
+++ b/api/schemas/tool.py
@@ -142,6 +142,12 @@ class HttpApiConfig(BaseModel):
         default=None, description="Recording ID for an audio custom message."
     )
 
+    variable_extraction_timing: Literal["before", "after", "both"] = Field(
+        default="before",
+        description="When to run variable extraction relative to the tool call (before, after, or both)",
+    )
+
+
     @field_validator("method", mode="before")
     @classmethod
     def validate_method(cls, v: Any) -> str:

--- a/api/services/workflow/pipecat_engine_custom_tools.py
+++ b/api/services/workflow/pipecat_engine_custom_tools.py
@@ -378,6 +378,14 @@ class CustomToolManager:
                         )
                     )
 
+                # Determine when to run variable extraction relative to the tool call
+                extraction_timing = config.get("variable_extraction_timing", "before")
+
+                if extraction_timing in ("before", "both"):
+                    await self._engine._perform_variable_extraction_if_needed(
+                        self._engine._current_node, run_in_background=False
+                    )
+
                 result = await execute_http_tool(
                     tool=tool,
                     arguments=function_call_params.arguments,
@@ -385,6 +393,11 @@ class CustomToolManager:
                     gathered_context_vars=self._engine._gathered_context,
                     organization_id=await self.get_organization_id(),
                 )
+
+                if extraction_timing in ("after", "both"):
+                    await self._engine._perform_variable_extraction_if_needed(
+                        self._engine._current_node, run_in_background=False
+                    )
 
                 await function_call_params.result_callback(result)
 

--- a/api/services/workflow/tools/custom_tool.py
+++ b/api/services/workflow/tools/custom_tool.py
@@ -231,6 +231,17 @@ async def execute_http_tool(
     method = config.get("method", "POST").upper()
     url = config.get("url", "")
 
+    # Build render context for template variable substitution (same as preset params)
+    initial_context = dict(call_context_vars or {})
+    render_context: Dict[str, Any] = {
+        **initial_context,
+        "initial_context": initial_context,
+        "gathered_context": dict(gathered_context_vars or {}),
+    }
+
+    # Apply template rendering to URL (supports {{variable}} in path)
+    url = render_template(url, render_context)
+
     # Get headers from config
     headers = dict(config.get("headers", {}) or {})
 

--- a/api/tests/test_custom_tools.py
+++ b/api/tests/test_custom_tools.py
@@ -730,6 +730,116 @@ class TestExecuteHttpTool:
                 # Verify credential lookup was NOT called
                 mock_db.get_credential_by_uuid.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_url_with_initial_context_variable(self):
+        """Test that {{{{}}}} in URL path is resolved from initial_context."""
+        tool = MockToolModel(
+            tool_uuid="test-uuid-url-var",
+            name="Dynamic URL",
+            description="API with URL template",
+            category="http_api",
+            definition={
+                "schema_version": 1,
+                "type": "http_api",
+                "config": {
+                    "method": "GET",
+                    "url": "https://api.example.com/{{initial_context.resource}}/details",
+                    "timeout_ms": 5000,
+                },
+            },
+        )
+
+        with patch(
+            "api.services.workflow.tools.custom_tool.httpx.AsyncClient"
+        ) as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"id": 1}
+            mock_client.request.return_value = mock_response
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            await execute_http_tool(
+                tool,
+                {},
+                call_context_vars={"resource": "orders"},
+            )
+
+            call_kwargs = mock_client.request.call_args.kwargs
+            assert call_kwargs["url"] == "https://api.example.com/orders/details"
+
+    @pytest.mark.asyncio
+    async def test_url_with_gathered_context_variable(self):
+        """Test that {{{{}}}} in URL path is resolved from gathered_context."""
+        tool = MockToolModel(
+            tool_uuid="test-uuid-url-gathered",
+            name="Dynamic URL Gathered",
+            description="API with URL template from gathered context",
+            category="http_api",
+            definition={
+                "schema_version": 1,
+                "type": "http_api",
+                "config": {
+                    "method": "GET",
+                    "url": "https://api.example.com/customers/{{gathered_context.customer_id}}/profile",
+                    "timeout_ms": 5000,
+                },
+            },
+        )
+
+        with patch(
+            "api.services.workflow.tools.custom_tool.httpx.AsyncClient"
+        ) as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"name": "John"}
+            mock_client.request.return_value = mock_response
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            await execute_http_tool(
+                tool,
+                {},
+                gathered_context_vars={"customer_id": "42"},
+            )
+
+            call_kwargs = mock_client.request.call_args.kwargs
+            assert call_kwargs["url"] == "https://api.example.com/customers/42/profile"
+
+    @pytest.mark.asyncio
+    async def test_url_without_template_variables_unchanged(self):
+        """Test that URLs without template variables are passed through unchanged."""
+        tool = MockToolModel(
+            tool_uuid="test-uuid-no-var",
+            name="Static URL",
+            description="API with static URL",
+            category="http_api",
+            definition={
+                "schema_version": 1,
+                "type": "http_api",
+                "config": {
+                    "method": "GET",
+                    "url": "https://api.example.com/static/endpoint",
+                    "timeout_ms": 5000,
+                },
+            },
+        )
+
+        with patch(
+            "api.services.workflow.tools.custom_tool.httpx.AsyncClient"
+        ) as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {}
+            mock_client.request.return_value = mock_response
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            await execute_http_tool(tool, {})
+
+            call_kwargs = mock_client.request.call_args.kwargs
+            assert call_kwargs["url"] == "https://api.example.com/static/endpoint"
+
 
 class TestCoerceParameterValue:
     """Tests for _coerce_parameter_value function."""

--- a/api/tests/test_custom_tools.py
+++ b/api/tests/test_custom_tools.py
@@ -1201,6 +1201,9 @@ class TestCustomToolManagerUnit:
             mock_engine
         )
         mock_engine.llm = mock_llm
+        mock_engine._perform_variable_extraction_if_needed = AsyncMock()
+        mock_engine._current_node = None
+        mock_engine._gathered_context = {}
 
         manager = CustomToolManager(mock_engine)
 

--- a/ui/src/app/tools/[toolUuid]/components/HttpApiToolConfig.tsx
+++ b/ui/src/app/tools/[toolUuid]/components/HttpApiToolConfig.tsx
@@ -141,6 +141,9 @@ export function HttpApiToolConfig({
 
                         <div className="grid gap-2">
                             <Label>Endpoint URL</Label>
+                            <Label className="text-xs text-muted-foreground">
+                                Supports {`{{variable}}`} syntax using initial and gathered context variables in the URL path
+                            </Label>
                             <UrlInput
                                 value={url}
                                 onChange={onUrlChange}

--- a/ui/src/app/tools/[toolUuid]/components/HttpApiToolConfig.tsx
+++ b/ui/src/app/tools/[toolUuid]/components/HttpApiToolConfig.tsx
@@ -234,7 +234,7 @@ export function HttpApiToolConfig({
                                         <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
                                         <span>This text is spoken as-is. For multilingual workflows, choose your phrasing carefully.</span>
                                     </div>
-                                    
+
                                     <Textarea
                                         value={customMessage}
                                         onChange={(e) => onCustomMessageChange(e.target.value)}

--- a/ui/src/app/tools/[toolUuid]/components/HttpApiToolConfig.tsx
+++ b/ui/src/app/tools/[toolUuid]/components/HttpApiToolConfig.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { AlertCircle, Variable } from "lucide-react";
+
 import type { RecordingResponseSchema } from "@/client/types.gen";
 import { StaticTextWarning, TextOrAudioInput } from "@/components/flow/TextOrAudioInput";
 import {
@@ -17,6 +19,7 @@ import {
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 
@@ -45,6 +48,8 @@ export interface HttpApiToolConfigProps {
     onCustomMessageTypeChange: (type: 'text' | 'audio') => void;
     customMessageRecordingId: string;
     onCustomMessageRecordingIdChange: (id: string) => void;
+    variableExtractionTiming: 'before' | 'after' | 'both';
+    onVariableExtractionTimingChange: (timing: 'before' | 'after' | 'both') => void;
     recordings?: RecordingResponseSchema[];
 }
 
@@ -73,6 +78,8 @@ export function HttpApiToolConfig({
     onCustomMessageTypeChange,
     customMessageRecordingId,
     onCustomMessageRecordingIdChange,
+    variableExtractionTiming,
+    onVariableExtractionTimingChange,
     recordings = [],
 }: HttpApiToolConfigProps) {
     return (
@@ -152,6 +159,63 @@ export function HttpApiToolConfig({
                             />
                         </div>
 
+                        <div className="grid gap-3 pt-4 border-t">
+                            <div className="flex items-center gap-2">
+                                <Variable className="h-4 w-4" />
+                                <Label>Variable Extraction Timing</Label>
+                            </div>
+                            <Label className="text-xs text-muted-foreground">
+                                Control when conversation variables are extracted for use in tool parameters
+                            </Label>
+                            <RadioGroup
+                                value={variableExtractionTiming}
+                                onValueChange={(v) => onVariableExtractionTimingChange(v as 'before' | 'after' | 'both')}
+                            >
+                                <label
+                                    htmlFor="extract-before"
+                                    className={`flex items-start gap-3 p-3 border rounded-lg cursor-pointer transition-colors ${
+                                        variableExtractionTiming === 'before' ? 'border-primary bg-primary/5' : 'hover:bg-muted/50'
+                                    }`}
+                                >
+                                    <RadioGroupItem value="before" id="extract-before" className="mt-0.5" />
+                                    <div>
+                                        <p className="font-medium text-sm">Before tool call</p>
+                                        <p className="text-xs text-muted-foreground">
+                                            Extract variables from the conversation before the HTTP request. Use when URL or preset parameters depend on gathered context.
+                                        </p>
+                                    </div>
+                                </label>
+                                <label
+                                    htmlFor="extract-after"
+                                    className={`flex items-start gap-3 p-3 border rounded-lg cursor-pointer transition-colors ${
+                                        variableExtractionTiming === 'after' ? 'border-primary bg-primary/5' : 'hover:bg-muted/50'
+                                    }`}
+                                >
+                                    <RadioGroupItem value="after" id="extract-after" className="mt-0.5" />
+                                    <div>
+                                        <p className="font-medium text-sm">After tool call</p>
+                                        <p className="text-xs text-muted-foreground">
+                                            Extract variables after the HTTP response returns. Use when downstream nodes need data derived from the response.
+                                        </p>
+                                    </div>
+                                </label>
+                                <label
+                                    htmlFor="extract-both"
+                                    className={`flex items-start gap-3 p-3 border rounded-lg cursor-pointer transition-colors ${
+                                        variableExtractionTiming === 'both' ? 'border-primary bg-primary/5' : 'hover:bg-muted/50'
+                                    }`}
+                                >
+                                    <RadioGroupItem value="both" id="extract-both" className="mt-0.5" />
+                                    <div>
+                                        <p className="font-medium text-sm">Both</p>
+                                        <p className="text-xs text-muted-foreground">
+                                            Extract before and after the tool call. Ensures parameters use the latest context and the response is captured for downstream use.
+                                        </p>
+                                    </div>
+                                </label>
+                            </RadioGroup>
+                        </div>
+
                         <div className="grid gap-2 pt-4 border-t">
                             <Label>Custom Message</Label>
                             <Label className="text-xs text-muted-foreground">
@@ -166,6 +230,11 @@ export function HttpApiToolConfig({
                             >
                                 <>
                                     <StaticTextWarning />
+                                    <div className="flex items-start gap-2 rounded-md bg-amber-50 p-2 text-xs text-amber-700 border border-amber-200">
+                                        <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                                        <span>This text is spoken as-is. For multilingual workflows, choose your phrasing carefully.</span>
+                                    </div>
+                                    
                                     <Textarea
                                         value={customMessage}
                                         onChange={(e) => onCustomMessageChange(e.target.value)}

--- a/ui/src/app/tools/[toolUuid]/page.tsx
+++ b/ui/src/app/tools/[toolUuid]/page.tsx
@@ -117,6 +117,7 @@ export default function ToolDetailPage() {
     // HTTP API form state - custom message type
     const [customMessageType, setCustomMessageType] = useState<'text' | 'audio'>('text');
     const [customMessageRecordingId, setCustomMessageRecordingId] = useState("");
+    const [variableExtractionTiming, setVariableExtractionTiming] = useState<'before' | 'after' | 'both'>('before');
 
     // MCP form state
     const [mcpUrl, setMcpUrl] = useState("");
@@ -225,6 +226,9 @@ export default function ToolDetailPage() {
                 setCustomMessage(config.customMessage || "");
                 setCustomMessageType(config.customMessageType || "text");
                 setCustomMessageRecordingId(config.customMessageRecordingId || "");
+                setVariableExtractionTiming(
+                    (config.variable_extraction_timing as 'before' | 'after' | 'both') || 'before'
+                );
 
                 // Convert headers object to array
                 if (config.headers) {
@@ -437,6 +441,7 @@ export default function ToolDetailPage() {
                             customMessage: customMessageType === 'text' ? (customMessage || undefined) : undefined,
                             customMessageType,
                             customMessageRecordingId: customMessageType === 'audio' ? (customMessageRecordingId || undefined) : undefined,
+                            variable_extraction_timing: variableExtractionTiming,
                         },
                     },
                 };
@@ -762,6 +767,8 @@ const data = await response.json();`;
                             onCustomMessageTypeChange={setCustomMessageType}
                             customMessageRecordingId={customMessageRecordingId}
                             onCustomMessageRecordingIdChange={setCustomMessageRecordingId}
+                            variableExtractionTiming={variableExtractionTiming}
+                            onVariableExtractionTimingChange={setVariableExtractionTiming}
                             recordings={recordings}
                         />
                     )}

--- a/ui/src/client/types.gen.ts
+++ b/ui/src/client/types.gen.ts
@@ -1894,6 +1894,12 @@ export type HttpApiConfig = {
      * Recording ID for an audio custom message.
      */
     customMessageRecordingId?: string | null;
+    /**
+     * VariableExtractionTiming
+     *
+     * When to run variable extraction relative to the tool call (before, after, or both)
+     */
+    variable_extraction_timing?: 'before' | 'after' | 'both' | null;
 };
 
 /**

--- a/ui/src/components/http/url-input.tsx
+++ b/ui/src/components/http/url-input.tsx
@@ -19,11 +19,29 @@ export interface UrlValidationResult {
     error?: string;
 }
 
+const DOMAIN_REGEX = /^https?:\/\/([^\/]+)/;
+
+function domainContainsTemplateVar(domain: string): boolean {
+    return domain.includes("{{") || domain.includes("}}");
+}
+
 export function validateUrl(url: string): UrlValidationResult {
     const trimmedUrl = url.trim();
 
     if (!trimmedUrl) {
         return { valid: false, error: "URL is required" };
+    }
+
+    // If the URL contains template variables, validate domain separately
+    if (trimmedUrl.includes("{{")) {
+        const domainMatch = trimmedUrl.match(DOMAIN_REGEX);
+        if (!domainMatch || domainContainsTemplateVar(domainMatch[1])) {
+            return {
+                valid: false,
+                error: "Invalid URL format. Template variables are only allowed in the URL path.",
+            };
+        }
+        return { valid: true };
     }
 
     if (!URL_REGEX.test(trimmedUrl)) {


### PR DESCRIPTION
## Summary

Two feature additions for HTTP API tools that make tool parameters
aware of runtime conversation context.

---

### 1. `{{variable}}` substitution in Endpoint URL

The endpoint URL is now rendered through `render_template()` at
execution time, using the same context as preset parameters
(`initial_context` + `gathered_context`).

- `https://api.example.com/{{gathered_context.user_id}}/profile` — resolved at runtime
- `https://{{subdomain}}.example.com/api` — rejected by frontend validation (domain vars not allowed)
- `https://api.example.com/static/path` — unchanged behavior

### 2. Variable Extraction Timing option

New `before` / `after` / `both` setting on HTTP tools that controls
when conversation variable extraction runs:

| Option | Behavior | Use case |
|---|---|---|
| **Before** (default) | Extract before the HTTP request | URL/preset params depend on gathered context |
| **After** | Extract after the HTTP response | Downstream nodes need data derived from the response |
| **Both** | Extract at both points | Maximize context freshness |

Extraction only runs when the node has `extraction_enabled` and
`extraction_variables` configured (no-op otherwise).

### Files changed (6)

| File | Change |
|---|---|
| `api/services/workflow/tools/custom_tool.py` | Render URL via `render_template()` before HTTP request |
| `api/routes/tool.py` | Add `variable_extraction_timing` field to `HttpApiConfig` |
| `api/services/workflow/pipecat_engine_custom_tools.py` | Read timing and call extraction before/after `execute_http_tool` |
| `ui/src/components/http/url-input.tsx` | Allow `{{variable}}` in path, reject in domain |
| `ui/src/app/tools/[toolUuid]/components/HttpApiToolConfig.tsx` | Add URL hint + Variable Extraction Timing radio group |
| `ui/src/app/tools/[toolUuid]/page.tsx` | Wire state, populate from tool, include in save payload |
| `ui/src/client/types.gen.ts` | Add `variable_extraction_timing` to `HttpApiConfig` type |

### Tests added (3)

- `test_url_with_initial_context_variable`
- `test_url_with_gathered_context_variable`
- `test_url_without_template_variables_unchanged`