### PR TITLE
fix: guard Chatwoot bubble toggle until holder is in the DOM

### DIFF
--- a/ui/src/components/ChatwootWidget.tsx
+++ b/ui/src/components/ChatwootWidget.tsx
@@ -99,9 +99,12 @@ export default function ChatwootWidget() {
       }
     };
 
-    // The SDK may not be ready on first navigation; apply once it fires
-    // `chatwoot:ready`, otherwise apply immediately.
-    if (window.$chatwoot) {
+    // Apply immediately only once the bubble holder is actually in the DOM.
+    // `window.$chatwoot` exists synchronously after run(), but `.woot--bubble-holder`
+    // is appended later when the widget iframe loads, and toggleBubbleVisibility()
+    // dereferences it with no null check. When it's absent, fall through to
+    // `chatwoot:ready`, which the SDK fires once the holder exists.
+    if (window.$chatwoot && document.querySelector(".woot--bubble-holder")) {
       applyVisibility();
       return;
     }


### PR DESCRIPTION
## Problem

Intermittent production crash, surfaced via the React/Sentry error boundary, on navigating to `/workflow`:

```
TypeError: Cannot read properties of null (reading 'classList')
    at _ (https://chat.dograh.com/packs/js/sdk.js:295)
    at Object.toggleBubbleVisibility (sdk.js:300)
    at ChatwootWidget
```

Follow-up to #483, which rewrote `ChatwootWidget` to toggle the support bubble per route via the Chatwoot SDK.

## Root cause

`ChatwootWidget`'s visibility effect took the **synchronous fast path** whenever `window.$chatwoot` was merely truthy:

```ts
if (window.$chatwoot) { applyVisibility(); return; }
```

But the SDK assigns `window.$chatwoot` (with `toggleBubbleVisibility`) **synchronously** in `run()`, while the bubble-holder DOM node — `.woot--bubble-holder` — is only appended **later**, after the widget iframe finishes its network load. In that gap, `toggleBubbleVisibility("show")` runs `removeClasses(document.querySelector('.woot--bubble-holder'), 'woot-hidden')` and dereferences `null.classList`.

Because the throw is synchronous inside the effect body, it reaches the React error boundary (an async `chatwoot:ready` listener throw would instead hit `window.onerror`). It's intermittent because it only fires when a navigation into `/workflow` lands inside the `run()` → iframe-mounts-holder window; a warm-cached `sdk.js` actually widens that window.

## Fix

Gate the immediate-apply path on the bubble holder actually being in the DOM. When it's absent, fall through to the existing `chatwoot:ready` listener — which the SDK fires only *after* the holder is created, so that path was already safe.

```diff
-    if (window.$chatwoot) {
+    if (window.$chatwoot && document.querySelector(".woot--bubble-holder")) {
```

Since the holder is never removed once created, "holder absent" ⟺ "`chatwoot:ready` not yet fired", so the deferred apply always runs — no navigation sequence ends with the bubble in the wrong state. Once the holder exists, every later navigation takes the unchanged fast path.

## Scope / notes

- One-line behavioral change (plus an explanatory comment). `ChatwootWidget` is an isolated leaf (returns `null`, single mount, globals consumed only in-file) → no blast radius.
- **Out of scope:** the separate, pre-existing Chatwoot `getAppFrame().contentWindow` null-deref family (visible in PostHog) — a distinct SDK init-race that should be fixed on its own.

## Verification

- `tsc --noEmit` and `eslint` on the file both pass clean.
- Manual repro (for reviewers): prod build with real `NEXT_PUBLIC_CHATWOOT_URL/_TOKEN`, DevTools → Network → block `*/widget*` while allowing `*/packs/js/sdk.js` (freezes `$chatwoot` set + holder absent), then navigate to `/workflow`. Pre-fix throws the `classList` TypeError; post-fix does not, and the bubble appears once the iframe is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents an intermittent crash by delaying the Chatwoot bubble toggle until its holder element exists. This avoids the `null.classList` error on `/workflow` and keeps the bubble state correct.

- **Bug Fixes**
  - Gate the immediate path: require `window.$chatwoot` and `.woot--bubble-holder` before calling `applyVisibility()`; otherwise wait for `chatwoot:ready`.
  - Once the holder exists, later navigations use the fast path with no behavior change.

<sup>Written for commit a80c93ad17ece5e7c08adf37e36e3ebde73a5800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Guards the Chatwoot bubble-toggle fast path against a null-deref crash that occurred when `window.$chatwoot` was truthy but `.woot--bubble-holder` had not yet been appended to the DOM by the widget iframe.

- Adds `document.querySelector(\".woot--bubble-holder\")` to the fast-path guard so `toggleBubbleVisibility()` is only called synchronously when the element it dereferences is actually present; absent holder falls through to the `chatwoot:ready` listener, which fires after the holder exists.
- Improves the inline comment to explain the SDK timing model (synchronous `$chatwoot` assignment vs. deferred holder creation).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal one-line guard on an isolated leaf component with no shared state or side effects beyond window globals.

The fix is logically complete: the fast path only runs when both `window.$chatwoot` and `.woot--bubble-holder` are present, the fallback listener is already guarded with `{ once: true }` and a matching cleanup, and the PR description's claim that the holder is never removed (so its presence ≡ `chatwoot:ready` already fired) holds by SDK design. All navigation sequences — initial load, warm cache, rapid tab switching — land in the correct state. No data flows, no auth paths, and no other components are touched.

No files require special attention — the single changed file is a self-contained widget with no downstream callers.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/components/ChatwootWidget.tsx | One-line guard added to the visibility fast path; fix is logically sound, cleanup path is unchanged and correct, no new edge cases introduced. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant R as React Effect
    participant W as window.$chatwoot
    participant DOM as .woot--bubble-holder
    participant SDK as Chatwoot SDK

    Note over R,SDK: Navigation lands on /workflow (builder path)
    R->>W: Check window.$chatwoot
    W-->>R: truthy (set synchronously by run())
    R->>DOM: document.querySelector(".woot--bubble-holder")
    DOM-->>R: null (iframe not yet loaded)
    Note over R: Fast path skipped — falls through
    R->>SDK: "addEventListener("chatwoot:ready", applyVisibility, {once:true})"

    Note over SDK,DOM: Widget iframe finishes loading
    SDK->>DOM: Appends .woot--bubble-holder
    SDK->>R: dispatches "chatwoot:ready"
    R->>W: applyVisibility() → toggleBubbleVisibility("hide")

    Note over R,SDK: Subsequent navigation (holder already in DOM)
    R->>W: Check window.$chatwoot → truthy
    R->>DOM: document.querySelector(".woot--bubble-holder") → non-null
    Note over R: Fast path taken — applyVisibility() called synchronously
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant R as React Effect
    participant W as window.$chatwoot
    participant DOM as .woot--bubble-holder
    participant SDK as Chatwoot SDK

    Note over R,SDK: Navigation lands on /workflow (builder path)
    R->>W: Check window.$chatwoot
    W-->>R: truthy (set synchronously by run())
    R->>DOM: document.querySelector(".woot--bubble-holder")
    DOM-->>R: null (iframe not yet loaded)
    Note over R: Fast path skipped — falls through
    R->>SDK: "addEventListener("chatwoot:ready", applyVisibility, {once:true})"

    Note over SDK,DOM: Widget iframe finishes loading
    SDK->>DOM: Appends .woot--bubble-holder
    SDK->>R: dispatches "chatwoot:ready"
    R->>W: applyVisibility() → toggleBubbleVisibility("hide")

    Note over R,SDK: Subsequent navigation (holder already in DOM)
    R->>W: Check window.$chatwoot → truthy
    R->>DOM: document.querySelector(".woot--bubble-holder") → non-null
    Note over R: Fast path taken — applyVisibility() called synchronously
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: guard Chatwoot bubble toggle until ..."](https://github.com/dograh-hq/dograh/commit/a80c93ad17ece5e7c08adf37e36e3ebde73a5800) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40868716)</sub>

<!-- /greptile_comment -->