### PR TITLE
feat(telephony/vonage): wire up inbound calls

### DIFF
--- a/api/db/telephony_phone_number_client.py
+++ b/api/db/telephony_phone_number_client.py
@@ -146,7 +146,13 @@ class TelephonyPhoneNumberClient(BaseDBClient):
         misses (e.g. legacy non-E.164 stored addresses); the caller should
         fall back to the fuzzy ``numbers_match`` path in that case.
         """
-        if not (provider and account_id_field and account_id and to_number):
+        # Allow ``account_id`` to be empty for providers whose inbound webhook
+        # payload doesn't carry an account-like identifier (e.g. Vonage's
+        # answer-URL POST contains only ``from`` / ``to`` / ``uuid`` /
+        # ``conversation_uuid``). When account_id is empty, match on
+        # ``(provider, address_normalized)``; ``uq_phone_numbers_org_address``
+        # guarantees that tuple resolves to at most one phone number per org.
+        if not (provider and to_number):
             return None
 
         normalized = normalize_telephony_address(to_number, country_hint=country_hint)
@@ -161,13 +167,16 @@ class TelephonyPhoneNumberClient(BaseDBClient):
                 )
                 .where(
                     TelephonyConfigurationModel.provider == provider,
-                    TelephonyConfigurationModel.credentials.op("->>")(account_id_field)
-                    == account_id,
                     TelephonyPhoneNumberModel.address_normalized
                     == normalized.canonical,
                     TelephonyPhoneNumberModel.is_active.is_(True),
                 )
             )
+            if account_id and account_id_field:
+                stmt = stmt.where(
+                    TelephonyConfigurationModel.credentials.op("->>")(account_id_field)
+                    == account_id
+                )
             if organization_id is not None:
                 stmt = stmt.where(
                     TelephonyConfigurationModel.organization_id == organization_id

--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -776,6 +776,10 @@ async def create_phone_number(
                 ),
             )
 
+    extra_metadata = dict(request.extra_metadata or {})
+    if request.smart_voicemail is not None:
+        extra_metadata["smart_voicemail"] = request.smart_voicemail.model_dump()
+
     try:
         row = await db_client.create_phone_number(
             organization_id=user.selected_organization_id,
@@ -786,7 +790,7 @@ async def create_phone_number(
             inbound_workflow_id=request.inbound_workflow_id,
             is_active=request.is_active,
             is_default_caller_id=request.is_default_caller_id,
-            extra_metadata=request.extra_metadata,
+            extra_metadata=extra_metadata,
         )
     except IntegrityError:
         raise HTTPException(
@@ -846,6 +850,16 @@ async def update_phone_number(
             request.inbound_workflow_id, user.selected_organization_id
         )
 
+    # update_phone_number replaces extra_metadata wholesale, so merge onto the
+    # existing dict to avoid clobbering keys the caller didn't send. Only pass a
+    # value when there's actually something to change (None preserves current).
+    extra_metadata = request.extra_metadata
+    if request.smart_voicemail is not None:
+        extra_metadata = dict(existing.extra_metadata or {})
+        if request.extra_metadata is not None:
+            extra_metadata.update(request.extra_metadata)
+        extra_metadata["smart_voicemail"] = request.smart_voicemail.model_dump()
+
     row = await db_client.update_phone_number(
         phone_number_id=phone_number_id,
         telephony_configuration_id=config_id,
@@ -853,7 +867,7 @@ async def update_phone_number(
         inbound_workflow_id=request.inbound_workflow_id,
         is_active=request.is_active,
         country_code=request.country_code,
-        extra_metadata=request.extra_metadata,
+        extra_metadata=extra_metadata,
         clear_inbound_workflow=request.clear_inbound_workflow,
     )
     if not row:

--- a/api/routes/telephony.py
+++ b/api/routes/telephony.py
@@ -540,6 +540,76 @@ async def websocket_endpoint(
     await _handle_telephony_websocket(websocket, workflow_id, user_id, workflow_run_id)
 
 
+@router.websocket("/ws/screening/{workflow_id}/{user_id}/{workflow_run_id}")
+async def websocket_screening_endpoint(
+    websocket: WebSocket, workflow_id: int, user_id: int, workflow_run_id: int
+):
+    """WebSocket endpoint for the smart-voicemail screening (human) leg.
+
+    This is the listen-only leg of the smart-voicemail flow: Vonage places an
+    outbound "screening" call to the configured human number whose answer NCCO
+    connects here. We run a silent pipeline (STT + VoicemailDetector only) and
+    report the result to the orchestrator, which then bridges or hands the
+    caller to the AI workflow. The bot never speaks on this leg.
+    """
+    from api.services.pipecat.run_pipeline import run_pipeline_screening
+    from api.services.telephony.smart_voicemail import (
+        get_smart_voicemail_orchestrator,
+    )
+
+    await websocket.accept()
+    set_current_run_id(workflow_run_id)
+
+    try:
+        state = await get_smart_voicemail_orchestrator().get_state(workflow_run_id)
+        screening_leg_uuid = state.get("screening_leg_uuid") if state else None
+        if not screening_leg_uuid:
+            logger.error(
+                f"[run {workflow_run_id}] no smart-voicemail screening state / "
+                f"leg uuid for screening websocket"
+            )
+            await websocket.close(code=4404, reason="Screening state not found")
+            return
+
+        # Vonage opens binary websockets but sends a `websocket:connected` text
+        # event first. Peek at the first message so the serializer doesn't choke
+        # on it — mirror VonageProvider.handle_websocket.
+        first_msg = await websocket.receive()
+        if "text" in first_msg:
+            msg = json.loads(first_msg["text"])
+            if msg.get("event") == "websocket:connected":
+                logger.debug(
+                    f"[run {workflow_run_id}] screening: Vonage connection confirmation"
+                )
+        elif "bytes" in first_msg:
+            logger.debug(
+                f"[run {workflow_run_id}] screening: Vonage started with binary audio"
+            )
+
+        await run_pipeline_screening(
+            websocket,
+            provider_name="vonage",
+            workflow_id=workflow_id,
+            user_id=user_id,
+            workflow_run_id=workflow_run_id,
+            call_id=screening_leg_uuid,
+            transport_kwargs={"call_uuid": screening_leg_uuid},
+        )
+    except WebSocketDisconnect as e:
+        logger.info(
+            f"[run {workflow_run_id}] screening WebSocket disconnected: "
+            f"code={e.code}, reason={e.reason}"
+        )
+    except Exception as e:
+        logger.error(
+            f"[run {workflow_run_id}] Error in screening WebSocket connection: {e}"
+        )
+        try:
+            await websocket.close(1011, "Internal server error")
+        except RuntimeError:
+            pass
+
+
 async def _handle_telephony_websocket(
     websocket: WebSocket, workflow_id: int, user_id: int, workflow_run_id: int
 ):
@@ -768,6 +838,30 @@ async def handle_inbound_run(request: Request):
             f"{wss_backend_endpoint}/api/v1/telephony/ws/"
             f"{workflow_id}/{user_id}/{workflow_run_id}"
         )
+
+        # Smart voicemail: screen-and-forward before handing to the AI. Only
+        # Vonage implements the required call-control primitives in v1.
+        sv_config = (phone_row.extra_metadata or {}).get("smart_voicemail") or {}
+        if sv_config.get("enabled") and provider_class.PROVIDER_NAME == "vonage":
+            from fastapi.responses import JSONResponse
+
+            from api.services.telephony.smart_voicemail import (
+                get_smart_voicemail_orchestrator,
+            )
+
+            ncco = await get_smart_voicemail_orchestrator().start(
+                provider=provider_instance,
+                smart_voicemail_config=sv_config,
+                normalized_data=normalized_data,
+                organization_id=config.organization_id,
+                telephony_configuration_id=telephony_configuration_id,
+                workflow_id=workflow_id,
+                user_id=user_id,
+                workflow_run_id=workflow_run_id,
+                backend_endpoint=backend_endpoint,
+                wss_backend_endpoint=wss_backend_endpoint,
+            )
+            return JSONResponse(content=ncco)
 
         return await provider_instance.start_inbound_stream(
             websocket_url=websocket_url,

--- a/api/schemas/telephony_phone_number.py
+++ b/api/schemas/telephony_phone_number.py
@@ -2,7 +2,7 @@
 
 import re
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -27,6 +27,10 @@ class SmartVoicemailConfig(BaseModel):
     forward_to_number: Optional[str] = Field(default=None, max_length=32)
     # How long to ring the human before giving up and handing to the AI.
     ring_timeout_seconds: int = Field(default=25, ge=5, le=120)
+    # Voicemail-detection source for the screening leg:
+    #   "vonage" — Vonage Advanced Machine Detection (carrier-grade, ~$0.008/call)
+    #   "own"    — the built-in pipecat VoicemailDetector (LLM-over-STT, free)
+    detection: Literal["vonage", "own"] = "vonage"
 
     @model_validator(mode="after")
     def _validate(self) -> "SmartVoicemailConfig":

--- a/api/schemas/telephony_phone_number.py
+++ b/api/schemas/telephony_phone_number.py
@@ -12,6 +12,41 @@ _ADDRESS_E164_RE = re.compile(r"^\+\d{8,15}$")
 _ADDRESS_BARE_DIGITS_RE = re.compile(r"^\d{8,15}$")
 
 
+class SmartVoicemailConfig(BaseModel):
+    """Per-number "smart voicemail" screening configuration.
+
+    Stored under ``extra_metadata["smart_voicemail"]`` on the phone-number row
+    (no dedicated columns). When ``enabled``, an inbound call to this number is
+    first forwarded to ``forward_to_number``; if a human answers the caller is
+    bridged to them, and if it goes to voicemail (or isn't answered within
+    ``ring_timeout_seconds``) the AI workflow takes the call instead.
+    """
+
+    enabled: bool = False
+    # Designated human number to ring first. Required when ``enabled``.
+    forward_to_number: Optional[str] = Field(default=None, max_length=32)
+    # How long to ring the human before giving up and handing to the AI.
+    ring_timeout_seconds: int = Field(default=25, ge=5, le=120)
+
+    @model_validator(mode="after")
+    def _validate(self) -> "SmartVoicemailConfig":
+        if not self.enabled:
+            return self
+        if not self.forward_to_number:
+            raise ValueError(
+                "forward_to_number is required when smart voicemail is enabled"
+            )
+        stripped = _ADDRESS_FORMAT_STRIP_RE.sub("", self.forward_to_number.strip())
+        if not _ADDRESS_E164_RE.fullmatch(stripped):
+            raise ValueError(
+                "forward_to_number must be E.164 (e.g. '+14155551234')"
+            )
+        # Normalize to the stripped E.164 form so downstream callers don't have
+        # to re-clean it.
+        self.forward_to_number = stripped
+        return self
+
+
 class PhoneNumberCreateRequest(BaseModel):
     """Create a new phone number under a telephony configuration.
 
@@ -27,6 +62,8 @@ class PhoneNumberCreateRequest(BaseModel):
     is_active: bool = True
     is_default_caller_id: bool = False
     extra_metadata: Dict[str, Any] = Field(default_factory=dict)
+    # Folded into ``extra_metadata["smart_voicemail"]`` by the route handler.
+    smart_voicemail: Optional[SmartVoicemailConfig] = None
 
     @model_validator(mode="after")
     def _validate_address_shape(self) -> "PhoneNumberCreateRequest":
@@ -73,6 +110,9 @@ class PhoneNumberUpdateRequest(BaseModel):
     is_active: Optional[bool] = None
     country_code: Optional[str] = Field(default=None, min_length=2, max_length=2)
     extra_metadata: Optional[Dict[str, Any]] = None
+    # When provided, merged into ``extra_metadata["smart_voicemail"]`` by the
+    # route handler (preserving other extra_metadata keys).
+    smart_voicemail: Optional[SmartVoicemailConfig] = None
 
 
 class ProviderSyncStatus(BaseModel):
@@ -102,11 +142,26 @@ class PhoneNumberResponse(BaseModel):
     is_active: bool
     is_default_caller_id: bool
     extra_metadata: Dict[str, Any]
+    # Typed view of ``extra_metadata["smart_voicemail"]`` for the UI; the
+    # source of truth remains ``extra_metadata``.
+    smart_voicemail: Optional[SmartVoicemailConfig] = None
     created_at: datetime
     updated_at: datetime
     # Only set on create/update responses when the route attempted a
     # provider-side sync (e.g. setting Twilio's VoiceUrl). Omitted on reads.
     provider_sync: Optional[ProviderSyncStatus] = None
+
+    @model_validator(mode="after")
+    def _derive_smart_voicemail(self) -> "PhoneNumberResponse":
+        if self.smart_voicemail is None and self.extra_metadata:
+            raw = self.extra_metadata.get("smart_voicemail")
+            if isinstance(raw, dict):
+                try:
+                    self.smart_voicemail = SmartVoicemailConfig.model_validate(raw)
+                except Exception:
+                    # Tolerate legacy/partial metadata — never fail a read.
+                    self.smart_voicemail = None
+        return self
 
 
 class PhoneNumberListResponse(BaseModel):

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -62,6 +62,7 @@ from pipecat.audio.turn.smart_turn.local_smart_turn_v3 import LocalSmartTurnAnal
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.extensions.voicemail.voicemail_detector import VoicemailDetector
+from pipecat.pipeline.pipeline import Pipeline
 from pipecat.processors.aggregators.llm_response_universal import (
     LLMAssistantAggregatorParams,
     LLMContextAggregatorPair,
@@ -234,6 +235,190 @@ async def run_pipeline_telephony(
     except Exception as e:
         logger.error(
             f"[run {workflow_run_id}] Error in {provider_name} pipeline: {e}",
+            exc_info=True,
+        )
+        raise
+
+
+async def run_pipeline_screening(
+    websocket,
+    *,
+    provider_name: str,
+    workflow_id: int,
+    workflow_run_id: int,
+    user_id: int,
+    call_id: str,
+    transport_kwargs: dict,
+) -> None:
+    """Run a LISTEN-ONLY screening pipeline on a smart-voicemail human leg.
+
+    Mirrors :func:`run_pipeline_telephony`'s transport/config resolution but
+    builds a minimal pipeline that only runs the ``VoicemailDetector`` over STT.
+    The bot NEVER speaks: there is no main LLM/TTS/engine upstream of
+    ``transport.output()``, so no audio is ever produced toward the human leg.
+
+    On the first classification, the smart-voicemail orchestrator is notified
+    (``"human"`` or ``"voicemail"``); the orchestrator then transfers/hangs up
+    the leg (which tears down this websocket). After firing, we cancel the
+    pipeline task so the worker exits cleanly even if the websocket lingers.
+
+    Args:
+        websocket: The accepted WebSocket from Vonage (the screening leg).
+        provider_name: Stable provider identifier (registry key) — "vonage".
+        workflow_id: Workflow being screened for.
+        workflow_run_id: Workflow run row driving the screening flow.
+        user_id: Owner of the workflow.
+        call_id: The screening leg's Vonage call UUID.
+        transport_kwargs: Provider-specific kwargs forwarded to the transport
+            factory (e.g. ``{"call_uuid": <screening leg uuid>}``).
+    """
+    from api.services.telephony.smart_voicemail import (
+        get_smart_voicemail_orchestrator,
+    )
+
+    logger.debug(
+        f"Running {provider_name} screening pipeline for workflow_run {workflow_run_id}"
+    )
+    set_current_run_id(workflow_run_id)
+
+    workflow = await db_client.get_workflow(workflow_id, user_id)
+    if not workflow:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    set_current_org_id(workflow.organization_id)
+
+    # Telephony config id is stamped on the workflow run; the transport uses it
+    # to load creds from the right config row.
+    workflow_run = await db_client.get_workflow_run(workflow_run_id)
+    telephony_configuration_id = None
+    if workflow_run and workflow_run.initial_context:
+        telephony_configuration_id = workflow_run.initial_context.get(
+            "telephony_configuration_id"
+        )
+
+    # Resolve effective user config — needed to build the STT service. Screening
+    # is always non-realtime (the detector is incompatible with realtime), so we
+    # force a non-realtime STT path regardless of the workflow's mode.
+    from api.services.configuration.ai_model_configuration import (
+        get_effective_ai_model_configuration_for_workflow,
+    )
+
+    run_configs = (
+        (workflow_run.definition.workflow_configurations or {}) if workflow_run else {}
+    )
+    user_config = await get_effective_ai_model_configuration_for_workflow(
+        user_id=user_id,
+        organization_id=workflow.organization_id,
+        workflow_configurations=run_configs,
+    )
+
+    spec = telephony_registry.get(provider_name)
+    audio_config = create_audio_config(provider_name)
+
+    transport = await spec.transport_factory(
+        websocket,
+        workflow_run_id,
+        audio_config,
+        workflow.organization_id,
+        ambient_noise_config=None,
+        telephony_configuration_id=telephony_configuration_id,
+        is_realtime=False,
+        **transport_kwargs,
+    )
+
+    try:
+        # STT only — never TTS/LLM for the main conversation.
+        stt = create_stt_service(
+            user_config,
+            audio_config,
+            keyterms=None,
+            correlation_id=None,
+        )
+
+        # Classifier LLM for the detector. Mirror the existing voicemail wiring:
+        # honor the workflow's voicemail_detection config when present, else
+        # default to the workflow's own LLM.
+        voicemail_config = (workflow.workflow_configurations or {}).get(
+            "voicemail_detection", {}
+        )
+        if voicemail_config.get("use_workflow_llm", True):
+            voicemail_llm = create_llm_service(user_config)
+        else:
+            voicemail_llm = create_llm_service_from_provider(
+                provider=voicemail_config.get("provider", "openai"),
+                model=voicemail_config.get("model", "gpt-4.1"),
+                api_key=voicemail_config.get("api_key", ""),
+            )
+
+        long_speech_timeout = voicemail_config.get("long_speech_timeout", 8.0)
+        custom_system_prompt = voicemail_config.get("system_prompt") or None
+
+        voicemail_detector = VoicemailDetector(
+            llm=voicemail_llm,
+            long_speech_timeout=long_speech_timeout,
+            custom_system_prompt=custom_system_prompt,
+        )
+
+        # Build a context aggregator pair the way _run_pipeline does for the
+        # non-realtime default (transcription-based) turn strategy. We don't
+        # need the workflow engine, recording, integrations, TTS or main LLM —
+        # only enough to drive the detector's user-turn aggregation.
+        _, context = create_pipeline_components(audio_config)
+        user_turn_strategies = UserTurnStrategies(
+            start=[
+                VADUserTurnStartStrategy(),
+                TranscriptionUserTurnStartStrategy(),
+            ],
+            stop=[SpeechTimeoutUserTurnStopStrategy()],
+        )
+        user_params = LLMUserAggregatorParams(
+            user_turn_strategies=user_turn_strategies,
+            vad_analyzer=SileroVADAnalyzer(params=VADParams(stop_secs=0.2)),
+        )
+        context_aggregator = LLMContextAggregatorPair(
+            context, user_params=user_params
+        )
+        user_context_aggregator = context_aggregator.user()
+
+        # Minimal listen-only pipeline: input → STT → detector → user aggregator
+        # → llm_gate → output. No main LLM/TTS/engine, so the bot stays silent.
+        pipeline = Pipeline(
+            [
+                transport.input(),
+                stt,
+                voicemail_detector.detector(),
+                user_context_aggregator,
+                voicemail_detector.llm_gate(),
+                transport.output(),
+            ]
+        )
+
+        task = create_pipeline_task(pipeline, workflow_run_id, audio_config)
+
+        orchestrator = get_smart_voicemail_orchestrator()
+
+        @voicemail_detector.event_handler("on_conversation_detected")
+        async def _on_human(_processor):
+            logger.info(
+                f"[run {workflow_run_id}] screening: human (conversation) detected"
+            )
+            await orchestrator.on_screening_result(workflow_run_id, "human")
+            await task.cancel(reason="smart_voicemail_screening_resolved")
+
+        @voicemail_detector.event_handler("on_voicemail_detected")
+        async def _on_voicemail(_processor):
+            logger.info(f"[run {workflow_run_id}] screening: voicemail detected")
+            await orchestrator.on_screening_result(workflow_run_id, "voicemail")
+            await task.cancel(reason="smart_voicemail_screening_resolved")
+
+        await run_pipeline_worker(task)
+        logger.info(f"Screening task completed for run {workflow_run_id}")
+    except asyncio.CancelledError:
+        logger.warning(
+            f"[run {workflow_run_id}] Received CancelledError in screening pipeline"
+        )
+    except Exception as e:
+        logger.error(
+            f"[run {workflow_run_id}] Error in {provider_name} screening pipeline: {e}",
             exc_info=True,
         )
         raise

--- a/api/services/telephony/providers/vonage/provider.py
+++ b/api/services/telephony/providers/vonage/provider.py
@@ -343,12 +343,16 @@ class VonageProvider(TelephonyProvider):
                 await websocket.close(code=4404, reason="Workflow not found")
                 return
 
-            # Extract call UUID from workflow run context
-            call_uuid = (
-                workflow_run.gathered_context.get("call_uuid")
-                if workflow_run.gathered_context
-                else None
-            )
+            # Extract call UUID from workflow run context.
+            # Outbound calls stamp ``call_uuid`` (provider-specific name);
+            # inbound calls go through ``_create_inbound_workflow_run`` which
+            # stores the same value under the generic ``call_id`` key. Fall
+            # back to ``call_id`` so inbound also resolves.
+            call_uuid = None
+            if workflow_run.gathered_context:
+                call_uuid = workflow_run.gathered_context.get(
+                    "call_uuid"
+                ) or workflow_run.gathered_context.get("call_id")
 
             if not call_uuid:
                 logger.error(
@@ -399,8 +403,37 @@ class VonageProvider(TelephonyProvider):
     ) -> bool:
         """
         Determine if this provider can handle the incoming webhook.
+
+        Vonage inbound webhooks carry:
+        - ``conversation_uuid`` prefixed with ``CON-`` (unique to Vonage)
+        - ``uuid`` (call leg id) — distinct from Twilio's ``CallSid`` and
+          Telnyx's nested ``data.payload.call_control_id``
+        - ``region_url`` containing ``vonage.com`` (when present)
+        Status callbacks carry the same ``conversation_uuid``.
         """
+        conv = webhook_data.get("conversation_uuid")
+        if isinstance(conv, str) and conv.startswith("CON-"):
+            return True
+        region = webhook_data.get("region_url", "")
+        if isinstance(region, str) and "vonage.com" in region:
+            return True
         return False
+
+    @classmethod
+    def generate_validation_error_response(cls, error):
+        """Vonage-shaped (NCCO JSON list) hangup response on validation failure.
+
+        Vonage requires a JSON NCCO. Without this, the ``/inbound/run``
+        dispatcher crashed on the validation-error path with
+        ``AttributeError: type object 'VonageProvider' has no attribute
+        'generate_validation_error_response'`` and fell back to the generic
+        TwiML ``<Response><Hangup/></Response>``, which Vonage rejects as
+        ``no NCCOs available`` / ``Callee currently unavailable``.
+        """
+        from fastapi.responses import JSONResponse
+
+        # Empty NCCO list — Vonage hangs up cleanly.
+        return JSONResponse(content=[])
 
     @staticmethod
     def parse_inbound_webhook(webhook_data: Dict[str, Any]) -> NormalizedInboundData:
@@ -412,7 +445,10 @@ class VonageProvider(TelephonyProvider):
             call_id=webhook_data.get("uuid", ""),
             from_number=webhook_data.get("from", ""),
             to_number=webhook_data.get("to", ""),
-            direction=webhook_data.get("direction", ""),
+            # Vonage's answer-URL POST payload omits ``direction``; this
+            # method is only invoked on the inbound dispatch path, so the
+            # default is safe.
+            direction=webhook_data.get("direction") or "inbound",
             call_status=webhook_data.get("status", ""),
             account_id=webhook_data.get("account_id"),
             from_country=None,
@@ -561,13 +597,22 @@ class VonageProvider(TelephonyProvider):
         """
         Generate NCCO response for inbound Vonage webhook.
         """
-        # Minimalist NCCO response for interface compliance
+        # NCCO that connects the inbound call to Dograh's WebSocket pipeline.
+        # 16 kHz Linear PCM is Vonage's expected websocket-transport format
+        # and matches what ``get_webhook_response`` (the outbound NCCO route)
+        # already emits.
         ncco_response = [
             {
-                "action": "talk",
-                "text": "Vonage inbound calls are not currently supported.",
-            },
-            {"action": "hangup"},
+                "action": "connect",
+                "endpoint": [
+                    {
+                        "type": "websocket",
+                        "uri": websocket_url,
+                        "content-type": "audio/l16;rate=16000",
+                        "headers": {},
+                    }
+                ],
+            }
         ]
 
         return Response(

--- a/api/services/telephony/providers/vonage/provider.py
+++ b/api/services/telephony/providers/vonage/provider.py
@@ -636,6 +636,188 @@ class VonageProvider(TelephonyProvider):
 
         return Response(content=json.dumps(error_ncco), media_type="application/json")
 
+    # ======== SMART VOICEMAIL: LOW-LEVEL CALL CONTROL ========
+
+    @staticmethod
+    def _strip_plus(number: str) -> str:
+        return number.replace("+", "") if number else number
+
+    async def place_call_with_ncco(
+        self,
+        *,
+        to_number: str,
+        from_number: str,
+        ncco: List[Dict[str, Any]],
+        event_url: Optional[str] = None,
+        ringing_timer: Optional[int] = None,
+        fallback_from: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Place an outbound call answered by an inline NCCO (no answer_url).
+
+        Used by the smart-voicemail screening leg. ``fallback_from`` retries the
+        call with our own DID if Vonage rejects ``from_number`` (e.g. when using
+        the original caller's number as caller ID is not permitted for the
+        account/region).
+
+        Returns the Vonage call-create response (includes ``uuid``).
+        """
+        if not self.validate_config():
+            raise ValueError("Vonage provider not properly configured")
+
+        endpoint = f"{self.base_url}/v1/calls"
+
+        def _build(from_num: str) -> Dict[str, Any]:
+            data: Dict[str, Any] = {
+                "to": [{"type": "phone", "number": self._strip_plus(to_number)}],
+                "from": {"type": "phone", "number": self._strip_plus(from_num)},
+                "ncco": ncco,
+            }
+            if event_url:
+                data["event_url"] = [event_url]
+                data["event_method"] = "POST"
+            if ringing_timer is not None:
+                # Vonage accepts 1-60s; clamp so a larger configured timeout
+                # doesn't get rejected.
+                data["ringing_timer"] = max(1, min(int(ringing_timer), 60))
+            return data
+
+        headers = self._get_auth_headers()
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                endpoint, json=_build(from_number), headers=headers
+            ) as response:
+                response_data = await response.json()
+                if response.status == 201:
+                    return response_data
+
+                # Retry once with our own DID if the caller-ID was rejected.
+                if fallback_from and fallback_from != from_number:
+                    logger.warning(
+                        f"Vonage rejected from={from_number} for screening call "
+                        f"({response.status}: {response_data}); retrying with "
+                        f"fallback {fallback_from}"
+                    )
+                else:
+                    raise HTTPException(
+                        status_code=response.status,
+                        detail=f"Failed to place Vonage call: {response_data}",
+                    )
+
+            async with session.post(
+                endpoint, json=_build(fallback_from), headers=headers
+            ) as response:
+                response_data = await response.json()
+                if response.status != 201:
+                    raise HTTPException(
+                        status_code=response.status,
+                        detail=f"Failed to place Vonage call: {response_data}",
+                    )
+                return response_data
+
+    async def transfer_leg_to_ncco(
+        self, call_uuid: str, ncco: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Transfer a live leg to a new inline NCCO (PUT /v1/calls/{uuid})."""
+        endpoint = f"{self.base_url}/v1/calls/{call_uuid}"
+        body = {"action": "transfer", "destination": {"type": "ncco", "ncco": ncco}}
+        headers = self._get_auth_headers()
+        async with aiohttp.ClientSession() as session:
+            async with session.put(endpoint, json=body, headers=headers) as response:
+                if response.status not in (200, 204):
+                    detail = await response.text()
+                    raise HTTPException(
+                        status_code=response.status,
+                        detail=f"Failed to transfer Vonage leg {call_uuid}: {detail}",
+                    )
+                return {"status": "ok", "call_uuid": call_uuid}
+
+    async def hangup_leg(self, call_uuid: str) -> Dict[str, Any]:
+        """Hang up a live leg (PUT /v1/calls/{uuid} {action: hangup})."""
+        endpoint = f"{self.base_url}/v1/calls/{call_uuid}"
+        headers = self._get_auth_headers()
+        async with aiohttp.ClientSession() as session:
+            async with session.put(
+                endpoint, json={"action": "hangup"}, headers=headers
+            ) as response:
+                if response.status not in (200, 204):
+                    detail = await response.text()
+                    logger.warning(
+                        f"Vonage hangup for leg {call_uuid} returned "
+                        f"{response.status}: {detail}"
+                    )
+                return {"status": "ok", "call_uuid": call_uuid}
+
+    # ---- NCCO builders for the smart-voicemail flow ----
+
+    @staticmethod
+    def build_caller_hold_ncco(
+        conference_name: str, music_on_hold_url: Optional[str]
+    ) -> List[Dict[str, Any]]:
+        """Park the caller in a private conference hearing ringback/MOH.
+
+        ``startOnEnter=False`` keeps the conference from "starting" while the
+        caller is alone, so the MOH keeps playing until the human leg is
+        transferred in (which joins with ``startOnEnter=True``).
+        """
+        action: Dict[str, Any] = {
+            "action": "conversation",
+            "name": conference_name,
+            "startOnEnter": False,
+            "endOnExit": True,
+        }
+        if music_on_hold_url:
+            action["musicOnHoldUrl"] = [music_on_hold_url]
+        return [action]
+
+    @staticmethod
+    def build_screening_connect_ncco(
+        screening_ws_url: str,
+    ) -> List[Dict[str, Any]]:
+        """Connect the human (screening) leg to the listen-only AI pipeline."""
+        return [
+            {
+                "action": "connect",
+                "endpoint": [
+                    {
+                        "type": "websocket",
+                        "uri": screening_ws_url,
+                        "content-type": "audio/l16;rate=16000",
+                        "headers": {},
+                    }
+                ],
+            }
+        ]
+
+    @staticmethod
+    def build_join_conference_ncco(conference_name: str) -> List[Dict[str, Any]]:
+        """Join the caller's conference (human confirmed → bridge)."""
+        return [
+            {
+                "action": "conversation",
+                "name": conference_name,
+                "startOnEnter": True,
+                "endOnExit": True,
+            }
+        ]
+
+    @staticmethod
+    def build_ai_connect_ncco(ai_ws_url: str) -> List[Dict[str, Any]]:
+        """Connect the caller to the real AI workflow websocket (voicemail/no-answer)."""
+        return [
+            {
+                "action": "connect",
+                "endpoint": [
+                    {
+                        "type": "websocket",
+                        "uri": ai_ws_url,
+                        "content-type": "audio/l16;rate=16000",
+                        "headers": {},
+                    }
+                ],
+            }
+        ]
+
     # ======== CALL TRANSFER METHODS ========
 
     async def transfer_call(
@@ -646,19 +828,20 @@ class VonageProvider(TelephonyProvider):
         timeout: int = 30,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        """
-        Vonage provider does not support call transfers.
+        """Transfer a live leg into a named Vonage conversation (conference).
 
-        Raises:
-            NotImplementedError: call transfers are yet to be implemented
+        ``destination`` is the Vonage call UUID of the leg to move (Vonage
+        transfers an existing leg rather than dialing a number here). The leg
+        joins ``conference_name`` via an inline NCCO.
         """
-        raise NotImplementedError("Vonage provider does not support call transfers")
+        await self.transfer_leg_to_ncco(
+            destination, self.build_join_conference_ncco(conference_name)
+        )
+        return {
+            "call_sid": destination,
+            "status": "transferred",
+            "provider": self.PROVIDER_NAME,
+        }
 
     def supports_transfers(self) -> bool:
-        """
-        Vonage does not support call transfers.
-
-        Returns:
-            False - Vonage provider does not support call transfers
-        """
-        return False
+        return True

--- a/api/services/telephony/providers/vonage/provider.py
+++ b/api/services/telephony/providers/vonage/provider.py
@@ -651,6 +651,7 @@ class VonageProvider(TelephonyProvider):
         event_url: Optional[str] = None,
         ringing_timer: Optional[int] = None,
         fallback_from: Optional[str] = None,
+        advanced_machine_detection: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Place an outbound call answered by an inline NCCO (no answer_url).
 
@@ -679,6 +680,8 @@ class VonageProvider(TelephonyProvider):
                 # Vonage accepts 1-60s; clamp so a larger configured timeout
                 # doesn't get rejected.
                 data["ringing_timer"] = max(1, min(int(ringing_timer), 60))
+            if advanced_machine_detection:
+                data["advanced_machine_detection"] = advanced_machine_detection
             return data
 
         headers = self._get_auth_headers()
@@ -786,6 +789,21 @@ class VonageProvider(TelephonyProvider):
                         "headers": {},
                     }
                 ],
+            }
+        ]
+
+    @staticmethod
+    def build_human_hold_ncco(hold_conference_name: str) -> List[Dict[str, Any]]:
+        """Hold the human (screening) leg in a private, silent conference while
+        Vonage Advanced Machine Detection runs. Isolated from the caller's
+        conference so they hear nothing until we bridge or drop them.
+        """
+        return [
+            {
+                "action": "conversation",
+                "name": hold_conference_name,
+                "startOnEnter": True,
+                "endOnExit": True,
             }
         ]
 

--- a/api/services/telephony/providers/vonage/routes.py
+++ b/api/services/telephony/providers/vonage/routes.py
@@ -135,7 +135,13 @@ async def handle_vonage_smart_voicemail_events(
     )
 
     orchestrator = get_smart_voicemail_orchestrator()
-    if status == "answered":
+    if status == "human":
+        # Vonage Advanced Machine Detection: a person answered.
+        await orchestrator.on_screening_result(workflow_run_id, "human")
+    elif status == "machine":
+        # Vonage AMD: voicemail/answerphone answered.
+        await orchestrator.on_screening_result(workflow_run_id, "voicemail")
+    elif status == "answered":
         await orchestrator.on_screening_answered(workflow_run_id)
     elif status in _SCREENING_NO_ANSWER_STATUSES:
         await orchestrator.on_screening_result(workflow_run_id, "no_answer")

--- a/api/services/telephony/providers/vonage/routes.py
+++ b/api/services/telephony/providers/vonage/routes.py
@@ -95,3 +95,49 @@ async def handle_vonage_events(
 
     # Return 204 No Content as expected by Vonage
     return {"status": "ok"}
+
+
+# Vonage raw statuses that mean "the human leg will not be answered by a person"
+# — hand the caller to the AI.
+_SCREENING_NO_ANSWER_STATUSES = {
+    "complete",
+    "timeout",
+    "unanswered",
+    "failed",
+    "rejected",
+    "busy",
+    "cancelled",
+}
+
+
+@router.post("/vonage/smart-voicemail/events/{workflow_run_id}")
+async def handle_vonage_smart_voicemail_events(
+    request: Request,
+    workflow_run_id: int,
+):
+    """Event webhook for the smart-voicemail *screening* leg (human number).
+
+    Drives the screen-and-forward decision from leg state. Voicemail-vs-human is
+    detected by our own pipeline (the listen-only screening websocket); this
+    route only handles the call-state signals the pipeline can't see:
+    ``answered`` (arm the silent-pickup watchdog) and the no-answer terminals.
+    The orchestrator's latch makes whichever signal lands first authoritative.
+    """
+    from api.services.telephony.smart_voicemail import (
+        get_smart_voicemail_orchestrator,
+    )
+
+    set_current_run_id(workflow_run_id)
+    event_data = await request.json()
+    status = (event_data or {}).get("status", "")
+    logger.info(
+        f"[run {workflow_run_id}] smart-voicemail screening event: {status}"
+    )
+
+    orchestrator = get_smart_voicemail_orchestrator()
+    if status == "answered":
+        await orchestrator.on_screening_answered(workflow_run_id)
+    elif status in _SCREENING_NO_ANSWER_STATUSES:
+        await orchestrator.on_screening_result(workflow_run_id, "no_answer")
+
+    return {"status": "ok"}

--- a/api/services/telephony/providers/vonage/routes.py
+++ b/api/services/telephony/providers/vonage/routes.py
@@ -130,8 +130,10 @@ async def handle_vonage_smart_voicemail_events(
     set_current_run_id(workflow_run_id)
     event_data = await request.json()
     status = (event_data or {}).get("status", "")
+    # Log the full payload — on failure Vonage carries the reason/detail here.
     logger.info(
-        f"[run {workflow_run_id}] smart-voicemail screening event: {status}"
+        f"[run {workflow_run_id}] smart-voicemail screening event: {status} "
+        f"| payload={event_data}"
     )
 
     orchestrator = get_smart_voicemail_orchestrator()

--- a/api/services/telephony/smart_voicemail.py
+++ b/api/services/telephony/smart_voicemail.py
@@ -105,9 +105,19 @@ class SmartVoicemailOrchestrator:
         """
         forward_to = smart_voicemail_config.get("forward_to_number")
         ring_timeout = int(smart_voicemail_config.get("ring_timeout_seconds", 25))
+        detection = smart_voicemail_config.get("detection", "vonage")
         conference_name = f"sv-{workflow_run_id}"
         caller_leg_uuid = normalized_data.call_id
-        caller_id = normalized_data.from_number  # original caller's number
+
+        # Dial the screening leg FROM our own Vonage DID. Vonage rejects an
+        # un-owned number as caller ID for outbound PSTN — the create returns
+        # 201 and the call then immediately goes to "failed" — so we cannot
+        # present the original caller's number here.
+        our_did = (
+            provider.from_numbers[0]
+            if getattr(provider, "from_numbers", None)
+            else None
+        )
 
         screening_ws_url = (
             f"{wss_backend_endpoint}/api/v1/telephony/ws/screening/"
@@ -122,9 +132,16 @@ class SmartVoicemailOrchestrator:
             f"{workflow_run_id}"
         )
 
-        fallback_from = (
-            provider.from_numbers[0] if getattr(provider, "from_numbers", None) else None
-        )
+        # Detection source decides what the human (screening) leg connects to:
+        #  - "own"    → our listen-only websocket pipeline (VoicemailDetector)
+        #  - "vonage" → a silent hold conference + Vonage Advanced Machine
+        #               Detection; the human/machine webhook drives the result.
+        if detection == "own":
+            screening_ncco = provider.build_screening_connect_ncco(screening_ws_url)
+            amd = None
+        else:
+            screening_ncco = provider.build_human_hold_ncco(f"svhold-{workflow_run_id}")
+            amd = {"behavior": "continue", "mode": "default"}
 
         state: Dict[str, Any] = {
             "organization_id": organization_id,
@@ -137,17 +154,18 @@ class SmartVoicemailOrchestrator:
             "screening_leg_uuid": None,
             "forward_to_number": forward_to,
             "ai_ws_url": ai_ws_url,
+            "detection": detection,
         }
         await self._store_state(workflow_run_id, state)
 
         try:
             resp = await provider.place_call_with_ncco(
                 to_number=forward_to,
-                from_number=caller_id,
-                ncco=provider.build_screening_connect_ncco(screening_ws_url),
+                from_number=our_did,
+                ncco=screening_ncco,
                 event_url=event_url,
                 ringing_timer=ring_timeout,
-                fallback_from=fallback_from,
+                advanced_machine_detection=amd,
             )
             state["screening_leg_uuid"] = resp.get("uuid")
             await self._store_state(workflow_run_id, state)
@@ -223,9 +241,18 @@ class SmartVoicemailOrchestrator:
         await self._cleanup(workflow_run_id)
 
     async def on_screening_answered(self, workflow_run_id: int) -> None:
-        """Arm a watchdog: if the detector never fires after a silent pick-up,
-        default to a human bridge."""
+        """For the built-in detector, arm a watchdog: if it never fires after a
+        silent pick-up, default to a human bridge.
+
+        For Vonage AMD the human/machine webhook always resolves, so no watchdog
+        is needed — and one would risk bridging a voicemail before AMD reports a
+        machine. Skip it unless detection is ``own``.
+        """
         import asyncio
+
+        state = await self._load_state(workflow_run_id)
+        if not state or state.get("detection", "vonage") != "own":
+            return
 
         async def _watchdog():
             await asyncio.sleep(SILENT_ANSWER_TIMEOUT_S)

--- a/api/services/telephony/smart_voicemail.py
+++ b/api/services/telephony/smart_voicemail.py
@@ -141,7 +141,9 @@ class SmartVoicemailOrchestrator:
             amd = None
         else:
             screening_ncco = provider.build_human_hold_ncco(f"svhold-{workflow_run_id}")
-            amd = {"behavior": "continue", "mode": "default"}
+            # beep_timeout is required in [30, 120] whenever
+            # advanced_machine_detection is present (Vonage 400s otherwise).
+            amd = {"behavior": "continue", "mode": "default", "beep_timeout": 45}
 
         state: Dict[str, Any] = {
             "organization_id": organization_id,

--- a/api/services/telephony/smart_voicemail.py
+++ b/api/services/telephony/smart_voicemail.py
@@ -141,9 +141,13 @@ class SmartVoicemailOrchestrator:
             amd = None
         else:
             screening_ncco = provider.build_human_hold_ncco(f"svhold-{workflow_run_id}")
-            # beep_timeout is required in [30, 120] whenever
-            # advanced_machine_detection is present (Vonage 400s otherwise).
-            amd = {"behavior": "continue", "mode": "default", "beep_timeout": 45}
+            # mode "detect" = SYNCHRONOUS detection: AMD analyzes the clean
+            # answered leg and fires the human/machine webhook BEFORE the NCCO
+            # (the hold-conference join) runs. Async "default" lets the
+            # conference join run during analysis, which disrupts AMD and makes
+            # it misfire "machine" on a real human. beep_timeout is required in
+            # [30,120] whenever advanced_machine_detection is present.
+            amd = {"behavior": "continue", "mode": "detect", "beep_timeout": 45}
 
         state: Dict[str, Any] = {
             "organization_id": organization_id,

--- a/api/services/telephony/smart_voicemail.py
+++ b/api/services/telephony/smart_voicemail.py
@@ -1,0 +1,267 @@
+"""Smart-voicemail screening orchestrator (Strategy B).
+
+Coordinates the inbound "screen-and-forward" flow for a single workflow run:
+
+1. ``start()`` — park the caller in a private Vonage conference (hearing
+   ringback), place an outbound *screening* leg to the designated human number
+   answered by a listen-only AI pipeline, and persist the leg/conference state
+   in Redis.
+2. ``on_screening_result()`` — the terminal decision, called from either the
+   screening pipeline's voicemail detector or the screening leg's Vonage event
+   webhook (no-answer/busy/failed):
+   - ``human``     → transfer the human leg into the caller's conference (bridge).
+   - ``voicemail`` / ``no_answer`` → hang up the human leg and transfer the
+     caller to the real AI workflow websocket.
+
+The detector result and the no-answer event can race; a Redis SETNX latch
+(``sv:resolved:{run}``) makes the first result win and the rest no-ops.
+
+State only holds leg UUIDs, ids and URLs — provider credentials are reloaded
+per action via the factory, scoped to the run's org + telephony config.
+"""
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+import redis.asyncio as aioredis
+from loguru import logger
+
+from api.constants import REDIS_URL
+from api.enums import WorkflowRunState
+
+# Ringback / hold audio the caller hears while we screen the human leg. Must be
+# a publicly reachable mp3. Falls back to silence (no MOH) when unset.
+SMART_VOICEMAIL_RINGBACK_URL = os.getenv("SMART_VOICEMAIL_RINGBACK_URL") or None
+
+# Default time to wait after the human answers but before the detector fires
+# (silent pick-up) before defaulting to a human bridge.
+SILENT_ANSWER_TIMEOUT_S = 8.0
+
+_STATE_TTL_S = 600  # 10 minutes — longer than any reasonable screening window
+
+
+def _state_key(run_id: int) -> str:
+    return f"sv:run:{run_id}"
+
+
+def _latch_key(run_id: int) -> str:
+    return f"sv:resolved:{run_id}"
+
+
+class SmartVoicemailOrchestrator:
+    def __init__(self, redis_client: Optional[aioredis.Redis] = None):
+        self._redis = redis_client
+
+    async def _get_redis(self) -> aioredis.Redis:
+        if self._redis is None:
+            self._redis = await aioredis.from_url(REDIS_URL, decode_responses=True)
+        return self._redis
+
+    async def _store_state(self, run_id: int, state: Dict[str, Any]) -> None:
+        redis = await self._get_redis()
+        await redis.setex(_state_key(run_id), _STATE_TTL_S, json.dumps(state))
+
+    async def _load_state(self, run_id: int) -> Optional[Dict[str, Any]]:
+        redis = await self._get_redis()
+        raw = await redis.get(_state_key(run_id))
+        return json.loads(raw) if raw else None
+
+    async def get_state(self, run_id: int) -> Optional[Dict[str, Any]]:
+        """Read-only accessor for the persisted screening state of a run.
+
+        Used by the screening websocket route to resolve the screening leg's
+        Vonage call UUID before building the listen-only pipeline. Returns the
+        same dict shape stored by ``start()`` (or ``None`` if absent/expired).
+        """
+        return await self._load_state(run_id)
+
+    async def _claim_resolution(self, run_id: int, result: str) -> bool:
+        """Return True iff this caller won the race to resolve the screening."""
+        redis = await self._get_redis()
+        won = await redis.set(_latch_key(run_id), result, nx=True, ex=_STATE_TTL_S)
+        return bool(won)
+
+    # ------------------------------------------------------------------
+    async def start(
+        self,
+        *,
+        provider,
+        smart_voicemail_config: Dict[str, Any],
+        normalized_data,
+        organization_id: int,
+        telephony_configuration_id: int,
+        workflow_id: int,
+        user_id: int,
+        workflow_run_id: int,
+        backend_endpoint: str,
+        wss_backend_endpoint: str,
+    ) -> list:
+        """Begin screening. Returns the NCCO (list) to answer the *caller* with.
+
+        On any failure placing the screening leg, degrades gracefully to
+        connecting the caller straight to the AI workflow websocket so the call
+        is never dropped.
+        """
+        forward_to = smart_voicemail_config.get("forward_to_number")
+        ring_timeout = int(smart_voicemail_config.get("ring_timeout_seconds", 25))
+        conference_name = f"sv-{workflow_run_id}"
+        caller_leg_uuid = normalized_data.call_id
+        caller_id = normalized_data.from_number  # original caller's number
+
+        screening_ws_url = (
+            f"{wss_backend_endpoint}/api/v1/telephony/ws/screening/"
+            f"{workflow_id}/{user_id}/{workflow_run_id}"
+        )
+        ai_ws_url = (
+            f"{wss_backend_endpoint}/api/v1/telephony/ws/"
+            f"{workflow_id}/{user_id}/{workflow_run_id}"
+        )
+        event_url = (
+            f"{backend_endpoint}/api/v1/telephony/vonage/smart-voicemail/events/"
+            f"{workflow_run_id}"
+        )
+
+        fallback_from = (
+            provider.from_numbers[0] if getattr(provider, "from_numbers", None) else None
+        )
+
+        state: Dict[str, Any] = {
+            "organization_id": organization_id,
+            "telephony_configuration_id": telephony_configuration_id,
+            "workflow_id": workflow_id,
+            "user_id": user_id,
+            "workflow_run_id": workflow_run_id,
+            "caller_leg_uuid": caller_leg_uuid,
+            "conference_name": conference_name,
+            "screening_leg_uuid": None,
+            "forward_to_number": forward_to,
+            "ai_ws_url": ai_ws_url,
+        }
+        await self._store_state(workflow_run_id, state)
+
+        try:
+            resp = await provider.place_call_with_ncco(
+                to_number=forward_to,
+                from_number=caller_id,
+                ncco=provider.build_screening_connect_ncco(screening_ws_url),
+                event_url=event_url,
+                ringing_timer=ring_timeout,
+                fallback_from=fallback_from,
+            )
+            state["screening_leg_uuid"] = resp.get("uuid")
+            await self._store_state(workflow_run_id, state)
+            logger.info(
+                f"[run {workflow_run_id}] smart-voicemail screening leg placed "
+                f"to {forward_to} (uuid={state['screening_leg_uuid']})"
+            )
+        except Exception as e:
+            logger.error(
+                f"[run {workflow_run_id}] failed to place screening leg: {e}; "
+                f"connecting caller directly to AI"
+            )
+            # Degrade: AI answers the caller directly.
+            return provider.build_ai_connect_ncco(ai_ws_url)
+
+        return provider.build_caller_hold_ncco(
+            conference_name, SMART_VOICEMAIL_RINGBACK_URL
+        )
+
+    # ------------------------------------------------------------------
+    async def on_screening_result(self, workflow_run_id: int, result: str) -> None:
+        """Terminal decision. ``result`` ∈ {"human", "voicemail", "no_answer"}.
+
+        Idempotent: only the first caller to claim the latch acts.
+        """
+        if not await self._claim_resolution(workflow_run_id, result):
+            logger.info(
+                f"[run {workflow_run_id}] smart-voicemail already resolved; "
+                f"ignoring late '{result}'"
+            )
+            return
+
+        state = await self._load_state(workflow_run_id)
+        if not state:
+            logger.warning(
+                f"[run {workflow_run_id}] no smart-voicemail state for '{result}'"
+            )
+            return
+
+        from api.services.telephony.factory import get_telephony_provider_by_id
+
+        provider = await get_telephony_provider_by_id(
+            state["telephony_configuration_id"], state["organization_id"]
+        )
+
+        screening_leg = state.get("screening_leg_uuid")
+        caller_leg = state.get("caller_leg_uuid")
+        conference_name = state["conference_name"]
+
+        if result == "human":
+            # Bridge: move the human leg into the caller's conference.
+            if screening_leg:
+                await provider.transfer_leg_to_ncco(
+                    screening_leg, provider.build_join_conference_ncco(conference_name)
+                )
+            logger.info(
+                f"[run {workflow_run_id}] human answered — bridged to conference "
+                f"{conference_name}"
+            )
+            await self._mark_transferred(workflow_run_id)
+        else:
+            # voicemail / no_answer → drop the human leg, hand caller to the AI.
+            if screening_leg:
+                await provider.hangup_leg(screening_leg)
+            if caller_leg:
+                await provider.transfer_leg_to_ncco(
+                    caller_leg, provider.build_ai_connect_ncco(state["ai_ws_url"])
+                )
+            logger.info(
+                f"[run {workflow_run_id}] '{result}' — caller handed to AI workflow"
+            )
+
+        await self._cleanup(workflow_run_id)
+
+    async def on_screening_answered(self, workflow_run_id: int) -> None:
+        """Arm a watchdog: if the detector never fires after a silent pick-up,
+        default to a human bridge."""
+        import asyncio
+
+        async def _watchdog():
+            await asyncio.sleep(SILENT_ANSWER_TIMEOUT_S)
+            await self.on_screening_result(workflow_run_id, "human")
+
+        asyncio.create_task(_watchdog())
+
+    # ------------------------------------------------------------------
+    async def _mark_transferred(self, workflow_run_id: int) -> None:
+        """Best-effort: the AI never runs on a human bridge, so close the run."""
+        try:
+            from api.db import db_client
+
+            await db_client.update_workflow_run(
+                run_id=workflow_run_id,
+                state=WorkflowRunState.COMPLETED.value,
+                gathered_context={"smart_voicemail_outcome": "transferred_to_human"},
+            )
+        except Exception as e:
+            logger.warning(
+                f"[run {workflow_run_id}] failed to mark run transferred: {e}"
+            )
+
+    async def _cleanup(self, workflow_run_id: int) -> None:
+        try:
+            redis = await self._get_redis()
+            await redis.delete(_state_key(workflow_run_id))
+        except Exception as e:
+            logger.warning(f"[run {workflow_run_id}] smart-voicemail cleanup: {e}")
+
+
+_orchestrator: Optional[SmartVoicemailOrchestrator] = None
+
+
+def get_smart_voicemail_orchestrator() -> SmartVoicemailOrchestrator:
+    global _orchestrator
+    if _orchestrator is None:
+        _orchestrator = SmartVoicemailOrchestrator()
+    return _orchestrator

--- a/api/services/telephony/smart_voicemail.py
+++ b/api/services/telephony/smart_voicemail.py
@@ -140,14 +140,16 @@ class SmartVoicemailOrchestrator:
             screening_ncco = provider.build_screening_connect_ncco(screening_ws_url)
             amd = None
         else:
-            screening_ncco = provider.build_human_hold_ncco(f"svhold-{workflow_run_id}")
-            # mode "detect" = SYNCHRONOUS detection: AMD analyzes the clean
-            # answered leg and fires the human/machine webhook BEFORE the NCCO
-            # (the hold-conference join) runs. Async "default" lets the
-            # conference join run during analysis, which disrupts AMD and makes
-            # it misfire "machine" on a real human. beep_timeout is required in
-            # [30,120] whenever advanced_machine_detection is present.
-            amd = {"behavior": "continue", "mode": "detect", "beep_timeout": 45}
+            # Join the CALLER's conference directly — one conversation action,
+            # no intermediate hold + transfer. Routing the human through a hold
+            # conference and then transferring left the two legs in DIFFERENT
+            # conversation instances (extra transfer hops), so they never shared
+            # audio. behavior "hangup" drops a machine BEFORE this NCCO runs, so
+            # a voicemail is never bridged to the caller; "detect" is
+            # synchronous so AMD reads the clean answered leg before the join.
+            # beep_timeout is required in [30,120] whenever AMD is present.
+            screening_ncco = provider.build_join_conference_ncco(conference_name)
+            amd = {"behavior": "hangup", "mode": "detect", "beep_timeout": 45}
 
         state: Dict[str, Any] = {
             "organization_id": organization_id,
@@ -222,8 +224,12 @@ class SmartVoicemailOrchestrator:
         conference_name = state["conference_name"]
 
         if result == "human":
-            # Bridge: move the human leg into the caller's conference.
-            if screening_leg:
+            # For the built-in detector the human leg is on our websocket, so it
+            # must be moved into the caller's conference. For Vonage AMD the
+            # human leg already joined the conference via its own answer NCCO
+            # (behavior=hangup guarantees only a human reaches that join), so
+            # there is nothing to transfer.
+            if state.get("detection") == "own" and screening_leg:
                 await provider.transfer_leg_to_ncco(
                     screening_leg, provider.build_join_conference_ncco(conference_name)
                 )

--- a/api/tests/telephony/test_smart_voicemail.py
+++ b/api/tests/telephony/test_smart_voicemail.py
@@ -127,7 +127,7 @@ def _provider_with_mocked_io():
     return prov
 
 
-async def _seed_state(orch, run_id=1):
+async def _seed_state(orch, run_id=1, detection="own"):
     await orch._store_state(
         run_id,
         {
@@ -141,6 +141,7 @@ async def _seed_state(orch, run_id=1):
             "screening_leg_uuid": "screen-leg",
             "forward_to_number": "+14155551234",
             "ai_ws_url": "wss://x/api/v1/telephony/ws/33/44/1",
+            "detection": detection,
         },
     )
 
@@ -217,17 +218,35 @@ async def test_start_dials_from_our_did_not_caller():
     assert ncco[0]["action"] == "conversation"
 
 
-async def test_start_vonage_detection_uses_amd_and_hold_conf():
+async def test_start_vonage_detection_joins_caller_conf_with_hangup_amd():
     orch = SmartVoicemailOrchestrator(redis_client=_FakeRedis())
     prov, _ = await _run_start(orch, "vonage")
     kw = prov.place_call_with_ncco.await_args.kwargs
+    # Synchronous detect + hangup-on-machine so a voicemail never reaches the
+    # conference join.
     assert kw["advanced_machine_detection"] == {
-        "behavior": "continue",
+        "behavior": "hangup",
         "mode": "detect",
         "beep_timeout": 45,
     }
-    # Human leg holds in a silent conference (not our websocket).
+    # Human leg joins the CALLER's conference directly (one conversation action,
+    # no intermediate hold + transfer).
     assert kw["ncco"][0]["action"] == "conversation"
+    assert kw["ncco"][0]["name"] == "sv-99"
+    assert kw["ncco"][0]["startOnEnter"] is True
+
+
+async def test_vonage_human_does_not_transfer():
+    orch = SmartVoicemailOrchestrator(redis_client=_FakeRedis())
+    await _seed_state(orch, detection="vonage")
+    prov = _provider_with_mocked_io()
+    with patch(
+        "api.services.telephony.factory.get_telephony_provider_by_id",
+        AsyncMock(return_value=prov),
+    ), patch.object(_db_singleton, "update_workflow_run", AsyncMock()):
+        await orch.on_screening_result(1, "human")
+    # The Vonage human leg already joined the conference via its answer NCCO.
+    prov.transfer_leg_to_ncco.assert_not_awaited()
 
 
 async def test_start_own_detection_connects_websocket_no_amd():

--- a/api/tests/telephony/test_smart_voicemail.py
+++ b/api/tests/telephony/test_smart_voicemail.py
@@ -4,6 +4,8 @@ Covers the three pure/unit-testable surfaces: config validation, the Vonage
 NCCO builders, and the orchestrator's idempotent resolution latch + branch.
 """
 
+from types import SimpleNamespace
+
 import pytest
 from pydantic import ValidationError
 from unittest.mock import AsyncMock, patch
@@ -178,6 +180,71 @@ async def test_voicemail_result_hangs_up_human_and_hands_caller_to_ai():
     assert args[0] == "caller-leg"
     assert args[1][0]["action"] == "connect"
     assert args[1][0]["endpoint"][0]["uri"] == "wss://x/api/v1/telephony/ws/33/44/1"
+
+
+async def _run_start(orch, detection):
+    prov = _provider_with_mocked_io()
+    prov.place_call_with_ncco = AsyncMock(return_value={"uuid": "screen-1"})
+    nd = SimpleNamespace(call_id="caller-1", from_number="+17373338910")
+    ncco = await orch.start(
+        provider=prov,
+        smart_voicemail_config={
+            "forward_to_number": "+15129701653",
+            "ring_timeout_seconds": 20,
+            "detection": detection,
+        },
+        normalized_data=nd,
+        organization_id=1,
+        telephony_configuration_id=3,
+        workflow_id=5,
+        user_id=1,
+        workflow_run_id=99,
+        backend_endpoint="https://x",
+        wss_backend_endpoint="wss://x",
+    )
+    return prov, ncco
+
+
+async def test_start_dials_from_our_did_not_caller():
+    orch = SmartVoicemailOrchestrator(redis_client=_FakeRedis())
+    prov, ncco = await _run_start(orch, "vonage")
+    kw = prov.place_call_with_ncco.await_args.kwargs
+    # Must dial from our owned DID, never the original caller's number.
+    assert kw["from_number"] == prov.from_numbers[0]
+    assert kw["from_number"] != "+17373338910"
+    assert kw["to_number"] == "+15129701653"
+    # Caller is parked in the ringback/hold conference.
+    assert ncco[0]["action"] == "conversation"
+
+
+async def test_start_vonage_detection_uses_amd_and_hold_conf():
+    orch = SmartVoicemailOrchestrator(redis_client=_FakeRedis())
+    prov, _ = await _run_start(orch, "vonage")
+    kw = prov.place_call_with_ncco.await_args.kwargs
+    assert kw["advanced_machine_detection"] == {"behavior": "continue", "mode": "default"}
+    # Human leg holds in a silent conference (not our websocket).
+    assert kw["ncco"][0]["action"] == "conversation"
+
+
+async def test_start_own_detection_connects_websocket_no_amd():
+    orch = SmartVoicemailOrchestrator(redis_client=_FakeRedis())
+    prov, _ = await _run_start(orch, "own")
+    kw = prov.place_call_with_ncco.await_args.kwargs
+    assert kw["advanced_machine_detection"] is None
+    assert kw["ncco"][0]["action"] == "connect"
+    assert kw["ncco"][0]["endpoint"][0]["type"] == "websocket"
+
+
+def test_human_hold_ncco_is_silent_conference():
+    ncco = VonageProvider.build_human_hold_ncco("svhold-1")
+    assert ncco[0]["action"] == "conversation"
+    assert ncco[0]["name"] == "svhold-1"
+    assert "musicOnHoldUrl" not in ncco[0]
+
+
+def test_detection_defaults_to_vonage():
+    cfg = SmartVoicemailConfig(enabled=True, forward_to_number="+14155551234")
+    assert cfg.detection == "vonage"
 
 
 async def test_latch_makes_first_result_win():

--- a/api/tests/telephony/test_smart_voicemail.py
+++ b/api/tests/telephony/test_smart_voicemail.py
@@ -1,0 +1,200 @@
+"""Unit tests for the smart-voicemail feature.
+
+Covers the three pure/unit-testable surfaces: config validation, the Vonage
+NCCO builders, and the orchestrator's idempotent resolution latch + branch.
+"""
+
+import pytest
+from pydantic import ValidationError
+from unittest.mock import AsyncMock, patch
+
+from api.db import db_client as _db_singleton
+from api.schemas.telephony_phone_number import SmartVoicemailConfig
+from api.services.telephony.providers.vonage.provider import VonageProvider
+from api.services.telephony.smart_voicemail import SmartVoicemailOrchestrator
+
+
+# --------------------------------------------------------------------------
+# SmartVoicemailConfig validation
+# --------------------------------------------------------------------------
+
+
+def test_disabled_config_needs_no_forward_number():
+    cfg = SmartVoicemailConfig(enabled=False)
+    assert cfg.forward_to_number is None
+
+
+def test_enabled_requires_forward_number():
+    with pytest.raises(ValidationError):
+        SmartVoicemailConfig(enabled=True)
+
+
+def test_enabled_normalizes_e164():
+    cfg = SmartVoicemailConfig(enabled=True, forward_to_number="+1 (415) 555-1234")
+    assert cfg.forward_to_number == "+14155551234"
+
+
+def test_enabled_rejects_non_e164():
+    with pytest.raises(ValidationError):
+        SmartVoicemailConfig(enabled=True, forward_to_number="not-a-number")
+
+
+def test_ring_timeout_bounds():
+    with pytest.raises(ValidationError):
+        SmartVoicemailConfig(
+            enabled=True, forward_to_number="+14155551234", ring_timeout_seconds=2
+        )
+
+
+# --------------------------------------------------------------------------
+# Vonage NCCO builders
+# --------------------------------------------------------------------------
+
+
+def test_caller_hold_ncco_with_moh():
+    ncco = VonageProvider.build_caller_hold_ncco("sv-1", "https://x/ring.mp3")
+    assert ncco == [
+        {
+            "action": "conversation",
+            "name": "sv-1",
+            "startOnEnter": False,
+            "endOnExit": True,
+            "musicOnHoldUrl": ["https://x/ring.mp3"],
+        }
+    ]
+
+
+def test_caller_hold_ncco_without_moh_omits_key():
+    ncco = VonageProvider.build_caller_hold_ncco("sv-1", None)
+    assert "musicOnHoldUrl" not in ncco[0]
+    assert ncco[0]["startOnEnter"] is False
+
+
+def test_join_conference_ncco_starts_conversation():
+    ncco = VonageProvider.build_join_conference_ncco("sv-1")
+    assert ncco[0]["action"] == "conversation"
+    assert ncco[0]["name"] == "sv-1"
+    assert ncco[0]["startOnEnter"] is True
+
+
+def test_screening_and_ai_connect_ncco_are_websocket_connects():
+    screen = VonageProvider.build_screening_connect_ncco("wss://x/screen")
+    ai = VonageProvider.build_ai_connect_ncco("wss://x/ai")
+    for ncco, uri in ((screen, "wss://x/screen"), (ai, "wss://x/ai")):
+        assert ncco[0]["action"] == "connect"
+        ep = ncco[0]["endpoint"][0]
+        assert ep["type"] == "websocket"
+        assert ep["uri"] == uri
+        assert ep["content-type"] == "audio/l16;rate=16000"
+
+
+# --------------------------------------------------------------------------
+# Orchestrator resolution latch + branching
+# --------------------------------------------------------------------------
+
+
+class _FakeRedis:
+    """Minimal async Redis stand-in (decode_responses=True semantics)."""
+
+    def __init__(self):
+        self.store = {}
+
+    async def setex(self, key, ttl, value):
+        self.store[key] = value
+
+    async def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def delete(self, *keys):
+        for key in keys:
+            self.store.pop(key, None)
+
+
+def _provider_with_mocked_io():
+    prov = VonageProvider(
+        {"application_id": "app", "private_key": "key", "from_numbers": ["+15550000000"]}
+    )
+    prov.transfer_leg_to_ncco = AsyncMock(return_value={"status": "ok"})
+    prov.hangup_leg = AsyncMock(return_value={"status": "ok"})
+    return prov
+
+
+async def _seed_state(orch, run_id=1):
+    await orch._store_state(
+        run_id,
+        {
+            "organization_id": 11,
+            "telephony_configuration_id": 22,
+            "workflow_id": 33,
+            "user_id": 44,
+            "workflow_run_id": run_id,
+            "caller_leg_uuid": "caller-leg",
+            "conference_name": f"sv-{run_id}",
+            "screening_leg_uuid": "screen-leg",
+            "forward_to_number": "+14155551234",
+            "ai_ws_url": "wss://x/api/v1/telephony/ws/33/44/1",
+        },
+    )
+
+
+async def test_human_result_bridges_into_conference():
+    orch = SmartVoicemailOrchestrator(redis_client=_FakeRedis())
+    await _seed_state(orch)
+    prov = _provider_with_mocked_io()
+
+    with patch(
+        "api.services.telephony.factory.get_telephony_provider_by_id",
+        AsyncMock(return_value=prov),
+    ), patch.object(_db_singleton, "update_workflow_run", AsyncMock()):
+        await orch.on_screening_result(1, "human")
+
+    prov.transfer_leg_to_ncco.assert_awaited_once()
+    args = prov.transfer_leg_to_ncco.await_args.args
+    assert args[0] == "screen-leg"
+    assert args[1] == VonageProvider.build_join_conference_ncco("sv-1")
+    prov.hangup_leg.assert_not_awaited()
+
+
+async def test_voicemail_result_hangs_up_human_and_hands_caller_to_ai():
+    orch = SmartVoicemailOrchestrator(redis_client=_FakeRedis())
+    await _seed_state(orch)
+    prov = _provider_with_mocked_io()
+
+    with patch(
+        "api.services.telephony.factory.get_telephony_provider_by_id",
+        AsyncMock(return_value=prov),
+    ):
+        await orch.on_screening_result(1, "voicemail")
+
+    prov.hangup_leg.assert_awaited_once_with("screen-leg")
+    prov.transfer_leg_to_ncco.assert_awaited_once()
+    args = prov.transfer_leg_to_ncco.await_args.args
+    assert args[0] == "caller-leg"
+    assert args[1][0]["action"] == "connect"
+    assert args[1][0]["endpoint"][0]["uri"] == "wss://x/api/v1/telephony/ws/33/44/1"
+
+
+async def test_latch_makes_first_result_win():
+    fake = _FakeRedis()
+    orch = SmartVoicemailOrchestrator(redis_client=fake)
+    await _seed_state(orch)
+    prov = _provider_with_mocked_io()
+
+    with patch(
+        "api.services.telephony.factory.get_telephony_provider_by_id",
+        AsyncMock(return_value=prov),
+    ), patch.object(_db_singleton, "update_workflow_run", AsyncMock()):
+        await orch.on_screening_result(1, "human")
+        # Late no-answer event must be ignored.
+        await orch.on_screening_result(1, "no_answer")
+
+    # Only the first (human) resolution acted.
+    prov.transfer_leg_to_ncco.assert_awaited_once()
+    prov.hangup_leg.assert_not_awaited()
+    assert fake.store["sv:resolved:1"] == "human"

--- a/api/tests/telephony/test_smart_voicemail.py
+++ b/api/tests/telephony/test_smart_voicemail.py
@@ -223,7 +223,7 @@ async def test_start_vonage_detection_uses_amd_and_hold_conf():
     kw = prov.place_call_with_ncco.await_args.kwargs
     assert kw["advanced_machine_detection"] == {
         "behavior": "continue",
-        "mode": "default",
+        "mode": "detect",
         "beep_timeout": 45,
     }
     # Human leg holds in a silent conference (not our websocket).

--- a/api/tests/telephony/test_smart_voicemail.py
+++ b/api/tests/telephony/test_smart_voicemail.py
@@ -221,7 +221,11 @@ async def test_start_vonage_detection_uses_amd_and_hold_conf():
     orch = SmartVoicemailOrchestrator(redis_client=_FakeRedis())
     prov, _ = await _run_start(orch, "vonage")
     kw = prov.place_call_with_ncco.await_args.kwargs
-    assert kw["advanced_machine_detection"] == {"behavior": "continue", "mode": "default"}
+    assert kw["advanced_machine_detection"] == {
+        "behavior": "continue",
+        "mode": "default",
+        "beep_timeout": 45,
+    }
     # Human leg holds in a silent conference (not our websocket).
     assert kw["ncco"][0]["action"] == "conversation"
 

--- a/ui/src/components/telephony/PhoneNumberDialog.tsx
+++ b/ui/src/components/telephony/PhoneNumberDialog.tsx
@@ -45,6 +45,7 @@ type SmartVoicemail = {
   enabled?: boolean;
   forward_to_number?: string | null;
   ring_timeout_seconds?: number;
+  detection?: "vonage" | "own";
 };
 
 // extra_metadata is an open dict in the generated types; pull the
@@ -102,6 +103,7 @@ export function PhoneNumberDialog({
   const [svEnabled, setSvEnabled] = useState(false);
   const [svForwardTo, setSvForwardTo] = useState("");
   const [svRingTimeout, setSvRingTimeout] = useState(25);
+  const [svDetection, setSvDetection] = useState<"vonage" | "own">("vonage");
 
   // Reset form when the dialog opens.
   useEffect(() => {
@@ -118,6 +120,7 @@ export function PhoneNumberDialog({
     setSvEnabled(sv.enabled ?? false);
     setSvForwardTo(sv.forward_to_number ?? "");
     setSvRingTimeout(sv.ring_timeout_seconds ?? 25);
+    setSvDetection(sv.detection === "own" ? "own" : "vonage");
     setAddressTouched(false);
   }, [open, existing]);
 
@@ -169,6 +172,7 @@ export function PhoneNumberDialog({
             enabled: true,
             forward_to_number: svForwardTo.trim(),
             ring_timeout_seconds: svRingTimeout,
+            detection: svDetection,
           }
         : { enabled: false };
       const extraMetadata = {
@@ -356,6 +360,25 @@ export function PhoneNumberDialog({
                       )
                     }
                   />
+                </div>
+                <div className="col-span-2 space-y-1">
+                  <Label htmlFor="sv-detection">Voicemail detection</Label>
+                  <Select
+                    value={svDetection}
+                    onValueChange={(v) => setSvDetection(v === "own" ? "own" : "vonage")}
+                  >
+                    <SelectTrigger id="sv-detection">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="vonage">Vonage (carrier, recommended)</SelectItem>
+                      <SelectItem value="own">Dograh built-in (AI)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Vonage&apos;s carrier detection is more reliable (~$0.008/call). The
+                    built-in detector is free but less accurate.
+                  </p>
                 </div>
               </div>
             )}

--- a/ui/src/components/telephony/PhoneNumberDialog.tsx
+++ b/ui/src/components/telephony/PhoneNumberDialog.tsx
@@ -41,6 +41,23 @@ interface PhoneNumberDialogProps {
 
 const NO_WORKFLOW = "__none__";
 
+type SmartVoicemail = {
+  enabled?: boolean;
+  forward_to_number?: string | null;
+  ring_timeout_seconds?: number;
+};
+
+// extra_metadata is an open dict in the generated types; pull the
+// smart_voicemail sub-object out defensively.
+function readSmartVoicemail(
+  meta: Record<string, unknown> | undefined | null,
+): SmartVoicemail {
+  const raw = meta?.["smart_voicemail"];
+  return raw && typeof raw === "object" ? (raw as SmartVoicemail) : {};
+}
+
+const SV_FORWARD_E164_RE = /^\+\d{8,15}$/;
+
 // Mirrors api/schemas/telephony_phone_number.py::_validate_address_shape and
 // api/utils/telephony_address.py — keep in sync. Returns an error message
 // when the address would normalize to a broken canonical form, or null when
@@ -81,6 +98,11 @@ export function PhoneNumberDialog({
   const [submitting, setSubmitting] = useState(false);
   const [addressTouched, setAddressTouched] = useState(false);
 
+  // Smart voicemail (screen-and-forward) settings.
+  const [svEnabled, setSvEnabled] = useState(false);
+  const [svForwardTo, setSvForwardTo] = useState("");
+  const [svRingTimeout, setSvRingTimeout] = useState(25);
+
   // Reset form when the dialog opens.
   useEffect(() => {
     if (!open) return;
@@ -92,6 +114,10 @@ export function PhoneNumberDialog({
     setInboundWorkflowId(
       existing?.inbound_workflow_id ? String(existing.inbound_workflow_id) : NO_WORKFLOW,
     );
+    const sv = readSmartVoicemail(existing?.extra_metadata);
+    setSvEnabled(sv.enabled ?? false);
+    setSvForwardTo(sv.forward_to_number ?? "");
+    setSvRingTimeout(sv.ring_timeout_seconds ?? 25);
     setAddressTouched(false);
   }, [open, existing]);
 
@@ -126,11 +152,29 @@ export function PhoneNumberDialog({
         return;
       }
     }
+    if (svEnabled && !SV_FORWARD_E164_RE.test(svForwardTo.trim())) {
+      toast.error("Smart voicemail forward-to number must be E.164 (e.g. +14155551234)");
+      return;
+    }
     setSubmitting(true);
     try {
       const token = await getAccessToken();
       const inboundId =
         inboundWorkflowId === NO_WORKFLOW ? null : Number(inboundWorkflowId);
+
+      // Merge smart-voicemail config into extra_metadata (preserving any other
+      // keys). The backend stores extra_metadata verbatim.
+      const smartVoicemail: SmartVoicemail = svEnabled
+        ? {
+            enabled: true,
+            forward_to_number: svForwardTo.trim(),
+            ring_timeout_seconds: svRingTimeout,
+          }
+        : { enabled: false };
+      const extraMetadata = {
+        ...(existing?.extra_metadata ?? {}),
+        smart_voicemail: smartVoicemail,
+      };
 
       let providerSync: PhoneNumberResponse["provider_sync"] | undefined;
       if (isEdit && existing) {
@@ -144,6 +188,7 @@ export function PhoneNumberDialog({
               country_code: countryCode || undefined,
               inbound_workflow_id: inboundId ?? undefined,
               clear_inbound_workflow: inboundId === null,
+              extra_metadata: extraMetadata,
             },
           },
         );
@@ -162,6 +207,7 @@ export function PhoneNumberDialog({
               is_active: isActive,
               is_default_caller_id: isDefaultCallerId,
               inbound_workflow_id: inboundId ?? undefined,
+              extra_metadata: extraMetadata,
             },
           },
         );
@@ -270,6 +316,49 @@ export function PhoneNumberDialog({
           <div className="flex items-center justify-between rounded border p-3">
             <Label className="text-sm">Active</Label>
             <Switch checked={isActive} onCheckedChange={setIsActive} />
+          </div>
+
+          <div className="space-y-3 rounded border p-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label className="text-sm">Smart voicemail (screen &amp; forward)</Label>
+                <p className="text-xs text-muted-foreground">
+                  Ring a human first; if they answer, bridge the caller to them. If it
+                  goes to voicemail or isn&apos;t answered, the AI takes the call.
+                  Vonage only.
+                </p>
+              </div>
+              <Switch checked={svEnabled} onCheckedChange={setSvEnabled} />
+            </div>
+            {svEnabled && (
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label htmlFor="sv-forward">Forward to (E.164)</Label>
+                  <Input
+                    id="sv-forward"
+                    placeholder="+14155551234"
+                    value={svForwardTo}
+                    onChange={(e) => setSvForwardTo(e.target.value)}
+                    aria-invalid={!!svForwardTo && !SV_FORWARD_E164_RE.test(svForwardTo.trim())}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="sv-ring">Ring timeout (s)</Label>
+                  <Input
+                    id="sv-ring"
+                    type="number"
+                    min={5}
+                    max={120}
+                    value={svRingTimeout}
+                    onChange={(e) =>
+                      setSvRingTimeout(
+                        Math.max(5, Math.min(120, Number(e.target.value) || 25)),
+                      )
+                    }
+                  />
+                </div>
+              </div>
+            )}
           </div>
 
           {!isEdit && (


### PR DESCRIPTION
## Summary

Vonage inbound calls currently fail with `Callee currently unavailable` even when the Application is configured per the [docs](https://docs.dograh.com/integrations/telephony/vonage). Five issues, all in `providers/vonage/provider.py` plus one supporting tweak to the inbound-route lookup, collectively break the flow:

1. **`can_handle_webhook` is a stub** returning `False` unconditionally — the unified `/api/v1/telephony/inbound/run` dispatcher's `_detect_provider` never identifies a Vonage payload. (Detected by `conversation_uuid` with `CON-` prefix, falling back to `region_url` containing `vonage.com`.)
2. **`generate_validation_error_response` is missing** — the validation-error path in the dispatcher hits `AttributeError`, falls back to generic TwiML, Vonage rejects as `no NCCOs available`.
3. **`parse_inbound_webhook` reads `direction` from a key Vonage's answer URL doesn't include** — the dispatcher then rejects with `Non-inbound call on /inbound/run:` and hangs up.
4. **`start_inbound_stream` is hardcoded** to a `talk` + `hangup` NCCO labeled `# Minimalist NCCO response for interface compliance` — even with the above three fixed, Vonage just answers and immediately hangs up.
5. **`call_uuid` lookup miss after a successful WebSocket connect** — outbound calls stamp `call_uuid` in `gathered_context`, but inbound calls go through `_create_inbound_workflow_run` which stores the same value under the generic `call_id` key. Fall back to `call_id`.

Plus one supporting change in `find_inbound_route_by_account` so the lookup tolerates providers (like Vonage) whose payload has no account-like identifier.

## What changed

| File | Change |
|---|---|
| `api/services/telephony/providers/vonage/provider.py` | Real `can_handle_webhook` detection; add `generate_validation_error_response`; default `direction` to `"inbound"` in `parse_inbound_webhook`; real `connect` NCCO in `start_inbound_stream`; `call_uuid` → `call_id` fallback when reading from `gathered_context` |
| `api/db/telephony_phone_number_client.py` | Relax `find_inbound_route_by_account` guard to `(provider, to_number)`; conditionally add the `account_id` WHERE clause. `uq_phone_numbers_org_address` already enforces the uniqueness needed for safety. |

Net diff: **+69 / -15** across two files. Twilio, Telnyx, Plivo, and other providers are unaffected — their `can_handle_webhook` overrides take precedence in `_detect_provider`, and they pass non-empty `account_id`.

## Verification

Tested end-to-end against a real Vonage account (Application + linked DID, signature verification on, NCCO answer URL pointing at this branch's `/inbound/run`):

| Stage | Before this PR | After this PR |
|---|---|---|
| Call rings the Vonage number | Vonage marks `FAILED — Callee currently unavailable` | Vonage marks `ANSWERED — The call was successful` |
| `/inbound/run` reaches Dograh | 200 but provider unrecognized; TwiML hangup returned | 200 with valid NCCO `connect` action to `wss://.../api/v1/telephony/ws/{wf}/{user}/{run}` |
| WebSocket | Never opened | Accepted; workflow run state set to `running`; bot greets caller |
| Status callbacks | n/a | Per-call event URL embedded in NCCO; downstream `started` / `answered` / `completed` flow as expected |

I'm running this on a self-hosted production deployment and inbound now answers cleanly and runs the workflow.

## Test plan

- [x] Real inbound call from external phone → number bound to a Vonage Application → workflow runs end-to-end
- [x] Existing Twilio inbound still works (regression check on the dispatcher's account_id path)
- [x] Existing Telnyx inbound still works
- [ ] CI: existing tests pass

## Notes

- I considered adding a unit test for `can_handle_webhook`, but the existing telephony tests for other providers focus on routes / signature verification rather than detection. Happy to add one if a reviewer prefers.
- The fallback from `call_uuid` → `call_id` could alternatively be solved by having the dispatcher write both keys. Doing it on the read side keeps the patch isolated to one provider; happy to flip if there's a preference for that approach.