### PR TITLE
feat(examples): add load-and-edit workflow SDK example in Python and TypeScript

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,10 @@ python python/fetch_workflow_and_call.py
 
 # Create a new workflow from a definition.
 python python/create_workflow.py
+
+# Load an existing workflow, edit the startCall prompt, and save as a draft.
+# Edit WORKFLOW_ID at the top of the file first.
+python python/load_and_edit_workflow.py
 ```
 
 ## TypeScript
@@ -41,4 +45,5 @@ export DOGRAH_API_TOKEN=sk-...
 
 npm run call    # fetch_workflow_and_call.ts
 npm run create  # create_workflow.ts
+npm run edit    # load_and_edit_workflow.ts  (edit WORKFLOW_ID in the file first)
 ```

--- a/examples/python/load_and_edit_workflow.py
+++ b/examples/python/load_and_edit_workflow.py
@@ -1,0 +1,75 @@
+"""Load an existing workflow, edit a node prompt, and save it as a draft.
+
+Requirements:
+    pip install -r requirements.txt
+
+Environment variables (loaded from `.env` in this directory):
+    DOGRAH_API_ENDPOINT  - Dograh API base URL (e.g. http://localhost:8000)
+    DOGRAH_API_TOKEN     - API token sent as X-API-Key
+
+Run:
+    python load_and_edit_workflow.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from dograh_sdk import DograhClient
+from dograh_sdk._generated_models import UpdateWorkflowRequest
+
+load_dotenv(Path(__file__).parent / ".env")
+
+# Replace with the numeric ID of an existing agent in your Dograh account.
+WORKFLOW_ID = 0
+
+# Sentence appended to the startCall node's prompt when the script runs.
+PROMPT_SUFFIX = " Please be concise — keep all responses under two sentences."
+
+
+def main() -> int:
+    api_endpoint = os.environ.get("DOGRAH_API_ENDPOINT", "http://localhost:8000")
+    api_token = os.environ.get("DOGRAH_API_TOKEN")
+
+    if not api_token:
+        print("DOGRAH_API_TOKEN is required", file=sys.stderr)
+        return 1
+
+    if WORKFLOW_ID == 0:
+        print("Set WORKFLOW_ID at the top of this file to an existing workflow ID", file=sys.stderr)
+        return 1
+
+    with DograhClient(base_url=api_endpoint, api_key=api_token) as client:
+        existing = client.get_workflow(WORKFLOW_ID)
+        print(f"Loaded workflow {existing.id}: {existing.name!r} (status={existing.status})")
+
+        definition = dict(existing.workflow_definition)
+
+        for node in definition.get("nodes", []):
+            if node.get("type") == "startCall":
+                data = dict(node.get("data") or {})
+                data["prompt"] = (data.get("prompt") or "") + PROMPT_SUFFIX
+                node["data"] = data
+                break
+
+        result = client.update_workflow(
+            WORKFLOW_ID,
+            body=UpdateWorkflowRequest(
+                name=existing.name,
+                workflow_definition=definition,
+            ),
+        )
+        print(
+            f"Saved draft for workflow {result.id}: {result.name!r} "
+            f"(version={result.version_number}, status={result.version_status})"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/typescript/load_and_edit_workflow.ts
+++ b/examples/typescript/load_and_edit_workflow.ts
@@ -1,0 +1,63 @@
+// Load an existing workflow, edit a node prompt, and save it as a draft.
+//
+// Requirements:
+//   npm install @dograh/sdk
+//
+// Environment variables:
+//   DOGRAH_API_ENDPOINT  - Dograh API base URL (e.g. http://localhost:8000)
+//   DOGRAH_API_TOKEN     - API token sent as X-API-Key
+//
+// Run:
+//   npx tsx load_and_edit_workflow.ts
+
+import { DograhClient } from "@dograh/sdk";
+
+// Replace with the numeric ID of an existing agent in your Dograh account.
+const WORKFLOW_ID = 0;
+
+// Sentence appended to the startCall node's prompt when the script runs.
+const PROMPT_SUFFIX = " Please be concise — keep all responses under two sentences.";
+
+async function main(): Promise<void> {
+    const apiEndpoint = process.env.DOGRAH_API_ENDPOINT ?? "http://localhost:8000";
+    const apiToken = process.env.DOGRAH_API_TOKEN;
+
+    if (!apiToken) throw new Error("DOGRAH_API_TOKEN is required");
+    if (WORKFLOW_ID === 0) throw new Error("Set WORKFLOW_ID at the top of this file to an existing workflow ID");
+
+    const client = new DograhClient({
+        baseUrl: apiEndpoint,
+        apiKey: apiToken,
+    });
+
+    const existing = await client.getWorkflow(WORKFLOW_ID);
+    console.log(`Loaded workflow ${existing.id}: ${JSON.stringify(existing.name)} (status=${existing.status})`);
+
+    const definition = structuredClone(existing.workflow_definition) as {
+        nodes?: Array<{ type?: string; data?: Record<string, unknown> }>;
+    };
+
+    for (const node of definition.nodes ?? []) {
+        if (node.type === "startCall") {
+            node.data = node.data ?? {};
+            node.data.prompt = ((node.data.prompt as string) ?? "") + PROMPT_SUFFIX;
+            break;
+        }
+    }
+
+    const result = await client.updateWorkflow(WORKFLOW_ID, {
+        body: {
+            name: existing.name,
+            workflow_definition: definition as Record<string, unknown>,
+        },
+    });
+    console.log(
+        `Saved draft for workflow ${result.id}: ${JSON.stringify(result.name)} ` +
+        `(version=${result.version_number}, status=${result.version_status})`,
+    );
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "call": "tsx --env-file=.env fetch_workflow_and_call.ts",
-    "create": "tsx --env-file=.env create_workflow.ts"
+    "create": "tsx --env-file=.env create_workflow.ts",
+    "edit": "tsx --env-file=.env load_and_edit_workflow.ts"
   },
   "dependencies": {
     "@dograh/sdk": "latest"


### PR DESCRIPTION
## Summary
- Adds `examples/python/load_and_edit_workflow.py` — fetches an existing agent via `get_workflow()`, appends a sentence to the `startCall` node prompt, and saves it as a new draft via `update_workflow()`
- Adds `examples/typescript/load_and_edit_workflow.ts` — structural mirror of the Python version using `getWorkflow()` / `updateWorkflow()`
- Adds `edit` script to `examples/typescript/package.json`
- Updates `examples/README.md` with run instructions for both scripts

## Why
`get_workflow()` and `update_workflow()` are already SDK-exposed but had no runnable example. This fills the gap for the common fetch → mutate → save-draft edit loop, complementing the existing `create_workflow` and `fetch_workflow_and_call` scripts.

## Changes
| File | Change |
|------|--------|
| `examples/python/load_and_edit_workflow.py` | New — fetch workflow, edit startCall prompt, save draft |
| `examples/typescript/load_and_edit_workflow.ts` | New — TypeScript mirror of the Python example |
| `examples/typescript/package.json` | Added `"edit"` script entry |
| `examples/README.md` | Added run instructions for both new scripts |

## Testing
```bash
# Python
pip install dograh-sdk
export DOGRAH_API_ENDPOINT=http://localhost:8000
export DOGRAH_API_TOKEN=sk-...
# Set WORKFLOW_ID in the file, then:
python examples/python/load_and_edit_workflow.py
# → Loaded workflow 42: 'my agent' (status=published)
# → Saved draft for workflow 42: 'my agent' (version=3, status=draft)

# TypeScript
cd examples/typescript && npm install
# Set WORKFLOW_ID in the file, then:
npm run edit
# → Loaded workflow 42: "my agent" (status=published)
# → Saved draft for workflow 42: "my agent" (version=3, status=draft)
```

Closes #370