### PR TITLE
fix: use system role for user-idle prompt injections

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,8 @@
   "postCreateCommand": "bash .devcontainer/scripts/post-create.sh",
   "postStartCommand": "bash .devcontainer/scripts/post-start.sh",
   "forwardPorts": [
+    3000,
+    8000,
     5432,
     6379,
     9000,

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -18,5 +18,5 @@ bcrypt==5.0.0
 email-validator==2.3.0
 posthog==7.11.1
 fastmcp==3.2.4
-tuner-pipecat-sdk==0.2.0
+tuner-pipecat-sdk==0.2.2
 PyNaCl==1.6.2

--- a/api/services/workflow/pipecat_engine_callbacks.py
+++ b/api/services/workflow/pipecat_engine_callbacks.py
@@ -46,14 +46,14 @@ class UserIdleHandler:
 
         if self._retry_count == 1:
             message = {
-                "role": "user",
+                "role": "system",
                 "content": "The user has been quiet. Politely and briefly ask if they're still there in the language that the user has been speaking so far.",
             }
             await aggregator.push_frame(LLMMessagesAppendFrame([message], run_llm=True))
             return
 
         message = {
-            "role": "user",
+            "role": "system",
             "content": "The user has been quiet. We will be disconnecting the call now. Wish them a good day in the language that the user has been speaking so far.",
         }
         await aggregator.push_frame(LLMMessagesAppendFrame([message], run_llm=True))

--- a/api/tests/test_realtime_message_append.py
+++ b/api/tests/test_realtime_message_append.py
@@ -20,7 +20,7 @@ async def test_openai_realtime_messages_append_frame_sends_conversation_item():
 
     await service._handle_messages_append(
         LLMMessagesAppendFrame(
-            [{"role": "user", "content": "Are you still there?"}],
+            [{"role": "system", "content": "Are you still there?"}],
             run_llm=True,
         )
     )
@@ -28,7 +28,7 @@ async def test_openai_realtime_messages_append_frame_sends_conversation_item():
     service.send_client_event.assert_awaited_once()
     event = service.send_client_event.await_args.args[0]
     assert isinstance(event, events.ConversationItemCreateEvent)
-    assert event.item.role == "user"
+    assert event.item.role == "system"
     assert event.item.type == "message"
     assert event.item.content == [
         events.ItemContent(type="input_text", text="Are you still there?")
@@ -53,7 +53,7 @@ async def test_user_idle_handler_uses_realtime_append_path():
     assert frame.run_llm is True
     assert frame.messages == [
         {
-            "role": "user",
+            "role": "system",
             "content": "The user has been quiet. Politely and briefly ask if they're still there in the language that the user has been speaking so far.",
         }
     ]


### PR DESCRIPTION
Fixes:
1) The UserIdleHandler injected its "are you still there?" and disconnect prompts as role="user" messages. These are agent-side directives, not user utterances, so they should be injected as role="system" to avoid polluting the conversation transcript with fake user turns and to read correctly by the LLM. Updated the realtime append tests to match.

2) forward ports 3000 (UI) and 8000 (API) in the devcontainer so the running services are reachable from the host.

3) Bump Tuner SDK version to 2.0.2

Testing and Validation:
<img width="985" height="635" alt="Screenshot 2026-06-12 at 14 17 40" src="https://github.com/user-attachments/assets/86068b47-c6fb-4d6a-80e6-8cecac6f1067" />

