### PR TITLE
fix: sync Smallest AI voice dropdown with selected model

### DIFF
--- a/api/services/configuration/options/__init__.py
+++ b/api/services/configuration/options/__init__.py
@@ -44,6 +44,7 @@ from .sarvam import (
 from .smallest import (
     SMALLEST_TTS_LANGUAGES,
     SMALLEST_TTS_MODELS,
+    SMALLEST_TTS_PRO_VOICES,
     SMALLEST_TTS_VOICES,
 )
 from .speechmatics import SPEECHMATICS_STT_LANGUAGES
@@ -87,6 +88,7 @@ __all__ = [
     "SARVAM_V3_VOICES",
     "SMALLEST_TTS_LANGUAGES",
     "SMALLEST_TTS_MODELS",
+    "SMALLEST_TTS_PRO_VOICES",
     "SMALLEST_TTS_VOICES",
     "SPEECHMATICS_STT_LANGUAGES",
 ]

--- a/api/services/configuration/options/smallest.py
+++ b/api/services/configuration/options/smallest.py
@@ -16,6 +16,15 @@ SMALLEST_TTS_VOICES = (
     "mia",
     "maithili",
 )
+# Premium voices for lightning_v3.1_pro (American, British, Indian accents; English + Hindi only)
+SMALLEST_TTS_PRO_VOICES = (
+    "meher",
+    "rhea",
+    "aviraj",
+    "cressida",
+    "willow",
+    "maverick",
+)
 SMALLEST_TTS_LANGUAGES = (
     "en",
     "hi",

--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -41,6 +41,7 @@ from api.services.configuration.options import (
     SARVAM_V3_VOICES,
     SMALLEST_TTS_LANGUAGES,
     SMALLEST_TTS_MODELS,
+    SMALLEST_TTS_PRO_VOICES,
     SMALLEST_TTS_VOICES,
     SPEECHMATICS_STT_LANGUAGES,
 )
@@ -1194,8 +1195,15 @@ class SmallestAITTSConfiguration(BaseTTSConfiguration):
     )
     voice: str = Field(
         default="sophia",
-        description="Smallest AI voice ID.",
-        json_schema_extra={"examples": SMALLEST_TTS_VOICES, "allow_custom_input": True},
+        description="Smallest AI voice ID. Available voices differ by model: lightning_v3.1 has a broad multilingual pool; lightning_v3.1_pro has premium American, British, and Indian accent voices (English + Hindi only).",
+        json_schema_extra={
+            "examples": list(SMALLEST_TTS_VOICES),
+            "allow_custom_input": True,
+            "model_options": {
+                "lightning_v3.1": list(SMALLEST_TTS_VOICES),
+                "lightning_v3.1_pro": list(SMALLEST_TTS_PRO_VOICES),
+            },
+        },
     )
     language: str = Field(
         default="en",


### PR DESCRIPTION
## Summary

- Fixes the bug where switching between `lightning_v3.1` and `lightning_v3.1_pro` in the TTS model dropdown kept showing the same voice list
- Adds `SMALLEST_TTS_PRO_VOICES` with the 6 premium voices for `lightning_v3.1_pro`: `meher`, `rhea`, `aviraj`, `cressida`, `willow`, `maverick`
- Adds `model_options` to `SmallestAITTSConfiguration`'s voice field so the frontend renders the correct voice list per model and auto-resets the voice when the model changes

## Root Cause

`SmallestAITTSConfiguration.voice` had a single flat `examples` list with no `model_options` mapping. The frontend's `ServiceConfigurationForm` already has full support for `model_options` (dropdown filtering + auto-reset on model change) — it just wasn't wired up for Smallest AI.

## Verification

All 21 voice IDs were tested against the Smallest AI API (`lightning_v3.1` × 15, `lightning_v3.1_pro` × 6) — every one returned HTTP 200.

## Test plan

- [ ] Select Smallest AI as TTS provider
- [ ] Confirm `lightning_v3.1` shows 15 standard voices (sophia, avery, liam, etc.)
- [ ] Switch model to `lightning_v3.1_pro` — voice dropdown should update to 6 premium voices (meher, rhea, aviraj, cressida, willow, maverick)
- [ ] Confirm agent creation no longer errors with invalid voice ID