### PR TITLE
fix: masked secret shape detection

### DIFF
--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -326,7 +326,7 @@ async def save_model_configuration_v2(
     existing = await get_organization_ai_model_configuration_v2(organization_id)
     configuration = merge_ai_model_configuration_v2_secrets(request, existing)
     try:
-        check_for_masked_keys_in_ai_model_configuration_v2(configuration)
+        check_for_masked_keys_in_ai_model_configuration_v2(configuration, existing)
         effective = compile_ai_model_configuration_v2(configuration)
         await UserConfigurationValidator().validate(
             effective,

--- a/api/routes/user.py
+++ b/api/routes/user.py
@@ -155,7 +155,7 @@ async def update_user_configurations(
             raise HTTPException(status_code=422, detail=str(e))
 
         try:
-            check_for_masked_keys(user_configurations)
+            check_for_masked_keys(user_configurations, existing_config)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
 

--- a/api/routes/workflow.py
+++ b/api/routes/workflow.py
@@ -1078,6 +1078,7 @@ async def update_workflow(
                     incoming_v2_override,
                     existing_v2_override_config,
                 )
+                mask_check_existing = existing_v2_override_config
                 if existing_v2_override_config is None:
                     resolved_config = await get_resolved_ai_model_configuration(
                         user_id=user.id,
@@ -1087,7 +1088,11 @@ async def update_workflow(
                         v2_override,
                         resolved_config.organization_configuration,
                     )
-                check_for_masked_keys_in_ai_model_configuration_v2(v2_override)
+                    mask_check_existing = resolved_config.organization_configuration
+                check_for_masked_keys_in_ai_model_configuration_v2(
+                    v2_override,
+                    mask_check_existing,
+                )
                 effective = compile_ai_model_configuration_v2(v2_override)
                 await UserConfigurationValidator().validate(
                     effective,

--- a/api/services/configuration/ai_model_configuration.py
+++ b/api/services/configuration/ai_model_configuration.py
@@ -244,7 +244,10 @@ def merge_ai_model_configuration_v2_secrets(
         existing_dograh = existing_dict.get("dograh") or {}
         incoming_key = incoming_dograh.get("api_key")
         existing_key = existing_dograh.get("api_key")
-        if incoming_key and existing_key and contains_masked_key(incoming_key):
+        if incoming_key and existing_key and contains_masked_key(
+            incoming_key,
+            existing_key,
+        ):
             incoming_dograh["api_key"] = resolve_masked_api_keys(
                 incoming_key,
                 existing_key,
@@ -258,9 +261,13 @@ def merge_ai_model_configuration_v2_secrets(
 
 def check_for_masked_keys_in_ai_model_configuration_v2(
     configuration: OrganizationAIModelConfigurationV2,
+    existing: OrganizationAIModelConfigurationV2 | None = None,
 ) -> None:
     data = configuration.model_dump(mode="json", exclude_none=True)
-    _raise_if_masked_secret(data)
+    existing_data = (
+        existing.model_dump(mode="json", exclude_none=True) if existing else None
+    )
+    _raise_if_masked_secret(data, existing_data)
 
 
 def mask_ai_model_configuration_v2(
@@ -381,22 +388,26 @@ def _merge_service_secret_fields(incoming: dict, existing: dict):
         existing_secret = existing[secret_field]
         if incoming_secret is None:
             incoming[secret_field] = existing_secret
-        elif contains_masked_key(incoming_secret):
+        elif contains_masked_key(incoming_secret, existing_secret):
             incoming[secret_field] = resolve_masked_api_keys(
                 incoming_secret,
                 existing_secret,
             )
 
 
-def _raise_if_masked_secret(value):
+def _raise_if_masked_secret(value, existing=None):
     if isinstance(value, dict):
         for key, nested in value.items():
-            if key in SERVICE_SECRET_FIELDS and contains_masked_key(nested):
+            existing_nested = existing.get(key) if isinstance(existing, dict) else None
+            if key in SERVICE_SECRET_FIELDS and contains_masked_key(
+                nested,
+                existing_nested,
+            ):
                 raise ValueError(
                     f"The {key} appears to be masked. Please provide the actual "
                     "value, not the masked value."
                 )
-            _raise_if_masked_secret(nested)
+            _raise_if_masked_secret(nested, existing_nested)
     elif isinstance(value, list):
         for item in value:
             _raise_if_masked_secret(item)

--- a/api/services/configuration/masking.py
+++ b/api/services/configuration/masking.py
@@ -28,7 +28,19 @@ def contains_masked_key(value: str | list[str] | None) -> bool:
     if value is None:
         return False
     keys = value if isinstance(value, list) else [value]
-    return any(MASK_MARKER in k for k in keys)
+    return any(MASK_MARKER in k or _matches_mask_shape(k) for k in keys)
+
+
+def _matches_mask_shape(key: str) -> bool:
+    """Return True when *key* has the exact shape produced by mask_key()."""
+    if not key:
+        return False
+
+    if len(key) <= VISIBLE_CHARS:
+        return key == MASK_CHAR * len(key)
+
+    masked_prefix_length = len(key) - VISIBLE_CHARS
+    return key[:masked_prefix_length] == MASK_CHAR * masked_prefix_length
 
 
 def check_for_masked_keys(config: "EffectiveAIModelConfiguration") -> None:

--- a/api/services/configuration/masking.py
+++ b/api/services/configuration/masking.py
@@ -23,12 +23,23 @@ SERVICE_SECRET_FIELDS = ("api_key", "credentials", "aws_access_key", "aws_secret
 MODEL_OVERRIDE_FIELDS = ("llm", "tts", "stt", "realtime")
 
 
-def contains_masked_key(value: str | list[str] | None) -> bool:
+def contains_masked_key(
+    value: str | list[str] | None,
+    existing: str | list[str] | None = None,
+) -> bool:
     """Return True if *value* looks like a masked placeholder."""
     if value is None:
         return False
     keys = value if isinstance(value, list) else [value]
-    return any(MASK_MARKER in k or _matches_mask_shape(k) for k in keys)
+    if existing is None:
+        return any(MASK_MARKER in k for k in keys)
+
+    existing_keys = existing if isinstance(existing, list) else [existing]
+    return any(
+        MASK_MARKER in key
+        or any(_matches_existing_mask(key, real_key) for real_key in existing_keys)
+        for key in keys
+    )
 
 
 def _matches_mask_shape(key: str) -> bool:
@@ -43,20 +54,39 @@ def _matches_mask_shape(key: str) -> bool:
     return key[:masked_prefix_length] == MASK_CHAR * masked_prefix_length
 
 
-def check_for_masked_keys(config: "EffectiveAIModelConfiguration") -> None:
+def _matches_existing_mask(key: str, existing: str | None) -> bool:
+    return bool(existing) and _matches_mask_shape(key) and is_mask_of(key, existing)
+
+
+def check_for_masked_keys(
+    config: "EffectiveAIModelConfiguration",
+    existing: "EffectiveAIModelConfiguration | None" = None,
+) -> None:
     """Raise ValueError if any service in *config* still has a masked secret."""
     for field in ("llm", "tts", "stt", "embeddings", "realtime"):
         service = getattr(config, field, None)
         if service is None:
             continue
+        existing_service = getattr(existing, field, None) if existing else None
         for secret_field in SERVICE_SECRET_FIELDS:
             if not hasattr(service, secret_field):
                 continue
             if secret_field == "api_key" and hasattr(service, "get_all_api_keys"):
                 secret_value = service.get_all_api_keys()
+                existing_secret_value = (
+                    existing_service.get_all_api_keys()
+                    if existing_service
+                    and hasattr(existing_service, "get_all_api_keys")
+                    else None
+                )
             else:
                 secret_value = getattr(service, secret_field, None)
-            if contains_masked_key(secret_value):
+                existing_secret_value = (
+                    getattr(existing_service, secret_field, None)
+                    if existing_service and hasattr(existing_service, secret_field)
+                    else None
+                )
+            if contains_masked_key(secret_value, existing_secret_value):
                 raise ValueError(
                     f"The {field} {secret_field} appears to be masked. "
                     "Please provide the actual value, not the masked value."

--- a/api/services/configuration/merge.py
+++ b/api/services/configuration/merge.py
@@ -50,7 +50,7 @@ def _merge_service_secret_fields(
         incoming_secret = incoming_cfg.get(secret_field)
         existing_secret = existing_cfg[secret_field]
         if incoming_secret is not None:
-            if contains_masked_key(incoming_secret):
+            if contains_masked_key(incoming_secret, existing_secret):
                 incoming_cfg[secret_field] = (
                     existing_secret
                     if masked_value_preserves_full_secret

--- a/api/tests/test_masked_key_rejection.py
+++ b/api/tests/test_masked_key_rejection.py
@@ -45,16 +45,16 @@ def _existing_openai_config():
 class TestMaskedKeyRejection:
     def test_detects_short_masked_api_keys(self):
         """Short masked API keys should be rejected even without the legacy marker."""
-        assert contains_masked_key(mask_key("EMPTY"))
-        assert contains_masked_key(mask_key("X"))
-        assert contains_masked_key(mask_key("mykey"))
+        assert contains_masked_key(mask_key("EMPTY"), "EMPTY")
+        assert contains_masked_key(mask_key("X"), "X")
+        assert contains_masked_key(mask_key("mykey"), "mykey")
 
     def test_detects_masked_api_key_with_mask_char_in_visible_suffix(self):
         """The visible suffix can contain MASK_CHAR and still be masked."""
         masked = mask_key("vsk*v")
 
         assert masked == "*sk*v"
-        assert contains_masked_key(masked)
+        assert contains_masked_key(masked, "vsk*v")
 
     def test_allows_unmasked_short_api_keys(self):
         """Unmasked short keys should not be rejected as masked placeholders."""
@@ -62,6 +62,8 @@ class TestMaskedKeyRejection:
         assert not contains_masked_key("X")
         assert not contains_masked_key("mykey")
         assert not contains_masked_key("vsk*v")
+        assert not contains_masked_key("*rk5f")
+        assert not contains_masked_key("*rk5f", "different-existing-key")
 
     def test_rejects_masked_api_key_on_provider_change(self):
         """Changing provider with a masked API key should return 400."""
@@ -86,6 +88,42 @@ class TestMaskedKeyRejection:
                     "llm": {
                         "provider": "google",
                         "api_key": MASKED_KEY,
+                        "model": "gemini-2.5-flash",
+                    }
+                },
+            )
+
+            assert response.status_code == 400
+            assert "masked" in response.json()["detail"].lower()
+
+    def test_rejects_short_masked_api_key_on_provider_change(self):
+        """Changing provider with a short masked API key should return 400."""
+        app = _make_test_app()
+        client = TestClient(app)
+        existing = EffectiveAIModelConfiguration(
+            llm=OpenAILLMService(
+                provider="openai",
+                api_key="EMPTY",
+                model="gpt-4.1",
+            )
+        )
+
+        with (
+            patch("api.routes.user.db_client") as mock_db,
+            patch("api.routes.user.UserConfigurationValidator") as mock_validator,
+        ):
+            mock_db.get_user_configurations = AsyncMock(return_value=existing)
+            mock_db.update_user_configuration = AsyncMock(
+                side_effect=lambda uid, cfg: cfg
+            )
+            mock_validator.return_value.validate = AsyncMock()
+
+            response = client.put(
+                "/user/configurations/user",
+                json={
+                    "llm": {
+                        "provider": "google",
+                        "api_key": mask_key("EMPTY"),
                         "model": "gemini-2.5-flash",
                     }
                 },
@@ -131,6 +169,43 @@ class TestMaskedKeyRejection:
         client = TestClient(app)
 
         new_key = "AIzaSyNewRealKey12345678"
+        updated = EffectiveAIModelConfiguration(
+            llm=GoogleLLMService(
+                provider="google",
+                api_key=new_key,
+                model="gemini-2.5-flash",
+            )
+        )
+
+        with (
+            patch("api.routes.user.db_client") as mock_db,
+            patch("api.routes.user.UserConfigurationValidator") as mock_validator,
+        ):
+            mock_db.get_user_configurations = AsyncMock(
+                return_value=_existing_openai_config()
+            )
+            mock_db.update_user_configuration = AsyncMock(return_value=updated)
+            mock_validator.return_value.validate = AsyncMock()
+
+            response = client.put(
+                "/user/configurations/user",
+                json={
+                    "llm": {
+                        "provider": "google",
+                        "api_key": new_key,
+                        "model": "gemini-2.5-flash",
+                    }
+                },
+            )
+
+            assert response.status_code == 200
+
+    def test_allows_new_star_prefixed_api_key(self):
+        """A new real key may have the same shape as an unrelated masked key."""
+        app = _make_test_app()
+        client = TestClient(app)
+
+        new_key = "*rk5f"
         updated = EffectiveAIModelConfiguration(
             llm=GoogleLLMService(
                 provider="google",

--- a/api/tests/test_masked_key_rejection.py
+++ b/api/tests/test_masked_key_rejection.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from api.routes.user import router
 from api.schemas.ai_model_configuration import EffectiveAIModelConfiguration
 from api.services.auth.depends import get_user
-from api.services.configuration.masking import mask_key
+from api.services.configuration.masking import contains_masked_key, mask_key
 from api.services.configuration.registry import (
     GoogleLLMService,
     GoogleVertexLLMConfiguration,
@@ -43,6 +43,26 @@ def _existing_openai_config():
 
 
 class TestMaskedKeyRejection:
+    def test_detects_short_masked_api_keys(self):
+        """Short masked API keys should be rejected even without the legacy marker."""
+        assert contains_masked_key(mask_key("EMPTY"))
+        assert contains_masked_key(mask_key("X"))
+        assert contains_masked_key(mask_key("mykey"))
+
+    def test_detects_masked_api_key_with_mask_char_in_visible_suffix(self):
+        """The visible suffix can contain MASK_CHAR and still be masked."""
+        masked = mask_key("vsk*v")
+
+        assert masked == "*sk*v"
+        assert contains_masked_key(masked)
+
+    def test_allows_unmasked_short_api_keys(self):
+        """Unmasked short keys should not be rejected as masked placeholders."""
+        assert not contains_masked_key("EMPTY")
+        assert not contains_masked_key("X")
+        assert not contains_masked_key("mykey")
+        assert not contains_masked_key("vsk*v")
+
     def test_rejects_masked_api_key_on_provider_change(self):
         """Changing provider with a masked API key should return 400."""
         app = _make_test_app()

--- a/api/tests/test_resolve_effective_config.py
+++ b/api/tests/test_resolve_effective_config.py
@@ -538,7 +538,10 @@ class TestWorkflowConfigurationSecrets:
         masked = mask_workflow_configurations(configs)
 
         assert masked["model_overrides"]["llm"]["api_key"] != "sk-real-llm-key"
-        assert contains_masked_key(masked["model_overrides"]["llm"]["api_key"])
+        assert contains_masked_key(
+            masked["model_overrides"]["llm"]["api_key"],
+            "sk-real-llm-key",
+        )
         assert masked["model_overrides"]["llm"]["api_key"].endswith("-key")
         assert masked["model_overrides"]["tts"]["api_key"] != "el-real-tts-key"
         assert masked["ambient_noise_configuration"] == {"enabled": True}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes masked secret detection by matching the exact `mask_key` shape and comparing against the existing secret. Blocks masked saves while allowing real short or star-prefixed keys that aren’t masks of the existing value.

- **Bug Fixes**
  - `contains_masked_key` now accepts the existing secret, checks legacy marker, matches mask shape, and verifies it’s a mask of the existing value to avoid false positives.
  - Routes and helpers pass existing configs into mask checks; merge paths resolve masked placeholders to existing secrets.
  - Tests cover short masked keys, star-in-suffix cases, rejecting short masked keys on provider change, and allowing unmasked short or star-prefixed new keys.

<sup>Written for commit eb09aea6cae0e33cfbde2ee2a735309633b8332a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes masked-secret detection so that short API keys (shorter than or equal to `VISIBLE_CHARS` + a few characters) can no longer slip past the guard as real values when they are actually the output of `mask_key`. The fix threads an `existing` key through every call site of `contains_masked_key`, `check_for_masked_keys`, and `_raise_if_masked_secret` so shape-based detection (`_matches_mask_shape` + `is_mask_of`) supplements the legacy `MASK_MARKER` substring check.

- **`masking.py`**: introduces `_matches_mask_shape` (checks all-mask prefix of exact `mask_key` length) and `_matches_existing_mask` (combines shape check with exact `is_mask_of` equality); `contains_masked_key` uses both when `existing` is available.
- **All call sites** (`organization.py`, `user.py`, `workflow.py`, `ai_model_configuration.py`, `merge.py`): pass the appropriate stored config as `existing` so the new shape detection activates; `workflow.py` introduces `mask_check_existing` to select the correct reference config (workflow override or resolved org config) before the check.
- **Tests**: new unit tests cover short masked keys, mask-char-in-suffix, star-prefixed genuine keys, and an integration test confirming short masked keys are rejected on provider change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrowly scoped bug fix with no regressions on legitimate keys.

The new shape detection (`_matches_mask_shape` + `is_mask_of`) is conservative: it only flags a key when it both has the exact prefix-mask structure produced by `mask_key` AND is exactly equal to `mask_key(existing)`. A genuine short key whose first characters happen to be `*` is only rejected if it is the literal mask of the current stored key for that account — a coincidence that is essentially impossible for any key of meaningful length. All three call paths (user config, org config, workflow override) now carry the right existing reference. The test suite covers the key edge cases (short all-mask keys, suffix containing `*`, cross-provider star-prefixed genuine keys) and all pre-existing tests continue to pass.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/services/configuration/masking.py | Core fix: adds `_matches_mask_shape` and `_matches_existing_mask` helpers; `contains_masked_key` now accepts `existing` and uses shape + exact `is_mask_of` check to catch short masked keys that lack `MASK_MARKER` |
| api/services/configuration/ai_model_configuration.py | Threads `existing` through `check_for_masked_keys_in_ai_model_configuration_v2` and `_raise_if_masked_secret`; dict branch correctly propagates `existing_nested` for full-depth shape detection |
| api/routes/workflow.py | Introduces `mask_check_existing` variable to carry the right existing config (workflow override or resolved org config) into the mask check; falls back to `None` (legacy MASK_MARKER only) when no existing config is found |
| api/services/configuration/merge.py | One-line update passes `existing_secret` to `contains_masked_key`, enabling short-key shape detection during workflow model-override secret merging |
| api/tests/test_masked_key_rejection.py | Adds unit tests for short masked keys, mask-char-in-suffix edge case, star-prefixed genuine keys, and an integration test for short masked key rejection on provider change |
| api/tests/test_resolve_effective_config.py | Updates existing assertion to pass the real key as `existing` to `contains_masked_key`, keeping the test aligned with the new signature |
| api/routes/organization.py | Passes `existing` org config to `check_for_masked_keys_in_ai_model_configuration_v2` so short masked keys in org-level saves are detected |
| api/routes/user.py | Passes `existing_config` to `check_for_masked_keys`, enabling context-aware short-key detection on user config updates |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming API Key] --> B{existing provided?}
    B -- No --> C{MASK_MARKER in key?}
    C -- Yes --> D[Masked ✓]
    C -- No --> E[Not masked ✗]
    B -- Yes --> F{MASK_MARKER in key?}
    F -- Yes --> D
    F -- No --> G{_matches_mask_shape?}
    G -- No --> E
    G -- Yes --> H{is_mask_of key, existing?}
    H -- Yes --> D
    H -- No --> E

    subgraph _matches_mask_shape
        I{len <= VISIBLE_CHARS?} -- Yes --> J[all chars are MASK_CHAR?]
        I -- No --> K[prefix of len-4 all MASK_CHAR?]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming API Key] --> B{existing provided?}
    B -- No --> C{MASK_MARKER in key?}
    C -- Yes --> D[Masked ✓]
    C -- No --> E[Not masked ✗]
    B -- Yes --> F{MASK_MARKER in key?}
    F -- Yes --> D
    F -- No --> G{_matches_mask_shape?}
    G -- No --> E
    G -- Yes --> H{is_mask_of key, existing?}
    H -- Yes --> D
    H -- No --> E

    subgraph _matches_mask_shape
        I{len <= VISIBLE_CHARS?} -- Yes --> J[all chars are MASK_CHAR?]
        I -- No --> K[prefix of len-4 all MASK_CHAR?]
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: masked secret saves"](https://github.com/dograh-hq/dograh/commit/eb09aea6cae0e33cfbde2ee2a735309633b8332a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40498211)</sub>

<!-- /greptile_comment -->