### PR TITLE
style(docs): add custom green scrollbar

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -57,3 +57,27 @@ button[data-testid*="search"],
   animation: search-pulse 2s ease-in-out infinite !important;
 }
 
+
+/* Custom scrollbar */
+
+/* Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #16A34A transparent;
+}
+
+/* WebKit: Chrome, Edge, Safari, mobile */
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  background: #16A34A;
+  border-radius: 4px;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: #15803D;
+}


### PR DESCRIPTION
  ## What
  Replaces the browser-default scrollbar with a custom brand-green
  scrollbar across the docs site.
 
  ## Why
  The default scrollbar looks out of place against the dark theme.
  This matches the Dograh green (#16A34A). 
  Cuz i've got ADHD and while refering the docs , the scrollbar looked awfull to me.

  ## Details
  - Cross-browser: WebKit (Chrome/Edge/Safari/mobile) + Firefox
  - 8px thin bar, rounded thumb, transparent track
  - Hover darkens to #15803D
  - CSS-only change in `docs/custom.css`, no JS
  
 ## Screenshot
 - Before
 
<img width="1366" height="667" alt="image" src="https://github.com/user-attachments/assets/24de0d15-8dd1-447e-9d6e-409247510b29" />
<img width="1366" height="667" alt="image" src="https://github.com/user-attachments/assets/e8b6a086-05fd-440d-a434-90852aed7596" />

- After 

<img width="1366" height="667" alt="image" src="https://github.com/user-attachments/assets/46d3c7a1-edc9-460e-beab-7de869986d03" />
<img width="1366" height="667" alt="image" src="https://github.com/user-attachments/assets/a77522bc-79c6-4212-a896-3e719f8d03ae" />


