### PR TITLE
feat: add Tone telephony provider (+91 TRAI-compliant via Exotel)

### DIFF
--- a/api/enums.py
+++ b/api/enums.py
@@ -20,6 +20,7 @@ class CallType(Enum):
 class WorkflowRunMode(Enum):
     ARI = "ari"
     PLIVO = "plivo"
+    TONE = "tone"
     TWILIO = "twilio"
     VONAGE = "vonage"
     VOBIZ = "vobiz"

--- a/api/schemas/telephony_config.py
+++ b/api/schemas/telephony_config.py
@@ -28,6 +28,10 @@ from api.services.telephony.providers.telnyx.config import (
     TelnyxConfigurationRequest,
     TelnyxConfigurationResponse,
 )
+from api.services.telephony.providers.tone.config import (
+    ToneConfigurationRequest,
+    ToneConfigurationResponse,
+)
 from api.services.telephony.providers.twilio.config import (
     TwilioConfigurationRequest,
     TwilioConfigurationResponse,
@@ -50,6 +54,7 @@ TelephonyConfigRequest = Annotated[
         CloudonixConfigurationRequest,
         PlivoConfigurationRequest,
         TelnyxConfigurationRequest,
+        ToneConfigurationRequest,
         TwilioConfigurationRequest,
         VobizConfigurationRequest,
         VonageConfigurationRequest,
@@ -73,6 +78,7 @@ class TelephonyConfigurationResponse(BaseModel):
     cloudonix: Optional[CloudonixConfigurationResponse] = None
     ari: Optional[ARIConfigurationResponse] = None
     telnyx: Optional[TelnyxConfigurationResponse] = None
+    tone: Optional[ToneConfigurationResponse] = None
 
 
 # ---------------------------------------------------------------------------
@@ -142,6 +148,8 @@ __all__ = [
     "TelephonyConfigurationResponse",
     "TelnyxConfigurationRequest",
     "TelnyxConfigurationResponse",
+    "ToneConfigurationRequest",
+    "ToneConfigurationResponse",
     "TwilioConfigurationRequest",
     "TwilioConfigurationResponse",
     "VobizConfigurationRequest",

--- a/api/services/telephony/providers/__init__.py
+++ b/api/services/telephony/providers/__init__.py
@@ -10,6 +10,7 @@ from api.services.telephony.providers import (  # noqa: F401  -- import for side
     ari,
     cloudonix,
     plivo,
+    tone,
     telnyx,
     twilio,
     vobiz,

--- a/api/services/telephony/providers/tone/__init__.py
+++ b/api/services/telephony/providers/tone/__init__.py
@@ -17,6 +17,7 @@ def _config_loader(value: dict) -> dict:
         "provider": "tone",
         "api_key": value.get("api_key"),
         "from_numbers": value.get("from_numbers", []),
+        "webhook_secret": value.get("webhook_secret"),
     }
 
 
@@ -36,6 +37,19 @@ _UI_METADATA = ProviderUIMetadata(
             label="Phone Numbers",
             type="string-array",
             description="E.164-formatted Tone phone numbers, e.g. +917314624707",
+        ),
+        ProviderUIField(
+            name="webhook_secret",
+            label="Webhook Secret",
+            type="password",
+            sensitive=True,
+            required=False,
+            description=(
+                "Optional shared secret for callback authentication. Generate any "
+                "random string (≥32 chars). Must also be configured on the Tone "
+                "side. Leave blank to skip verification (not recommended for "
+                "production)."
+            ),
         ),
     ],
 )

--- a/api/services/telephony/providers/tone/__init__.py
+++ b/api/services/telephony/providers/tone/__init__.py
@@ -1,0 +1,66 @@
+"""Tone telephony provider package."""
+
+from api.services.telephony.registry import (
+    ProviderSpec,
+    ProviderUIField,
+    ProviderUIMetadata,
+    register,
+)
+
+from .config import ToneConfigurationRequest, ToneConfigurationResponse
+from .provider import ToneProvider
+from .transport import create_transport
+
+
+def _config_loader(value: dict) -> dict:
+    return {
+        "provider": "tone",
+        "api_key": value.get("api_key"),
+        "from_numbers": value.get("from_numbers", []),
+    }
+
+
+_UI_METADATA = ProviderUIMetadata(
+    display_name="Tone",
+    docs_url="https://docs.usetone.ai",
+    fields=[
+        ProviderUIField(
+            name="api_key",
+            label="API Key",
+            type="password",
+            sensitive=True,
+            description="Your Tone API key from usetone.ai/dashboard/api-keys",
+        ),
+        ProviderUIField(
+            name="from_numbers",
+            label="Phone Numbers",
+            type="string-array",
+            description="E.164-formatted Tone phone numbers, e.g. +917314624707",
+        ),
+    ],
+)
+
+
+SPEC = ProviderSpec(
+    name="tone",
+    provider_cls=ToneProvider,
+    config_loader=_config_loader,
+    transport_factory=create_transport,
+    transport_sample_rate=8000,
+    config_request_cls=ToneConfigurationRequest,
+    ui_metadata=_UI_METADATA,
+    config_response_cls=ToneConfigurationResponse,
+    account_id_credential_field="api_key",
+)
+
+
+register(SPEC)
+
+
+__all__ = [
+    "SPEC",
+    "ToneConfigurationRequest",
+    "ToneConfigurationResponse",
+    "ToneProvider",
+    "create_transport",
+]

--- a/api/services/telephony/providers/tone/config.py
+++ b/api/services/telephony/providers/tone/config.py
@@ -2,7 +2,15 @@
 
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+
+def _mask(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return value
+    if len(value) <= 4:
+        return "****"
+    return "*" * (len(value) - 4) + value[-4:]
 
 
 class ToneConfigurationRequest(BaseModel):
@@ -14,11 +22,22 @@ class ToneConfigurationRequest(BaseModel):
         default_factory=list,
         description="E.164-formatted Tone phone numbers, e.g. ['+917314624707']",
     )
+    webhook_secret: Optional[str] = Field(
+        default=None,
+        description="Optional shared secret sent in X-Tone-Webhook-Secret header for callback authentication",
+    )
 
 
 class ToneConfigurationResponse(BaseModel):
     """Response schema for Tone configuration with masked sensitive fields."""
 
     provider: Literal["tone"] = Field(default="tone")
-    api_key: str  # Masked on return
+    api_key: str
     from_numbers: List[str]
+    webhook_secret: Optional[str] = None
+
+    @model_validator(mode="after")
+    def mask_sensitive_fields(self) -> "ToneConfigurationResponse":
+        self.api_key = _mask(self.api_key) or "****"
+        self.webhook_secret = _mask(self.webhook_secret)
+        return self

--- a/api/services/telephony/providers/tone/config.py
+++ b/api/services/telephony/providers/tone/config.py
@@ -1,0 +1,24 @@
+"""Tone telephony configuration schemas."""
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ToneConfigurationRequest(BaseModel):
+    """Request schema for Tone configuration."""
+
+    provider: Literal["tone"] = Field(default="tone")
+    api_key: str = Field(..., description="Tone API key (Bearer token)")
+    from_numbers: List[str] = Field(
+        default_factory=list,
+        description="E.164-formatted Tone phone numbers, e.g. ['+917314624707']",
+    )
+
+
+class ToneConfigurationResponse(BaseModel):
+    """Response schema for Tone configuration with masked sensitive fields."""
+
+    provider: Literal["tone"] = Field(default="tone")
+    api_key: str  # Masked on return
+    from_numbers: List[str]

--- a/api/services/telephony/providers/tone/provider.py
+++ b/api/services/telephony/providers/tone/provider.py
@@ -12,12 +12,22 @@ Verified Tone API call fields:
   Response: id, status, to, from, callType, webhookUrl, createdAt
 
 WebSocket protocol: Exotel Voicebot Applet (bidirectional)
-  Audio: 8 kHz, 16-bit PCM, base64-encoded
+  Audio: 8 kHz, base64-encoded; framed by pipecat.serializers.exotel
   Events: connected → start → media* → stop
-  The WSS URL is configured statically in Exotel App Bazaar — NOT returned
-  from a webhook. This is different from Twilio/Plivo where TwiML is returned.
+
+Outbound only in this PR. Outbound flow:
+  1. initiate_call() POSTs to Tone /v1/calls with webhookUrl pointing at
+     /api/v1/telephony/tone-webhook?workflow_id=...&user_id=...&workflow_run_id=...&organization_id=...
+  2. When the call connects, Tone hits that URL — handle_tone_webhook
+     stores Exotel's CallSid into the run's gathered_context.
+  3. Exotel then opens a WSS to
+     /api/v1/telephony/ws/{workflow_id}/{user_id}/{workflow_run_id}
+     which routes to handle_websocket() with full per-call context.
+
+Inbound is NOT supported here — see configure_inbound() / start_inbound_stream().
 """
 
+import hmac
 import json
 import random
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -34,7 +44,6 @@ from api.services.telephony.base import (
     ProviderSyncResult,
     TelephonyProvider,
 )
-from api.utils.common import get_backend_endpoints
 from api.utils.telephony_address import normalize_telephony_address
 
 if TYPE_CHECKING:
@@ -52,6 +61,7 @@ class ToneProvider(TelephonyProvider):
     def __init__(self, config: Dict[str, Any]):
         self.api_key: str = config.get("api_key", "")
         self.from_numbers: List[str] = config.get("from_numbers", [])
+        self.webhook_secret: Optional[str] = config.get("webhook_secret") or None
 
         if isinstance(self.from_numbers, str):
             self.from_numbers = [self.from_numbers]
@@ -75,6 +85,17 @@ class ToneProvider(TelephonyProvider):
         from_number: Optional[str] = None,
         **kwargs: Any,
     ) -> CallInitiationResult:
+        """Initiate outbound call via Tone API.
+
+        The ``webhook_url`` argument is built by the upstream caller
+        (``api/routes/telephony.py``) and already contains all four query
+        params required by ``handle_tone_webhook``: workflow_id, user_id,
+        workflow_run_id, organization_id. We pass it through unchanged.
+
+        Recognized kwargs:
+            callType (str): TRANSACTIONAL or PROMOTIONAL; defaults to
+                TRANSACTIONAL.
+        """
         if not self.validate_config():
             raise ValueError("Tone provider not properly configured")
 
@@ -87,13 +108,6 @@ class ToneProvider(TelephonyProvider):
             "callType": kwargs.pop("callType", "TRANSACTIONAL"),
             "webhookUrl": webhook_url,
         }
-
-        if workflow_run_id:
-            backend_endpoint, _ = await get_backend_endpoints()
-            payload["webhookUrl"] = (
-                f"{backend_endpoint}/api/v1/telephony/tone-webhook"
-                f"?workflow_run_id={workflow_run_id}"
-            )
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
@@ -184,7 +198,25 @@ class ToneProvider(TelephonyProvider):
         headers: Dict[str, str],
         body: str = "",
     ) -> bool:
-        return True
+        # Exotel has no HMAC. Use shared-secret header instead.
+        # If no secret configured → backward-compat allow (warn).
+        if not self.webhook_secret:
+            logger.warning(
+                "[Tone] verify_inbound_signature: no webhook_secret configured — "
+                "callback authentication is DISABLED. Set webhook_secret in provider "
+                "config to enable X-Tone-Webhook-Secret verification."
+            )
+            return True
+
+        # Header lookup is case-insensitive — Starlette gives lowercase keys.
+        provided = (
+            headers.get("X-Tone-Webhook-Secret")
+            or headers.get("x-tone-webhook-secret")
+            or ""
+        )
+        if not provided:
+            return False
+        return hmac.compare_digest(provided, self.webhook_secret)
 
     # ------------------------------------------------------------------
     # Status callback normalization
@@ -228,6 +260,19 @@ class ToneProvider(TelephonyProvider):
         user_id: int,
         workflow_run_id: int,
     ) -> None:
+        """Handle Exotel Voicebot Applet bidirectional WebSocket.
+
+        OUTBOUND ONLY in this PR. This method is reached when an outbound call
+        initiated via ``initiate_call()`` connects: the workflow_run_id is
+        already known at dispatch time and embedded in the WSS URL Exotel
+        connects to ( /api/v1/telephony/ws/{workflow_id}/{user_id}/{workflow_run_id} ).
+
+        INBOUND is not supported in this PR. Exotel App Bazaar requires a
+        single static WSS URL per Voicebot Applet, but workflow_run_id is
+        only created when an inbound call arrives. A separate endpoint that
+        creates the workflow_run on WebSocket connect would be needed —
+        out of scope here.
+        """
         from api.services.pipecat.run_pipeline import run_pipeline_telephony
 
         # Exotel sends: {"event":"connected"} then {"event":"start", "start":{...}}
@@ -296,8 +341,18 @@ class ToneProvider(TelephonyProvider):
     def can_handle_webhook(
         cls, webhook_data: Dict[str, Any], headers: Dict[str, str]
     ) -> bool:
-        # Exotel Passthru sends CallSid; no provider-specific signature header
-        return "CallSid" in webhook_data and "call_sid" not in headers
+        # Both Tone/Exotel and Twilio send CallSid, so CallSid alone is
+        # ambiguous. Discriminate against Twilio by:
+        #   - Twilio sends x-twilio-signature header; Exotel does not.
+        #   - Twilio's AccountSid starts with "AC"; Exotel's does not.
+        account_sid = webhook_data.get("AccountSid", "")
+        lower_headers = {k.lower(): v for k, v in headers.items()}
+        has_twilio_sig = "x-twilio-signature" in lower_headers
+        return (
+            "CallSid" in webhook_data
+            and not has_twilio_sig
+            and not account_sid.startswith("AC")
+        )
 
     @staticmethod
     def parse_inbound_webhook(webhook_data: Dict[str, Any]) -> NormalizedInboundData:
@@ -329,9 +384,12 @@ class ToneProvider(TelephonyProvider):
         normalized_data: NormalizedInboundData,
         backend_endpoint: str,
     ) -> Any:
-        # Tone/Exotel doesn't receive XML/JSON to start a stream.
-        # The Voicebot Applet in App Bazaar points directly at the WSS URL.
-        # Return a plain 200 acknowledgement.
+        # Inbound call support is NOT implemented in this PR.
+        # Exotel App Bazaar requires a static WSS URL per Voicebot Applet,
+        # but workflow_run_id is only known at dispatch time. A separate
+        # endpoint that creates the workflow_run on WebSocket connect would
+        # be needed. Returning 200 here is a no-op so the dispatcher doesn't
+        # error, but the call will not route correctly.
         from fastapi.responses import JSONResponse
         return JSONResponse(content={"status": "ok"})
 
@@ -379,16 +437,20 @@ class ToneProvider(TelephonyProvider):
     async def configure_inbound(
         self, address: str, webhook_url: Optional[str]
     ) -> ProviderSyncResult:
-        # Exotel App Bazaar flows must be configured manually in the Exotel dashboard.
-        # Tone does not expose a REST API to update the Voicebot Applet WSS URL.
+        # Inbound call support is NOT implemented in this PR. Exotel App Bazaar
+        # requires a static WSS URL, but Dograh's WSS endpoint
+        # (/api/v1/telephony/ws/{workflow_id}/{user_id}/{workflow_run_id})
+        # contains a per-call workflow_run_id that doesn't exist until the call
+        # arrives. Inbound support will require a separate endpoint that creates
+        # the workflow_run on WebSocket connect.
         logger.info(
-            f"[Tone] configure_inbound for {address}: Exotel App Bazaar must be "
-            f"configured manually. WSS endpoint: {webhook_url or '(cleared)'}"
+            f"[Tone] configure_inbound called for {address} — no-op. "
+            "Inbound is not supported in this PR version."
         )
         return ProviderSyncResult(
             ok=True,
             message=(
-                "Tone uses Exotel App Bazaar for call routing. "
-                "Update the Voicebot Applet WSS URL manually in your Exotel dashboard."
+                "Inbound calls are not supported by the Tone provider in this "
+                "PR. Outbound calls work via initiate_call()."
             ),
         )

--- a/api/services/telephony/providers/tone/provider.py
+++ b/api/services/telephony/providers/tone/provider.py
@@ -1,0 +1,394 @@
+"""
+Tone telephony provider implementation.
+
+Tone (usetone.ai) provisions TRAI-compliant +91 numbers for AI agents,
+built on Exotel as the underlying carrier.
+
+Tone API: https://api.usetone.ai/v1
+Auth:     Authorization: Bearer <api_key>
+
+Verified Tone API call fields:
+  Request:  to, from, callType, webhookUrl
+  Response: id, status, to, from, callType, webhookUrl, createdAt
+
+WebSocket protocol: Exotel Voicebot Applet (bidirectional)
+  Audio: 8 kHz, 16-bit PCM, base64-encoded
+  Events: connected → start → media* → stop
+  The WSS URL is configured statically in Exotel App Bazaar — NOT returned
+  from a webhook. This is different from Twilio/Plivo where TwiML is returned.
+"""
+
+import json
+import random
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import aiohttp
+from fastapi import HTTPException
+from loguru import logger
+
+from api.db import db_client
+from api.enums import WorkflowRunMode
+from api.services.telephony.base import (
+    CallInitiationResult,
+    NormalizedInboundData,
+    ProviderSyncResult,
+    TelephonyProvider,
+)
+from api.utils.common import get_backend_endpoints
+from api.utils.telephony_address import normalize_telephony_address
+
+if TYPE_CHECKING:
+    from fastapi import WebSocket
+
+TONE_API_BASE = "https://api.usetone.ai/v1"
+
+
+class ToneProvider(TelephonyProvider):
+    """Tone (usetone.ai) implementation of TelephonyProvider."""
+
+    PROVIDER_NAME = WorkflowRunMode.TONE.value
+    WEBHOOK_ENDPOINT = "tone-webhook"
+
+    def __init__(self, config: Dict[str, Any]):
+        self.api_key: str = config.get("api_key", "")
+        self.from_numbers: List[str] = config.get("from_numbers", [])
+
+        if isinstance(self.from_numbers, str):
+            self.from_numbers = [self.from_numbers]
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def validate_config(self) -> bool:
+        return bool(self.api_key and self.from_numbers)
+
+    # ------------------------------------------------------------------
+    # Outbound call
+    # ------------------------------------------------------------------
+
+    async def initiate_call(
+        self,
+        to_number: str,
+        webhook_url: str,
+        workflow_run_id: Optional[int] = None,
+        from_number: Optional[str] = None,
+        **kwargs: Any,
+    ) -> CallInitiationResult:
+        if not self.validate_config():
+            raise ValueError("Tone provider not properly configured")
+
+        _from = from_number or random.choice(self.from_numbers)
+
+        # Tone API POST /v1/calls — verified field names
+        payload: Dict[str, Any] = {
+            "to": to_number,
+            "from": _from,
+            "callType": kwargs.pop("callType", "TRANSACTIONAL"),
+            "webhookUrl": webhook_url,
+        }
+
+        if workflow_run_id:
+            backend_endpoint, _ = await get_backend_endpoints()
+            payload["webhookUrl"] = (
+                f"{backend_endpoint}/api/v1/telephony/tone-webhook"
+                f"?workflow_run_id={workflow_run_id}"
+            )
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{TONE_API_BASE}/calls",
+                json=payload,
+                headers={"Authorization": f"Bearer {self.api_key}"},
+            ) as response:
+                response_text = await response.text()
+                if response.status not in (200, 201, 202):
+                    raise HTTPException(
+                        status_code=response.status,
+                        detail=f"Failed to initiate Tone call: {response_text}",
+                    )
+
+                response_data = json.loads(response_text)
+                call_id = response_data.get("id", "")
+
+                if not call_id:
+                    raise HTTPException(
+                        status_code=500,
+                        detail=f"Tone response missing call id: {response_data}",
+                    )
+
+                return CallInitiationResult(
+                    call_id=call_id,
+                    status=response_data.get("status", "queued"),
+                    caller_number=_from,
+                    provider_metadata={"call_id": call_id},
+                    raw_response=response_data,
+                )
+
+    # ------------------------------------------------------------------
+    # Call status
+    # ------------------------------------------------------------------
+
+    async def get_call_status(self, call_id: str) -> Dict[str, Any]:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{TONE_API_BASE}/calls/{call_id}",
+                headers={"Authorization": f"Bearer {self.api_key}"},
+            ) as response:
+                if response.status != 200:
+                    error = await response.text()
+                    raise Exception(f"Failed to get Tone call status: {error}")
+                return await response.json()
+
+    # ------------------------------------------------------------------
+    # Phone numbers
+    # ------------------------------------------------------------------
+
+    async def get_available_phone_numbers(self) -> List[str]:
+        return self.from_numbers
+
+    # ------------------------------------------------------------------
+    # Webhook response
+    # (Tone/Exotel doesn't use XML — WSS URL is set in App Bazaar)
+    # Required by abstract base but not used for this provider.
+    # ------------------------------------------------------------------
+
+    async def get_webhook_response(
+        self, workflow_id: int, user_id: int, workflow_run_id: int
+    ) -> str:
+        # Tone does not use TwiML or Plivo XML. The WebSocket URL is configured
+        # statically in the Exotel App Bazaar Voicebot Applet. This method is
+        # defined to satisfy the abstract interface but should not be called.
+        logger.warning(
+            "[Tone] get_webhook_response called but Tone uses Exotel App Bazaar "
+            "for WebSocket URL configuration, not webhook XML responses."
+        )
+        return ""
+
+    # ------------------------------------------------------------------
+    # Webhook / inbound signature — Exotel has no HMAC
+    # ------------------------------------------------------------------
+
+    async def verify_webhook_signature(
+        self, url: str, params: Dict[str, Any], signature: str
+    ) -> bool:
+        # Exotel does not send an HMAC signature on HTTP callbacks.
+        # Auth is via IP whitelisting or Basic Auth in the callback URL.
+        # Always return True — harden via IP whitelist in production.
+        return True
+
+    async def verify_inbound_signature(
+        self,
+        url: str,
+        webhook_data: Dict[str, Any],
+        headers: Dict[str, str],
+        body: str = "",
+    ) -> bool:
+        return True
+
+    # ------------------------------------------------------------------
+    # Status callback normalization
+    # ------------------------------------------------------------------
+
+    def parse_status_callback(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        # Exotel Passthru applet sends form-encoded params
+        status_map = {
+            "initiated":  "initiated",
+            "ringing":    "ringing",
+            "in-progress": "answered",
+            "answered":   "answered",
+            "completed":  "completed",
+            "failed":     "failed",
+            "busy":       "busy",
+            "no-answer":  "no-answer",
+            "canceled":   "canceled",
+            "cancelled":  "canceled",
+        }
+
+        raw_status = (data.get("Status") or data.get("status") or "").lower()
+
+        return {
+            "call_id":      data.get("CallSid") or data.get("id", ""),
+            "status":       status_map.get(raw_status, raw_status),
+            "from_number":  data.get("From") or data.get("from"),
+            "to_number":    data.get("To") or data.get("to"),
+            "direction":    data.get("Direction"),
+            "duration":     data.get("Duration") or data.get("duration"),
+            "extra":        data,
+        }
+
+    # ------------------------------------------------------------------
+    # WebSocket audio (Exotel Voicebot Applet)
+    # ------------------------------------------------------------------
+
+    async def handle_websocket(
+        self,
+        websocket: "WebSocket",
+        workflow_id: int,
+        user_id: int,
+        workflow_run_id: int,
+    ) -> None:
+        from api.services.pipecat.run_pipeline import run_pipeline_telephony
+
+        # Exotel sends: {"event":"connected"} then {"event":"start", "start":{...}}
+        stream_sid = None
+        call_sid = None
+
+        for _ in range(2):
+            raw = await websocket.receive_text()
+            msg = json.loads(raw)
+
+            if msg.get("event") == "start":
+                start = msg.get("start", {})
+                stream_sid = start.get("stream_sid") or msg.get("stream_sid")
+                call_sid = start.get("call_sid")
+                break
+
+        if not stream_sid:
+            logger.error(f"[Tone] Missing stream_sid in start event for run {workflow_run_id}")
+            await websocket.close(code=4400, reason="Missing stream_sid")
+            return
+
+        # Resolve call_id from DB context (stored by tone-webhook) or from start event
+        if not call_sid:
+            workflow_run = await db_client.get_workflow_run_by_id(workflow_run_id)
+            if workflow_run and workflow_run.gathered_context:
+                call_sid = workflow_run.gathered_context.get("call_id")
+
+        logger.info(
+            f"[Tone] WebSocket connected: stream_sid={stream_sid} "
+            f"call_sid={call_sid} run={workflow_run_id}"
+        )
+
+        await run_pipeline_telephony(
+            websocket,
+            provider_name=self.PROVIDER_NAME,
+            workflow_id=workflow_id,
+            workflow_run_id=workflow_run_id,
+            user_id=user_id,
+            call_id=call_sid or "",
+            transport_kwargs={"stream_sid": stream_sid, "call_sid": call_sid},
+        )
+
+    # ------------------------------------------------------------------
+    # Call cost
+    # ------------------------------------------------------------------
+
+    async def get_call_cost(self, call_id: str) -> Dict[str, Any]:
+        try:
+            call_data = await self.get_call_status(call_id)
+            return {
+                "cost_usd":     float(call_data.get("cost") or 0),
+                "duration":     int(call_data.get("duration") or 0),
+                "status":       call_data.get("status", "unknown"),
+                "price_unit":   "INR",  # Tone is India-first
+                "raw_response": call_data,
+            }
+        except Exception as e:
+            logger.error(f"[Tone] Exception fetching call cost for {call_id}: {e}")
+            return {"cost_usd": 0.0, "duration": 0, "status": "error", "error": str(e)}
+
+    # ------------------------------------------------------------------
+    # Inbound call support
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def can_handle_webhook(
+        cls, webhook_data: Dict[str, Any], headers: Dict[str, str]
+    ) -> bool:
+        # Exotel Passthru sends CallSid; no provider-specific signature header
+        return "CallSid" in webhook_data and "call_sid" not in headers
+
+    @staticmethod
+    def parse_inbound_webhook(webhook_data: Dict[str, Any]) -> NormalizedInboundData:
+        from_raw = webhook_data.get("From", "")
+        to_raw = webhook_data.get("To", "")
+        return NormalizedInboundData(
+            provider=ToneProvider.PROVIDER_NAME,
+            call_id=webhook_data.get("CallSid", ""),
+            from_number=normalize_telephony_address(from_raw).canonical if from_raw else "",
+            to_number=normalize_telephony_address(to_raw).canonical if to_raw else "",
+            direction=webhook_data.get("Direction", "inbound"),
+            call_status=webhook_data.get("Status", ""),
+            account_id=webhook_data.get("AccountSid"),
+            raw_data=webhook_data,
+        )
+
+    @staticmethod
+    def validate_account_id(config_data: dict, webhook_account_id: str) -> bool:
+        # Exotel doesn't send a consistent account_id in all webhooks; allow through
+        if not webhook_account_id:
+            return bool(config_data.get("api_key"))
+        return True
+
+    async def start_inbound_stream(
+        self,
+        *,
+        websocket_url: str,
+        workflow_run_id: int,
+        normalized_data: NormalizedInboundData,
+        backend_endpoint: str,
+    ) -> Any:
+        # Tone/Exotel doesn't receive XML/JSON to start a stream.
+        # The Voicebot Applet in App Bazaar points directly at the WSS URL.
+        # Return a plain 200 acknowledgement.
+        from fastapi.responses import JSONResponse
+        return JSONResponse(content={"status": "ok"})
+
+    # ------------------------------------------------------------------
+    # Error responses
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def generate_error_response(error_type: str, message: str) -> tuple:
+        from fastapi.responses import JSONResponse
+        return JSONResponse(
+            content={"error": error_type, "message": message},
+            status_code=400,
+        )
+
+    @staticmethod
+    def generate_validation_error_response(error_type) -> tuple:
+        from fastapi.responses import JSONResponse
+        return JSONResponse(
+            content={"error": str(error_type), "message": "Validation failed"},
+            status_code=401,
+        )
+
+    # ------------------------------------------------------------------
+    # Call transfers
+    # ------------------------------------------------------------------
+
+    async def transfer_call(
+        self,
+        destination: str,
+        transfer_id: str,
+        conference_name: str,
+        timeout: int = 30,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        raise NotImplementedError("Tone provider does not support call transfers")
+
+    def supports_transfers(self) -> bool:
+        return False
+
+    # ------------------------------------------------------------------
+    # Inbound configuration (App Bazaar — manual, not programmable via REST)
+    # ------------------------------------------------------------------
+
+    async def configure_inbound(
+        self, address: str, webhook_url: Optional[str]
+    ) -> ProviderSyncResult:
+        # Exotel App Bazaar flows must be configured manually in the Exotel dashboard.
+        # Tone does not expose a REST API to update the Voicebot Applet WSS URL.
+        logger.info(
+            f"[Tone] configure_inbound for {address}: Exotel App Bazaar must be "
+            f"configured manually. WSS endpoint: {webhook_url or '(cleared)'}"
+        )
+        return ProviderSyncResult(
+            ok=True,
+            message=(
+                "Tone uses Exotel App Bazaar for call routing. "
+                "Update the Voicebot Applet WSS URL manually in your Exotel dashboard."
+            ),
+        )

--- a/api/services/telephony/providers/tone/routes.py
+++ b/api/services/telephony/providers/tone/routes.py
@@ -1,0 +1,109 @@
+"""Tone telephony routes (webhooks, status callbacks).
+
+Mounted under /api/v1/telephony by api.routes.telephony via the
+provider registry — see ProviderSpec.router.
+
+Exotel sends:
+  - Passthru applet callbacks: form-urlencoded with CallSid, Status, etc.
+  - No HMAC signature — authentication is via IP whitelisting or Basic Auth
+    embedded in the callback URL.
+"""
+
+import json
+
+from fastapi import APIRouter, Request
+from loguru import logger
+from pipecat.utils.run_context import set_current_run_id
+from starlette.responses import HTMLResponse
+
+from api.db import db_client
+from api.services.telephony.factory import get_telephony_provider_for_run
+from api.services.telephony.status_processor import (
+    StatusCallbackRequest,
+    _process_status_update,
+)
+
+router = APIRouter()
+
+
+async def _handle_tone_status_callback(workflow_run_id: int, request: Request):
+    set_current_run_id(workflow_run_id)
+
+    form_data = await request.form()
+    callback_data = dict(form_data)
+    logger.info(
+        f"[run {workflow_run_id}] Received Tone callback: {json.dumps(callback_data)}"
+    )
+
+    workflow_run = await db_client.get_workflow_run_by_id(workflow_run_id)
+    if not workflow_run:
+        logger.warning(f"Workflow run {workflow_run_id} not found for Tone callback")
+        return {"status": "ignored", "reason": "workflow_run_not_found"}
+
+    workflow = await db_client.get_workflow_by_id(workflow_run.workflow_id)
+    if not workflow:
+        logger.warning(f"Workflow {workflow_run.workflow_id} not found")
+        return {"status": "ignored", "reason": "workflow_not_found"}
+
+    provider = await get_telephony_provider_for_run(workflow_run, workflow.organization_id)
+
+    # Exotel has no HMAC signature — verify_inbound_signature is a pass-through
+    parsed_data = provider.parse_status_callback(callback_data)
+    status_update = StatusCallbackRequest(
+        call_id=parsed_data["call_id"],
+        status=parsed_data["status"],
+        from_number=parsed_data.get("from_number"),
+        to_number=parsed_data.get("to_number"),
+        direction=parsed_data.get("direction"),
+        duration=parsed_data.get("duration"),
+        extra=parsed_data.get("extra", {}),
+    )
+
+    await _process_status_update(workflow_run_id, status_update)
+    return {"status": "success"}
+
+
+@router.post("/tone-webhook", include_in_schema=False)
+async def handle_tone_webhook(
+    workflow_id: int,
+    user_id: int,
+    workflow_run_id: int,
+    organization_id: int,
+    request: Request,
+):
+    """
+    Handle initial webhook from Tone/Exotel when an outbound call is answered.
+
+    Tone does not use TwiML or Plivo XML. The WebSocket URL is configured
+    statically in the Exotel App Bazaar Voicebot Applet. This endpoint is used
+    as the webhookUrl in POST /v1/calls for status callbacks only.
+    """
+    set_current_run_id(workflow_run_id)
+    workflow_run = await db_client.get_workflow_run_by_id(workflow_run_id)
+
+    form_data = await request.form()
+    callback_data = dict(form_data)
+
+    # Store Exotel CallSid so handle_websocket can find it
+    call_id = callback_data.get("CallSid") or callback_data.get("id", "")
+    if call_id and workflow_run:
+        gathered_context = dict(workflow_run.gathered_context or {})
+        gathered_context["call_id"] = call_id
+        await db_client.update_workflow_run(
+            run_id=workflow_run_id, gathered_context=gathered_context
+        )
+
+    # No XML response needed — Exotel doesn't parse a webhook response for call control
+    return {"status": "ok"}
+
+
+@router.post("/tone/hangup-callback/{workflow_run_id}")
+async def handle_tone_hangup_callback(workflow_run_id: int, request: Request):
+    """Handle Tone/Exotel Passthru applet hangup callbacks."""
+    return await _handle_tone_status_callback(workflow_run_id, request)
+
+
+@router.post("/tone/ring-callback/{workflow_run_id}")
+async def handle_tone_ring_callback(workflow_run_id: int, request: Request):
+    """Handle Tone/Exotel ring callbacks."""
+    return await _handle_tone_status_callback(workflow_run_id, request)

--- a/api/services/telephony/providers/tone/routes.py
+++ b/api/services/telephony/providers/tone/routes.py
@@ -1,12 +1,11 @@
 """Tone telephony routes (webhooks, status callbacks).
 
-Mounted under /api/v1/telephony by api.routes.telephony via the
-provider registry — see ProviderSpec.router.
+Loaded on demand by ``api.routes.telephony`` via importlib.
 
 Exotel sends:
   - Passthru applet callbacks: form-urlencoded with CallSid, Status, etc.
-  - No HMAC signature — authentication is via IP whitelisting or Basic Auth
-    embedded in the callback URL.
+  - No HMAC signature — Tone authenticates callbacks via a shared secret
+    in the X-Tone-Webhook-Secret header (see ToneProvider.verify_inbound_signature).
 """
 
 import json
@@ -14,7 +13,6 @@ import json
 from fastapi import APIRouter, Request
 from loguru import logger
 from pipecat.utils.run_context import set_current_run_id
-from starlette.responses import HTMLResponse
 
 from api.db import db_client
 from api.services.telephony.factory import get_telephony_provider_for_run
@@ -47,7 +45,22 @@ async def _handle_tone_status_callback(workflow_run_id: int, request: Request):
 
     provider = await get_telephony_provider_for_run(workflow_run, workflow.organization_id)
 
-    # Exotel has no HMAC signature — verify_inbound_signature is a pass-through
+    # Shared-secret callback auth (Exotel has no HMAC). When provider has
+    # webhook_secret configured, X-Tone-Webhook-Secret header must match.
+    # NOTE: do not read request.body() here — Starlette marks the stream as
+    # consumed after request.form() above and body() would raise RuntimeError.
+    # Tone's verify_inbound_signature only inspects headers.
+    is_valid = await provider.verify_inbound_signature(
+        url=str(request.url),
+        webhook_data=callback_data,
+        headers=dict(request.headers),
+    )
+    if not is_valid:
+        logger.warning(
+            f"[run {workflow_run_id}] Tone callback rejected: invalid signature"
+        )
+        return {"status": "error", "reason": "invalid_signature"}
+
     parsed_data = provider.parse_status_callback(callback_data)
     status_update = StatusCallbackRequest(
         call_id=parsed_data["call_id"],
@@ -72,21 +85,27 @@ async def handle_tone_webhook(
     request: Request,
 ):
     """
-    Handle initial webhook from Tone/Exotel when an outbound call is answered.
+    Handle the initial Tone webhook fired when an outbound call connects.
 
-    Tone does not use TwiML or Plivo XML. The WebSocket URL is configured
-    statically in the Exotel App Bazaar Voicebot Applet. This endpoint is used
-    as the webhookUrl in POST /v1/calls for status callbacks only.
+    Tone does not use TwiML or Plivo XML — it carries no in-band call-control
+    response. We use this hit only to capture the Exotel CallSid into
+    gathered_context so handle_websocket() can correlate the subsequent WSS
+    stream back to this run.
     """
     set_current_run_id(workflow_run_id)
     workflow_run = await db_client.get_workflow_run_by_id(workflow_run_id)
+    if not workflow_run:
+        logger.warning(
+            f"Workflow run {workflow_run_id} not found for Tone webhook"
+        )
+        return {"status": "ignored", "reason": "workflow_run_not_found"}
 
     form_data = await request.form()
     callback_data = dict(form_data)
 
     # Store Exotel CallSid so handle_websocket can find it
     call_id = callback_data.get("CallSid") or callback_data.get("id", "")
-    if call_id and workflow_run:
+    if call_id:
         gathered_context = dict(workflow_run.gathered_context or {})
         gathered_context["call_id"] = call_id
         await db_client.update_workflow_run(

--- a/api/services/telephony/providers/tone/serializers.py
+++ b/api/services/telephony/providers/tone/serializers.py
@@ -1,0 +1,5 @@
+"""Exotel frame serializer (re-exported from pipecat)."""
+
+from pipecat.serializers.exotel import ExotelFrameSerializer
+
+__all__ = ["ExotelFrameSerializer"]

--- a/api/services/telephony/providers/tone/transport.py
+++ b/api/services/telephony/providers/tone/transport.py
@@ -1,0 +1,64 @@
+"""Tone (Exotel) transport factory."""
+
+from fastapi import WebSocket
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
+
+from api.services.pipecat.audio_config import AudioConfig
+from api.services.pipecat.audio_mixer import build_audio_out_mixer
+from api.services.pipecat.transport_params import realtime_param_overrides
+from api.services.telephony.factory import load_credentials_for_transport
+
+from .serializers import ExotelFrameSerializer
+
+
+async def create_transport(
+    websocket: WebSocket,
+    workflow_run_id: int,
+    audio_config: AudioConfig,
+    organization_id: int,
+    *,
+    ambient_noise_config: dict | None = None,
+    telephony_configuration_id: int | None = None,
+    is_realtime: bool = False,
+    stream_sid: str,
+    call_sid: str | None = None,
+):
+    """Create a FastAPIWebsocketTransport for a Tone/Exotel call."""
+    config = await load_credentials_for_transport(
+        organization_id, telephony_configuration_id, expected_provider="tone"
+    )
+
+    api_key = config.get("api_key")
+    if not api_key:
+        raise ValueError(
+            f"Incomplete Tone configuration for organization {organization_id}"
+        )
+
+    serializer = ExotelFrameSerializer(
+        stream_sid=stream_sid,
+        call_sid=call_sid,
+        params=ExotelFrameSerializer.InputParams(
+            exotel_sample_rate=8000,
+            sample_rate=audio_config.pipeline_sample_rate,
+        ),
+    )
+
+    mixer = await build_audio_out_mixer(
+        audio_config.transport_out_sample_rate, ambient_noise_config
+    )
+
+    return FastAPIWebsocketTransport(
+        websocket=websocket,
+        params=FastAPIWebsocketParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+            audio_in_sample_rate=audio_config.transport_in_sample_rate,
+            audio_out_sample_rate=audio_config.transport_out_sample_rate,
+            audio_out_mixer=mixer,
+            serializer=serializer,
+            **realtime_param_overrides(is_realtime),
+        ),
+    )

--- a/api/tests/telephony/tone/test_routes.py
+++ b/api/tests/telephony/tone/test_routes.py
@@ -1,0 +1,301 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from urllib.parse import urlencode
+
+import pytest
+from starlette.requests import Request
+
+from api.services.telephony.providers.tone.config import ToneConfigurationResponse
+from api.services.telephony.providers.tone.provider import ToneProvider
+from api.services.telephony.providers.tone.routes import (
+    handle_tone_hangup_callback,
+    handle_tone_webhook,
+)
+
+
+def test_tone_configuration_response_masks_sensitive_fields():
+    response = ToneConfigurationResponse(
+        api_key="tone_live_abc123xyz",
+        webhook_secret="my-super-secret-webhook-key",
+        from_numbers=["+917314624707"],
+    )
+    assert response.api_key == "*" * 15 + "3xyz"
+    assert "my-super-secret" not in response.webhook_secret
+    assert response.webhook_secret.endswith("-key")  # actual last 4 of "my-super-secret-webhook-key"
+    assert response.from_numbers == ["+917314624707"]  # non-sensitive unchanged
+
+
+def _provider(*, webhook_secret: str | None = None) -> ToneProvider:
+    cfg = {
+        "api_key": "tone_live_test_key",
+        "from_numbers": ["+917314624707"],
+    }
+    if webhook_secret is not None:
+        cfg["webhook_secret"] = webhook_secret
+    return ToneProvider(cfg)
+
+
+def _request(
+    *,
+    path: str,
+    query: dict[str, str | int],
+    form_data: dict[str, str],
+    headers: dict[str, str] | None = None,
+) -> Request:
+    body = urlencode(form_data).encode("utf-8")
+    query_string = urlencode(query).encode("utf-8")
+    request_headers = [
+        (b"content-type", b"application/x-www-form-urlencoded"),
+        *[
+            (name.lower().encode("ascii"), value.encode("ascii"))
+            for name, value in (headers or {}).items()
+        ],
+    ]
+
+    async def receive():
+        return {
+            "type": "http.request",
+            "body": body,
+            "more_body": False,
+        }
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "scheme": "https",
+            "server": ("example.test", 443),
+            "path": path,
+            "query_string": query_string,
+            "headers": request_headers,
+        },
+        receive,
+    )
+
+
+@pytest.mark.asyncio
+async def test_tone_webhook_saves_call_sid():
+    form_data = {
+        "CallSid": "call-abc-123",
+        "From": "+917314624707",
+        "To": "+919876543210",
+        "Direction": "outbound",
+    }
+    query = {
+        "workflow_id": 7,
+        "user_id": 8,
+        "workflow_run_id": 123,
+        "organization_id": 11,
+    }
+    request = _request(
+        path="/api/v1/telephony/tone-webhook",
+        query=query,
+        form_data=form_data,
+    )
+
+    with patch(
+        "api.services.telephony.providers.tone.routes.db_client"
+    ) as db_client:
+        db_client.get_workflow_run_by_id = AsyncMock(
+            return_value=SimpleNamespace(gathered_context={}, workflow_id=7)
+        )
+        db_client.update_workflow_run = AsyncMock()
+
+        response = await handle_tone_webhook(
+            workflow_id=7,
+            user_id=8,
+            workflow_run_id=123,
+            organization_id=11,
+            request=request,
+        )
+
+    assert response == {"status": "ok"}
+    db_client.update_workflow_run.assert_awaited_once()
+    _, kwargs = db_client.update_workflow_run.call_args
+    assert kwargs["gathered_context"]["call_id"] == "call-abc-123"
+    assert kwargs["run_id"] == 123
+
+
+@pytest.mark.asyncio
+async def test_tone_webhook_missing_workflow_run():
+    request = _request(
+        path="/api/v1/telephony/tone-webhook",
+        query={
+            "workflow_id": 7,
+            "user_id": 8,
+            "workflow_run_id": 999,
+            "organization_id": 11,
+        },
+        form_data={"CallSid": "call-xyz"},
+    )
+
+    with patch(
+        "api.services.telephony.providers.tone.routes.db_client"
+    ) as db_client:
+        db_client.get_workflow_run_by_id = AsyncMock(return_value=None)
+        db_client.update_workflow_run = AsyncMock()
+
+        result = await handle_tone_webhook(
+            workflow_id=7,
+            user_id=8,
+            workflow_run_id=999,
+            organization_id=11,
+            request=request,
+        )
+
+    assert result == {"status": "ignored", "reason": "workflow_run_not_found"}
+    db_client.update_workflow_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tone_status_callback_processes_completed_call():
+    provider = _provider()
+    form_data = {
+        "CallSid": "call-completed-1",
+        "Status": "completed",
+        "Duration": "45",
+        "From": "+917314624707",
+        "To": "+919876543210",
+    }
+    request = _request(
+        path="/api/v1/telephony/tone/hangup-callback/123",
+        query={},
+        form_data=form_data,
+    )
+
+    with (
+        patch("api.services.telephony.providers.tone.routes.db_client") as db_client,
+        patch(
+            "api.services.telephony.providers.tone.routes.get_telephony_provider_for_run",
+            new_callable=AsyncMock,
+            return_value=provider,
+        ),
+        patch(
+            "api.services.telephony.providers.tone.routes._process_status_update",
+            new_callable=AsyncMock,
+        ) as process_status,
+    ):
+        db_client.get_workflow_run_by_id = AsyncMock(
+            return_value=SimpleNamespace(workflow_id=7)
+        )
+        db_client.get_workflow_by_id = AsyncMock(
+            return_value=SimpleNamespace(organization_id=11)
+        )
+
+        result = await handle_tone_hangup_callback(
+            workflow_run_id=123, request=request
+        )
+
+    assert result == {"status": "success"}
+    process_status.assert_awaited_once()
+    args, _ = process_status.call_args
+    run_id_arg, status_update = args
+    assert run_id_arg == 123
+    assert status_update.status == "completed"
+    assert status_update.call_id == "call-completed-1"
+    assert status_update.duration == "45"
+
+
+@pytest.mark.asyncio
+async def test_tone_status_callback_ignores_unknown_workflow_run():
+    request = _request(
+        path="/api/v1/telephony/tone/hangup-callback/999",
+        query={},
+        form_data={"CallSid": "call-x", "Status": "completed"},
+    )
+
+    with (
+        patch("api.services.telephony.providers.tone.routes.db_client") as db_client,
+        patch(
+            "api.services.telephony.providers.tone.routes._process_status_update",
+            new_callable=AsyncMock,
+        ) as process_status,
+    ):
+        db_client.get_workflow_run_by_id = AsyncMock(return_value=None)
+
+        result = await handle_tone_hangup_callback(
+            workflow_run_id=999, request=request
+        )
+
+    assert result == {"status": "ignored", "reason": "workflow_run_not_found"}
+    process_status.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tone_callback_with_secret_accepts_valid():
+    secret = "s3cret-shared-token"
+    provider = _provider(webhook_secret=secret)
+    form_data = {
+        "CallSid": "call-secret-ok",
+        "Status": "completed",
+        "Duration": "30",
+    }
+    request = _request(
+        path="/api/v1/telephony/tone/hangup-callback/123",
+        query={},
+        form_data=form_data,
+        headers={"X-Tone-Webhook-Secret": secret},
+    )
+
+    with (
+        patch("api.services.telephony.providers.tone.routes.db_client") as db_client,
+        patch(
+            "api.services.telephony.providers.tone.routes.get_telephony_provider_for_run",
+            new_callable=AsyncMock,
+            return_value=provider,
+        ),
+        patch(
+            "api.services.telephony.providers.tone.routes._process_status_update",
+            new_callable=AsyncMock,
+        ) as process_status,
+    ):
+        db_client.get_workflow_run_by_id = AsyncMock(
+            return_value=SimpleNamespace(workflow_id=7)
+        )
+        db_client.get_workflow_by_id = AsyncMock(
+            return_value=SimpleNamespace(organization_id=11)
+        )
+
+        result = await handle_tone_hangup_callback(
+            workflow_run_id=123, request=request
+        )
+
+    assert result == {"status": "success"}
+    process_status.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_tone_callback_with_secret_rejects_invalid():
+    provider = _provider(webhook_secret="the-real-secret")
+    request = _request(
+        path="/api/v1/telephony/tone/hangup-callback/123",
+        query={},
+        form_data={"CallSid": "call-bad-secret", "Status": "completed"},
+        headers={"X-Tone-Webhook-Secret": "wrong-secret"},
+    )
+
+    with (
+        patch("api.services.telephony.providers.tone.routes.db_client") as db_client,
+        patch(
+            "api.services.telephony.providers.tone.routes.get_telephony_provider_for_run",
+            new_callable=AsyncMock,
+            return_value=provider,
+        ),
+        patch(
+            "api.services.telephony.providers.tone.routes._process_status_update",
+            new_callable=AsyncMock,
+        ) as process_status,
+    ):
+        db_client.get_workflow_run_by_id = AsyncMock(
+            return_value=SimpleNamespace(workflow_id=7)
+        )
+        db_client.get_workflow_by_id = AsyncMock(
+            return_value=SimpleNamespace(organization_id=11)
+        )
+
+        result = await handle_tone_hangup_callback(
+            workflow_run_id=123, request=request
+        )
+
+    assert result == {"status": "error", "reason": "invalid_signature"}
+    process_status.assert_not_awaited()


### PR DESCRIPTION
Adds Tone (usetone.ai) as a telephony provider — TRAI-compliant +91 
numbers for AI voice agents, built on Exotel.

- New provider: `api/services/telephony/providers/tone/`
- Uses `ExotelFrameSerializer` from tuner-pipecat-sdk (WebSocket, 8kHz PCM)
- Implements full `TelephonyProvider` interface (matches Plivo structure)
- Added `TONE` to `WorkflowRunMode` enum

Tone API: https://api.usetone.ai/v1