### PR TITLE
allow self-hosters to enable Stack Auth via Dockerfile build args (v33.0)

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,27 +3,20 @@
 # Stage 1: Dependencies
 FROM node:20-alpine AS deps
 WORKDIR /app
-
 # Install Python and build dependencies for native modules
 # This helps with ARM64 builds and native module compilation
 RUN apk add --no-cache python3 make g++ libc6-compat
-
 # Copy package files
 COPY ui/package*.json ./
-
 # Clean install with proper handling of native modules
 RUN --mount=type=cache,target=/root/.npm npm ci
-
 # Stage 2: Builder
 FROM node:20-alpine AS builder
 WORKDIR /app
-
 # Install libc6-compat for native modules in builder stage too
 RUN apk add --no-cache libc6-compat
-
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
-
 # Copy all files needed for build
 COPY ui/package*.json ./
 COPY ui/tsconfig.json ./
@@ -34,7 +27,6 @@ COPY ui/sentry.server.config.ts ./
 COPY ui/postcss.config.mjs ./
 COPY ui/public ./public
 COPY ui/src ./src
-
 # Set build-time environment variables (needed for Next.js build)
 ENV NEXT_PUBLIC_NODE_ENV="oss"
 ENV NEXT_TELEMETRY_DISABLED="1"
@@ -42,33 +34,31 @@ ENV NEXT_PUBLIC_CHATWOOT_URL="https://chat.dograh.com"
 ENV NEXT_PUBLIC_CHATWOOT_TOKEN="3fkFx2mCEjNHjM9gaNc4A82X"
 ENV BACKEND_URL="http://api:8000"
 
+ARG NEXT_PUBLIC_STACK_PROJECT_ID
+ARG NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY
+ENV NEXT_PUBLIC_STACK_PROJECT_ID=$NEXT_PUBLIC_STACK_PROJECT_ID
+ENV NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=$NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY
+# --------------------------------------------------------------------------
 # Build the application with standalone mode
 # Increase Node.js heap size to prevent out-of-memory errors during build
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build && \
-    rm -rf /tmp/* /root/.npm /root/.next/cache
-
+rm -rf /tmp/* /root/.npm /root/.next/cache
 # Stage 3: Runner (production image)
 FROM node:20-alpine AS runner
 WORKDIR /app
-
 # Environment variables will be provided by docker-compose
 ENV NODE_ENV=production
-
 # Create a non-root user
 RUN addgroup --system --gid 1001 nodejs && \
-    adduser --system --uid 1001 nextjs
-
+adduser --system --uid 1001 nextjs
 # Copy standalone build output
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
-
 # Switch to non-root user
 USER nextjs
-
 # Expose the port Next.js runs on
 EXPOSE 3010
-
 # Start the production server using the standalone Node.js server
 CMD sh -c "echo '🚀 Application ready at http://localhost:3010' && PORT=3010 node server.js"

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,20 +3,27 @@
 # Stage 1: Dependencies
 FROM node:20-alpine AS deps
 WORKDIR /app
+
 # Install Python and build dependencies for native modules
 # This helps with ARM64 builds and native module compilation
 RUN apk add --no-cache python3 make g++ libc6-compat
+
 # Copy package files
 COPY ui/package*.json ./
+
 # Clean install with proper handling of native modules
 RUN --mount=type=cache,target=/root/.npm npm ci
+
 # Stage 2: Builder
 FROM node:20-alpine AS builder
 WORKDIR /app
+
 # Install libc6-compat for native modules in builder stage too
 RUN apk add --no-cache libc6-compat
+
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
+
 # Copy all files needed for build
 COPY ui/package*.json ./
 COPY ui/tsconfig.json ./
@@ -27,6 +34,7 @@ COPY ui/sentry.server.config.ts ./
 COPY ui/postcss.config.mjs ./
 COPY ui/public ./public
 COPY ui/src ./src
+
 # Set build-time environment variables (needed for Next.js build)
 ENV NEXT_PUBLIC_NODE_ENV="oss"
 ENV NEXT_TELEMETRY_DISABLED="1"
@@ -34,31 +42,42 @@ ENV NEXT_PUBLIC_CHATWOOT_URL="https://chat.dograh.com"
 ENV NEXT_PUBLIC_CHATWOOT_TOKEN="3fkFx2mCEjNHjM9gaNc4A82X"
 ENV BACKEND_URL="http://api:8000"
 
+# Stack Auth (optional, for self-hosted social login). NEXT_PUBLIC_* values must
+# be set at build time so Next.js inlines them into the browser bundle; setting
+# them as runtime container env has no effect. Unset by default (empty strings),
+# which leaves the official image on the built-in local auth flow.
 ARG NEXT_PUBLIC_STACK_PROJECT_ID
 ARG NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY
 ENV NEXT_PUBLIC_STACK_PROJECT_ID=$NEXT_PUBLIC_STACK_PROJECT_ID
 ENV NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=$NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY
-# --------------------------------------------------------------------------
+
 # Build the application with standalone mode
 # Increase Node.js heap size to prevent out-of-memory errors during build
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build && \
-rm -rf /tmp/* /root/.npm /root/.next/cache
+    rm -rf /tmp/* /root/.npm /root/.next/cache
+
 # Stage 3: Runner (production image)
 FROM node:20-alpine AS runner
 WORKDIR /app
+
 # Environment variables will be provided by docker-compose
 ENV NODE_ENV=production
+
 # Create a non-root user
 RUN addgroup --system --gid 1001 nodejs && \
-adduser --system --uid 1001 nextjs
+    adduser --system --uid 1001 nextjs
+
 # Copy standalone build output
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
 # Switch to non-root user
 USER nextjs
+
 # Expose the port Next.js runs on
 EXPOSE 3010
+
 # Start the production server using the standalone Node.js server
 CMD sh -c "echo '🚀 Application ready at http://localhost:3010' && PORT=3010 node server.js"


### PR DESCRIPTION
## Problem

Self-hosters who want to use Stack Auth (Google / GitHub / social login)
instead of the built-in email-password flow cannot do so with the
current prebuilt `dograhai/dograh-ui` image, because `NEXT_PUBLIC_*`
environment variables are inlined into the browser bundle at
`npm run build` time by Next.js. Setting them as runtime env vars on the
container has no effect — the bundle was already compiled without them.

The only workaround today is to maintain a fork with a patched
Dockerfile, which creates unnecessary maintenance burden for anyone
deploying Dograh with Stack Auth.

## Solution

Add two optional `ARG` declarations to the **builder** stage of
`ui/Dockerfile`, immediately before the `npm run build` step:

- `NEXT_PUBLIC_STACK_PROJECT_ID`
- `NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY`

Each ARG is promoted to a matching `ENV` so Next.js picks it up during
the build. Self-hosters pass their project-specific values via
`docker build --build-arg` or their platform's build variable UI
(Railway, Coolify, etc.).

## Backward compatibility

- **When the args are not supplied** (the default), the values are empty
  strings and the UI behaves exactly as it does today — OSS / local auth,
  no Stack initialization. The official prebuilt image pipeline does not
  pass these args, so published images are unchanged.
- **When the args are supplied**, the Stack Auth client activates in the
  browser and the UI delegates authentication to the configured Stack
  project.
- No runtime code is modified — this is a build-config-only change.

## How to use

```bash
docker build \
  --build-arg NEXT_PUBLIC_STACK_PROJECT_ID=<your-project-id> \
  --build-arg NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=<your-key> \
  -f ui/Dockerfile .
```

Or set them as build variables in Railway / Coolify / any Docker-based
PaaS — they are picked up automatically as Docker build args.

## Related context

Stack Auth (now Hexclave) is already fully supported on the backend via
the `AUTH_PROVIDER=stack` env var and the existing `stack_auth.py`
integration. This PR closes the gap on the frontend side for
self-hosted deployments.