### PR TITLE
fix: reject misrouted smallwebrtc runs on the telephony websocket

### DIFF
--- a/api/db/workflow_run_client.py
+++ b/api/db/workflow_run_client.py
@@ -91,12 +91,17 @@ class WorkflowRunClient(BaseDBClient):
                 else workflow.template_context_variables
             )
 
+            merged_initial_context = {
+                **(default_context or {}),
+                **(initial_context or {}),
+            }
+
             new_run = WorkflowRunModel(
                 name=name,
                 workflow=workflow,
                 mode=mode,
                 definition_id=target_def.id if target_def else None,
-                initial_context=initial_context or default_context,
+                initial_context=merged_initial_context,
                 gathered_context=gathered_context or {},
                 logs=logs or {},
                 campaign_id=campaign_id,

--- a/api/routes/public_embed.py
+++ b/api/routes/public_embed.py
@@ -165,7 +165,10 @@ async def initialize_embed_session(request: Request, init_request: InitEmbedRequ
             workflow_id=embed_token.workflow_id,
             mode=WorkflowRunMode.SMALLWEBRTC.value,
             user_id=embed_token.created_by,  # Use token creator as run owner
-            initial_context=init_request.context_variables,
+            initial_context={
+                **(init_request.context_variables or {}),
+                "provider": WorkflowRunMode.SMALLWEBRTC.value,
+            },
         )
     except Exception as e:
         logger.error(f"Failed to create workflow run: {e}")

--- a/api/routes/telephony.py
+++ b/api/routes/telephony.py
@@ -21,7 +21,7 @@ from starlette.websockets import WebSocketDisconnect
 
 from api.db import db_client
 from api.db.models import UserModel
-from api.enums import CallType, WorkflowRunState
+from api.enums import CallType, WorkflowRunMode, WorkflowRunState
 from api.errors.telephony_errors import TelephonyError
 from api.sdk_expose import sdk_expose
 from api.services.auth.depends import get_user
@@ -578,12 +578,36 @@ async def _handle_telephony_websocket(
             provider_type = workflow_run.initial_context.get("provider")
             logger.info(f"Extracted provider_type: {provider_type}")
 
+        if (
+            workflow_run.mode == WorkflowRunMode.SMALLWEBRTC.value
+            or provider_type == WorkflowRunMode.SMALLWEBRTC.value
+        ):
+            logger.warning(
+                f"SmallWebRTC workflow run {workflow_run_id} reached telephony "
+                f"websocket; mode={workflow_run.mode}, provider={provider_type}"
+            )
+            await websocket.close(
+                code=4400,
+                reason=(
+                    "smallwebrtc runs connect through the WebRTC signaling endpoint, "
+                    "not the telephony websocket"
+                ),
+            )
+            return
+
         if not provider_type:
             logger.error(
                 f"No provider type found in workflow run {workflow_run_id}. "
                 f"gathered_context: {workflow_run.gathered_context}, mode: {workflow_run.mode}"
             )
-            await websocket.close(code=4400, reason="Provider type not found")
+            await websocket.close(
+                code=4400,
+                reason=(
+                    f"No provider type found for workflow run {workflow_run_id} "
+                    f"(mode: {workflow_run.mode}); telephony websocket requires "
+                    "a telephony provider"
+                ),
+            )
             return
 
         logger.info(

--- a/api/tests/test_telephony_routes.py
+++ b/api/tests/test_telephony_routes.py
@@ -1,10 +1,12 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from api.routes.telephony import router
+from api.enums import WorkflowRunMode, WorkflowRunState
+from api.routes.telephony import _handle_telephony_websocket, router
 from api.services.auth.depends import get_user
 
 
@@ -156,3 +158,41 @@ def test_initiate_call_rejects_existing_run_for_different_workflow():
     mock_db.get_workflow_run.assert_awaited_once_with(501, organization_id=11)
     assert not mock_db.create_workflow_run.called
     assert provider.initiate_call.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_smallwebrtc_run_reaching_telephony_websocket_closes_without_running():
+    websocket = AsyncMock()
+    workflow_run = SimpleNamespace(
+        id=501,
+        workflow_id=33,
+        mode=WorkflowRunMode.SMALLWEBRTC.value,
+        state=WorkflowRunState.INITIALIZED.value,
+        initial_context={},
+        gathered_context={},
+    )
+    workflow = SimpleNamespace(id=33, organization_id=11)
+    provider_lookup = AsyncMock()
+
+    with (
+        patch("api.routes.telephony.db_client") as mock_db,
+        patch(
+            "api.routes.telephony.get_telephony_provider_for_run",
+            new=provider_lookup,
+        ),
+    ):
+        mock_db.get_workflow_run = AsyncMock(return_value=workflow_run)
+        mock_db.get_workflow_by_id = AsyncMock(return_value=workflow)
+        mock_db.update_workflow_run = AsyncMock()
+
+        await _handle_telephony_websocket(websocket, 33, 99, 501)
+
+    websocket.close.assert_awaited_once_with(
+        code=4400,
+        reason=(
+            "smallwebrtc runs connect through the WebRTC signaling endpoint, "
+            "not the telephony websocket"
+        ),
+    )
+    assert mock_db.update_workflow_run.await_count == 0
+    assert provider_lookup.await_count == 0

--- a/api/tests/test_workflow_versioning.py
+++ b/api/tests/test_workflow_versioning.py
@@ -606,3 +606,34 @@ class TestRunDefinitionBinding:
         )
 
         assert run.definition_id == draft.id
+
+    async def test_run_initial_context_merges_with_template_context(
+        self, db_session, workflow_with_v1
+    ):
+        """Explicit run context should augment template context, not replace it."""
+        workflow, user = workflow_with_v1
+        await db_session.save_workflow_draft(
+            workflow_id=workflow.id,
+            template_context_variables={
+                "company_name": "Acme",
+                "default_only": "kept",
+            },
+        )
+        await db_session.publish_workflow_draft(workflow.id)
+
+        run = await db_session.create_workflow_run(
+            name="Embed Run",
+            workflow_id=workflow.id,
+            mode="smallwebrtc",
+            user_id=user.id,
+            initial_context={
+                "company_name": "Override Co",
+                "provider": "smallwebrtc",
+            },
+        )
+
+        assert run.initial_context == {
+            "company_name": "Override Co",
+            "default_only": "kept",
+            "provider": "smallwebrtc",
+        }


### PR DESCRIPTION
## Summary
When a smallwebrtc (browser/WebRTC) workflow run reaches the PSTN telephony websocket handler, reject it with a clear, actionable reason instead of an opaque "Provider type not found", and store the provider on smallwebrtc runs at creation so they are self-describing.

## Why this matters
In #433 a reporter using the default "Inbound (User Call AI)" workflow in browser mode hits `telephony.py | No provider type found in workflow run ... mode: smallwebrtc` and the connection closes with `Provider type not found`. A smallwebrtc run is a browser/WebRTC transport: the call is established through the WebRTC signaling endpoints in `api/routes/webrtc_signaling.py` (`/ws/(public/)signaling/...` -> `run_pipeline_smallwebrtc`), not through the telephony websocket, which only services telephony providers. So when a smallwebrtc run reaches `_handle_telephony_websocket`, the right behavior is a clear rejection that points to the correct endpoint, not an opaque error and not a pretend "running" state.

## What changed
- `api/routes/telephony.py`: in `_handle_telephony_websocket`, detect a smallwebrtc run (by `workflow_run.mode` or a `smallwebrtc` provider) and close with code 4400 and a reason explaining smallwebrtc connects through the WebRTC signaling endpoint. It does not set the run to `running` and does not invoke a telephony provider. The generic no-provider close reason now includes the run id and mode. PSTN provider behavior is unchanged.
- `api/routes/public_embed.py`: smallwebrtc runs are created with `initial_context["provider"] = smallwebrtc` (merged with the caller's context variables) so the stored run is self-describing.
- `api/tests/test_telephony_routes.py`: a focused async test asserting a smallwebrtc run reaching the telephony websocket is closed with the informative reason and is never transitioned to `running` or routed to a provider.

## Verification
`py_compile` passes for the edited files (Python 3.13 and 3.14). The full backend pytest environment could not be provisioned here (no `.env.test`, and dependency install is blocked), but a constrained run of the new telephony test passes; CI exercises the full suite.

Closes #433

AI was used for assistance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject misrouted `smallwebrtc` runs on the PSTN telephony websocket with a 4400 close and a clear pointer to the WebRTC signaling endpoint. Also merge run `initial_context` with template defaults and persist `provider: smallwebrtc` on embed runs to prevent the “Provider type not found” error in #433.

- **Bug Fixes**
  - api/routes/telephony.py: detect `smallwebrtc` via `run.mode` or `initial_context.provider`; close with 4400 and an actionable reason; improved “no provider” close message with run id and mode.
  - api/routes/public_embed.py: set `initial_context['provider'] = 'smallwebrtc'` (merged with user context) on creation.
  - api/db/workflow_run_client.py: merge template default context with provided `initial_context` so defaults are kept and caller values override.
  - tests: add async test for telephony closure and a versioning test for context merging.

<sup>Written for commit 941a54d68e5e89b6249f600054e8ce2c0907a06b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the opaque "Provider type not found" error when a `smallwebrtc` (browser/WebRTC) run accidentally connects to the PSTN telephony WebSocket by adding an early guard that closes with a descriptive 4400 reason. It also stores `provider: smallwebrtc` on run creation and changes `create_workflow_run` to always merge workflow template context variables with caller-provided context instead of choosing one or the other.

- **`api/routes/telephony.py`**: Adds a `WorkflowRunMode.SMALLWEBRTC` guard (by `mode` OR `provider` field) before any provider dispatch; improves the generic "no provider" close reason to include run id and mode.
- **`api/db/workflow_run_client.py`**: Changes context storage from `initial_context or default_context` to `{**default_context, **initial_context}`, merging template context variables into every new run; caller-supplied values always win.
- **`api/routes/public_embed.py`**: Injects `"provider": "smallwebrtc"` into `initial_context` at embed run creation so runs are self-describing without a `mode` check alone.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the fix is targeted and the rejection path returns early without touching run state or provider lookup.

The smallwebrtc guard is a straightforward early-exit that doesn't touch any existing telephony provider path. The context-merge change in create_workflow_run is a broader behavioral change (template vars now always included) but caller-supplied keys always win, so existing telephony inbound/outbound paths are not broken. The new test covers the core rejection scenario and the versioning test documents the merge contract.

api/db/workflow_run_client.py — the always-merge change affects every create_workflow_run caller, not just the smallwebrtc path; worth a quick scan of callers that previously relied on template vars being dropped when explicit context is provided.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/db/workflow_run_client.py | Behavior change: switched from `initial_context or default_context` to always merging `{**default_context, **initial_context}`; affects all callers — telephony inbound now receives template vars it did not before, and the telephony outbound route double-merges (manual spread + DB-layer merge), both harmless in practice but broader than the smallwebrtc scope described. |
| api/routes/telephony.py | Adds smallwebrtc guard after two DB calls and the state check; functionally correct but a smallwebrtc run in a non-INITIALIZED state will receive the 'not available for connection' 4409 close before reaching the new guard (noted in previous review thread). |
| api/routes/public_embed.py | Correctly injects `provider: smallwebrtc` last in the spread so it always wins over any caller-supplied context_variables; self-describing run creation looks good. |
| api/tests/test_telephony_routes.py | New async test correctly verifies close code/reason and absence of state-transition and provider-lookup calls for the smallwebrtc-reaches-telephony-WS scenario; covers the mode-arm of the OR guard. |
| api/tests/test_workflow_versioning.py | New integration test documents and validates the merged-context behavior introduced in workflow_run_client.py; straightforward and correct. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Browser Client
    participant TW as Telephony WebSocket
    participant DB as DB Client

    Note over C,DB: smallwebrtc run mistakenly hits telephony WS
    C->>TW: "WS connect (workflow_run_id=X)"
    TW->>DB: get_workflow_run(X)
    DB-->>TW: "run {mode: smallwebrtc, state: INITIALIZED}"
    TW->>DB: get_workflow_by_id(workflow_id)
    DB-->>TW: workflow
    Note over TW: state check passes (INITIALIZED)
    Note over TW: extract provider_type from initial_context
    TW->>TW: "mode==SMALLWEBRTC OR provider==SMALLWEBRTC?"
    TW-->>C: close(4400, smallwebrtc runs connect through WebRTC signaling endpoint)
    Note over TW: no state transition, no provider lookup

    Note over C,DB: Normal telephony run (unchanged path)
    C->>TW: "WS connect (workflow_run_id=Y)"
    TW->>DB: get_workflow_run(Y)
    DB-->>TW: "run {mode: twilio, provider: twilio}"
    TW->>DB: get_workflow_by_id(workflow_id)
    DB-->>TW: workflow
    TW->>DB: update_workflow_run(RUNNING)
    TW->>TW: provider.handle_websocket(...)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Browser Client
    participant TW as Telephony WebSocket
    participant DB as DB Client

    Note over C,DB: smallwebrtc run mistakenly hits telephony WS
    C->>TW: "WS connect (workflow_run_id=X)"
    TW->>DB: get_workflow_run(X)
    DB-->>TW: "run {mode: smallwebrtc, state: INITIALIZED}"
    TW->>DB: get_workflow_by_id(workflow_id)
    DB-->>TW: workflow
    Note over TW: state check passes (INITIALIZED)
    Note over TW: extract provider_type from initial_context
    TW->>TW: "mode==SMALLWEBRTC OR provider==SMALLWEBRTC?"
    TW-->>C: close(4400, smallwebrtc runs connect through WebRTC signaling endpoint)
    Note over TW: no state transition, no provider lookup

    Note over C,DB: Normal telephony run (unchanged path)
    C->>TW: "WS connect (workflow_run_id=Y)"
    TW->>DB: get_workflow_run(Y)
    DB-->>TW: "run {mode: twilio, provider: twilio}"
    TW->>DB: get_workflow_by_id(workflow_id)
    DB-->>TW: workflow
    TW->>DB: update_workflow_run(RUNNING)
    TW->>TW: provider.handle_websocket(...)
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `api/routes/telephony.py`, line 570-584 ([link](https://github.com/dograh-hq/dograh/blob/7ddfd0bccde3a0b14774e4290e6492d4c99b179a/api/routes/telephony.py#L570-L584)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The smallwebrtc guard fires after the `get_workflow_by_id` DB call and the state check. For the rejection path this means one extra DB round-trip and a potentially misleading "not available for connection" close if the run is in any state other than `INITIALIZED`. Moving the check to right after the `workflow_run` fetch avoids both issues — the mode is already known at that point and no workflow lookup is needed to reject it.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: merge workflow run initial context ..."](https://github.com/dograh-hq/dograh/commit/941a54d68e5e89b6249f600054e8ce2c0907a06b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40010212)</sub>

<!-- /greptile_comment -->