### PR TITLE
feat: add Cartesia Sonic 3.5 as a TTS option

### DIFF
--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -911,7 +911,7 @@ class DograhTTSService(BaseTTSConfiguration):
     speed: float = Field(default=1.0, ge=0.5, le=2.0, description="Speed of the voice.")
 
 
-CARTESIA_TTS_MODELS = ["sonic-3"]
+CARTESIA_TTS_MODELS = ["sonic-3.5", "sonic-3"]
 
 
 @register_tts
@@ -919,7 +919,7 @@ class CartesiaTTSConfiguration(BaseTTSConfiguration):
     model_config = CARTESIA_PROVIDER_MODEL_CONFIG
     provider: Literal[ServiceProviders.CARTESIA] = ServiceProviders.CARTESIA
     model: str = Field(
-        default="sonic-3",
+        default="sonic-3.5",
         description="Cartesia TTS model.",
         json_schema_extra={"examples": CARTESIA_TTS_MODELS},
     )

--- a/api/tests/test_cartesia_tts_service_factory.py
+++ b/api/tests/test_cartesia_tts_service_factory.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from api.services.configuration.registry import (
+    CARTESIA_TTS_MODELS,
+    CartesiaTTSConfiguration,
+    ServiceProviders,
+)
+from api.services.pipecat.service_factory import create_tts_service
+
+
+def test_cartesia_tts_configuration_defaults_to_sonic_3_5():
+    config = CartesiaTTSConfiguration(api_key="test-key")
+
+    assert config.provider == ServiceProviders.CARTESIA
+    assert config.model == "sonic-3.5"
+    assert CARTESIA_TTS_MODELS == ["sonic-3.5", "sonic-3"]
+
+
+def test_create_cartesia_tts_service_passes_selected_model():
+    user_config = SimpleNamespace(
+        tts=SimpleNamespace(
+            provider=ServiceProviders.CARTESIA.value,
+            api_key="test-key",
+            model="sonic-3.5",
+            voice="test-voice-id",
+            speed=1.0,
+            volume=1.0,
+        )
+    )
+    audio_config = SimpleNamespace(
+        transport_out_sample_rate=24000,
+        transport_in_sample_rate=16000,
+    )
+
+    with patch("api.services.pipecat.service_factory.CartesiaTTSService") as mock_service:
+        create_tts_service(user_config, audio_config)
+
+    assert mock_service.call_count == 1
+    kwargs = mock_service.call_args.kwargs
+    assert kwargs["api_key"] == "test-key"
+    assert kwargs["settings"].model == "sonic-3.5"
+    assert kwargs["settings"].voice == "test-voice-id"


### PR DESCRIPTION
## Summary
- add `sonic-3.5` to the Cartesia TTS model list
- make `sonic-3.5` the default Cartesia TTS model
- add a regression test covering the default model and service factory wiring

## Why
Cartesia now recommends `sonic-3.5` as the stable base model. Keeping `sonic-3` as the only default/visible option makes the OSS config lag behind the provider docs.

## Compatibility
- `sonic-3` remains available for compatibility