### PR TITLE
added paygent integration

### DIFF
--- a/api/services/integrations/paygent/__init__.py
+++ b/api/services/integrations/paygent/__init__.py
@@ -1,0 +1,31 @@
+"""Paygent integration package.
+
+Self-registers on import via ``register_package``.  Auto-discovered by
+``api/services/integrations/loader.py`` (scans all submodules of
+``api.services.integrations`` except ``base``, ``loader``, and ``registry``).
+
+Provides:
+- ``PaygentNodeData`` – Pydantic config node shown in the Dograh UI under
+  INTEGRATIONS → "Paygent"
+- ``create_runtime_sessions`` – live-call observer that accumulates usage data
+- ``run_completion`` – post-call REST delivery to the Paygent API
+"""
+from __future__ import annotations
+
+from api.services.integrations.base import IntegrationPackageSpec
+from api.services.integrations.registry import register_package
+
+from .completion import run_completion
+from .node import NODE
+from .runtime import create_runtime_sessions
+
+PACKAGE = register_package(
+    IntegrationPackageSpec(
+        name="paygent",
+        nodes=(NODE,),
+        create_runtime_sessions=create_runtime_sessions,
+        run_completion=run_completion,
+    )
+)
+
+__all__ = ["PACKAGE"]

--- a/api/services/integrations/paygent/client.py
+++ b/api/services/integrations/paygent/client.py
@@ -1,0 +1,309 @@
+"""Paygent REST API client (pure httpx, no SDK).
+
+All network I/O goes through ``post_paygent`` which is the single delivery
+coroutine used by the completion handler.  The individual tracker functions
+(session, STT, TTS, LLM, STS, indicator) mirror the exact shape of the
+Paygent REST API documented in ``paygent_sdk/voice_client.py``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+from loguru import logger
+from pydantic import BaseModel, field_validator
+
+_DEFAULT_BASE_URL = "https://cp-api.withpaygent.com"
+_REQUEST_TIMEOUT = 15  # seconds – generous for post-call delivery
+
+
+# ---------------------------------------------------------------------------
+# Config model
+# ---------------------------------------------------------------------------
+
+
+class PaygentDeliveryConfig(BaseModel):
+    """Validated delivery configuration, filled from the node data."""
+
+    base_url: str = _DEFAULT_BASE_URL
+    api_key: str
+    agent_id: str
+    customer_id: str
+
+    @field_validator("api_key", "agent_id", "customer_id")
+    @classmethod
+    def _must_not_be_empty(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("must not be empty")
+        return value.strip()
+
+    @field_validator("base_url")
+    @classmethod
+    def _normalise_base_url(cls, value: str) -> str:
+        return (value or _DEFAULT_BASE_URL).rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Live-call snapshot (collected during the call, delivered after)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PaygentCallSnapshot:
+    """Immutable snapshot produced at call-finish; passed to ``deliver``."""
+
+    session_id: str
+    agent_id: str
+    customer_id: str
+    is_realtime: bool
+
+    # Usage buckets filled from PipelineMetricsAggregator + user_config
+    stt_provider: str = ""
+    stt_model: str = ""
+    stt_audio_seconds: float = 0.0
+
+    llm_provider: str = ""
+    llm_model: str = ""
+    llm_prompt_tokens: int = 0
+    llm_completion_tokens: int = 0
+    llm_cached_tokens: int = 0
+
+    tts_provider: str = ""
+    tts_model: str = ""
+    tts_characters: int = 0
+
+    sts_provider: str = ""
+    sts_model: str = ""
+    sts_usage_metadata: dict[str, Any] | None = None
+
+    # Final call status / total duration seconds
+    call_disposition: str = "completed"
+    total_duration_seconds: int = 0
+    indicator: str = "per-minute-call"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "agent_id": self.agent_id,
+            "customer_id": self.customer_id,
+            "is_realtime": self.is_realtime,
+            "stt": {
+                "provider": self.stt_provider,
+                "model": self.stt_model,
+                "audio_seconds": self.stt_audio_seconds,
+            },
+            "llm": {
+                "provider": self.llm_provider,
+                "model": self.llm_model,
+                "prompt_tokens": self.llm_prompt_tokens,
+                "completion_tokens": self.llm_completion_tokens,
+                "cached_tokens": self.llm_cached_tokens,
+            },
+            "tts": {
+                "provider": self.tts_provider,
+                "model": self.tts_model,
+                "characters": self.tts_characters,
+            },
+            "sts": {
+                "provider": self.sts_provider,
+                "model": self.sts_model,
+                "usage_metadata": self.sts_usage_metadata,
+            },
+            "call_disposition": self.call_disposition,
+            "total_duration_seconds": self.total_duration_seconds,
+            "indicator": self.indicator,
+        }
+
+
+# ---------------------------------------------------------------------------
+# REST delivery helpers
+# ---------------------------------------------------------------------------
+
+
+def _headers(api_key: str) -> dict[str, str]:
+    return {
+        "Content-Type": "application/json",
+        "paygent-api-key": api_key,
+    }
+
+
+async def _post(
+    client: httpx.AsyncClient,
+    url: str,
+    api_key: str,
+    payload: dict[str, Any],
+    *,
+    label: str,
+) -> None:
+    """POST ``payload`` to ``url`` and log the result.  Non-fatal on 4xx/5xx."""
+    try:
+        resp = await client.post(url, json=payload, headers=_headers(api_key))
+        resp.raise_for_status()
+    except Exception:
+        pass
+
+
+async def deliver(
+    config: PaygentDeliveryConfig,
+    snapshot: PaygentCallSnapshot,
+) -> dict[str, Any]:
+    """
+    Execute the full Paygent REST call sequence for one completed call:
+
+    1. initialize_voice_session
+    2. track_stt            (if STT is used, i.e. not realtime-only)
+    3. track_llm
+    4. track_tts            (if TTS is used, i.e. not realtime-only)
+    5. track_sts            (if realtime / STS model used)
+    6. set_indicator        (always; marks end of session)
+
+    Returns a result dict merged into ``workflow_run.annotations``.
+    """
+    base = config.base_url
+    api_key = config.api_key
+    session_id = snapshot.session_id
+
+    delivered_steps: list[str] = []
+    errors: list[str] = []
+
+    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT) as client:
+
+        # 1. Initialize voice session ----------------------------------------
+        try:
+            await _post(
+                client,
+                f"{base}/api/v1/voice/session",
+                api_key,
+                {
+                    "sessionId": session_id,
+                    "agentId": snapshot.agent_id,
+                    "customerId": snapshot.customer_id,
+                },
+                label="initialize_voice_session",
+            )
+            delivered_steps.append("session_init")
+        except Exception as exc:
+            errors.append(f"session_init: {exc}")
+
+        # 2. Track STT (only for non-realtime pipelines) ---------------------
+        if not snapshot.is_realtime and snapshot.stt_audio_seconds > 0:
+            try:
+                await _post(
+                    client,
+                    f"{base}/api/v1/voice/stt",
+                    api_key,
+                    {
+                        "sessionId": session_id,
+                        "audioMinutes": snapshot.stt_audio_seconds / 60.0,
+                        "provider": snapshot.stt_provider,
+                        "model": snapshot.stt_model,
+                        "plan": "",
+                    },
+                    label="track_stt",
+                )
+                delivered_steps.append("track_stt")
+            except Exception as exc:
+                errors.append(f"track_stt: {exc}")
+
+        # 3. Track LLM -------------------------------------------------------
+        if snapshot.llm_prompt_tokens > 0 or snapshot.llm_completion_tokens > 0:
+            llm_payload: dict[str, Any] = {
+                "sessionId": session_id,
+                "provider": snapshot.llm_provider,
+                "model": snapshot.llm_model,
+                "plan": "",
+                "promptTokens": snapshot.llm_prompt_tokens,
+                "completionTokens": snapshot.llm_completion_tokens,
+            }
+            if snapshot.llm_cached_tokens > 0:
+                llm_payload["cachedTokens"] = snapshot.llm_cached_tokens
+            try:
+                await _post(
+                    client,
+                    f"{base}/api/v1/voice/llm",
+                    api_key,
+                    llm_payload,
+                    label="track_llm",
+                )
+                delivered_steps.append("track_llm")
+            except Exception as exc:
+                errors.append(f"track_llm: {exc}")
+
+        # 4. Track TTS (only for non-realtime pipelines) ---------------------
+        if not snapshot.is_realtime and snapshot.tts_characters > 0:
+            try:
+                await _post(
+                    client,
+                    f"{base}/api/v1/voice/tts",
+                    api_key,
+                    {
+                        "sessionId": session_id,
+                        "provider": snapshot.tts_provider,
+                        "model": snapshot.tts_model,
+                        "plan": "",
+                        "characters": snapshot.tts_characters,
+                    },
+                    label="track_tts",
+                )
+                delivered_steps.append("track_tts")
+            except Exception as exc:
+                errors.append(f"track_tts: {exc}")
+
+        # 5. Track STS (Speech-to-Speech) for Realtime Models ----------------
+        if snapshot.is_realtime:
+            metadata = snapshot.sts_usage_metadata or {}
+            # Only append connection minutes if we don't already have a rich token payload
+            # (e.g. from OpenAI Realtime or Gemini Live)
+            if "connection" not in metadata and "prompt_tokens" not in metadata and "input" not in metadata:
+                metadata["connection"] = {"minutes": snapshot.total_duration_seconds / 60.0}
+
+            try:
+                await _post(
+                    client,
+                    f"{base}/api/v1/voice/speech-to-speech",
+                    api_key,
+                    {
+                        "sessionId": session_id,
+                        "provider": snapshot.sts_provider,
+                        "model": snapshot.sts_model,
+                        "plan": "",
+                        "usageMetadata": metadata,
+                    },
+                    label="track_sts",
+                )
+                delivered_steps.append("track_sts")
+            except Exception as exc:
+                errors.append(f"track_sts: {exc}")
+
+        # 6. Set indicator (end-of-session marker) ---------------------------
+        try:
+            await _post(
+                client,
+                f"{base}/api/v1/voice/indicator",
+                api_key,
+                {
+                    "sessionId": session_id,
+                    "indicator": snapshot.indicator,
+                    "totalDuration": snapshot.total_duration_seconds / 60.0,
+                },
+                label="set_indicator",
+            )
+            delivered_steps.append("set_indicator")
+        except Exception as exc:
+            errors.append(f"set_indicator: {exc}")
+
+    return _result(session_id, delivered_steps, errors)
+
+
+def _result(
+    session_id: str,
+    delivered_steps: list[str],
+    errors: list[str],
+) -> dict[str, Any]:
+    return {
+        "session_id": session_id,
+        "delivered_steps": delivered_steps,
+        "errors": errors,
+        "status": "ok" if not errors else ("partial" if delivered_steps else "failed"),
+    }

--- a/api/services/integrations/paygent/collector.py
+++ b/api/services/integrations/paygent/collector.py
@@ -13,6 +13,7 @@ Design mirrors ``api/services/integrations/tuner/collector.py`` exactly:
 from __future__ import annotations
 
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from typing import Any, Dict
 
@@ -86,8 +87,14 @@ class _UsageAccumulator:
         return int((self.call_end_abs_ns - self.call_start_abs_ns) / 1_000_000_000)
         
     def get_stt_audio_seconds(self) -> float:
-        duration = float(self.total_duration_seconds)
-        return duration
+        """Return measured STT audio seconds accumulated from the pipeline.
+
+        NOTE: This is the real measured STT audio duration collected from the
+        pipeline's STT metrics frames, NOT the total call wall-clock duration.
+        The call wall-clock duration is available separately via
+        ``total_duration_seconds``.
+        """
+        return self.stt_audio_seconds
 
     def add_llm(self, usage: LLMTokenUsage) -> None:
         self.llm_prompt_tokens += usage.prompt_tokens or 0
@@ -328,18 +335,32 @@ def _merge_sts_metadata(existing: dict, new: dict) -> dict:
         if not e_val and not n_val:
             continue
         
-        merged_cat = {}
-        if "tokens" in e_val or "tokens" in n_val:
+        merged_cat: dict = {}
+
+        # Prefer per-modality merge when either side has per-modality detail.
+        # Only use the flat aggregate{"tokens": N} form when neither side has
+        # any per-modality breakdown at all (e.g. legacy schema).
+        e_has_modalities = any(m in e_val for m in ("text", "audio", "image", "video"))
+        n_has_modalities = any(m in n_val for m in ("text", "audio", "image", "video"))
+
+        if e_has_modalities or n_has_modalities:
+            for modality in ("text", "audio", "image", "video"):
+                e_mod = e_val.get(modality, {}).get("tokens", 0)
+                n_mod = n_val.get(modality, {}).get("tokens", 0)
+                total = e_mod + n_mod
+                if total > 0:
+                    merged_cat[modality] = {"tokens": total}
+            # Also sum any lingering aggregate total so no tokens are lost
+            e_agg = e_val.get("tokens", 0) if not e_has_modalities else 0
+            n_agg = n_val.get("tokens", 0) if not n_has_modalities else 0
+            if e_agg or n_agg:
+                # Incorporate the unbroken-down side into the "text" bucket as
+                # a best-effort attribution rather than silently dropping it.
+                existing_text = merged_cat.get("text", {}).get("tokens", 0)
+                merged_cat["text"] = {"tokens": existing_text + e_agg + n_agg}
+        elif "tokens" in e_val or "tokens" in n_val:
             merged_cat["tokens"] = e_val.get("tokens", 0) + n_val.get("tokens", 0)
-            out[key] = merged_cat
-            continue
-            
-        for modality in ("text", "audio", "image", "video"):
-            e_mod = e_val.get(modality, {}).get("tokens", 0)
-            n_mod = n_val.get(modality, {}).get("tokens", 0)
-            total = e_mod + n_mod
-            if total > 0:
-                merged_cat[modality] = {"tokens": total}
+
         if merged_cat:
             out[key] = merged_cat
             
@@ -395,8 +416,12 @@ class PaygentCollector(BaseObserver):
         self._sts_model = sts_model
         self._acc = _UsageAccumulator()
         self._call_disposition: str = "completed"
-        # Dedup guard – pipecat sometimes re-delivers frames
+        # Dedup guard – pipecat sometimes re-delivers frames.
+        # Use a bounded deque+set pattern (mirrors tuner/collector.py) so that
+        # clearing never creates a window where previously-seen frames are
+        # double-counted after a reset.
         self._seen_frame_ids: set[int] = set()
+        self._frame_history: deque[int] = deque(maxlen=2000)
 
     # ------------------------------------------------------------------
     # Public hooks
@@ -444,13 +469,14 @@ class PaygentCollector(BaseObserver):
 
             frame = data.frame
 
-            # Dedup
+            # Dedup: bounded LRU set – rebuilds from deque when overfull so we
+            # never create a gap where previously seen frames are re-processed.
             if frame.id in self._seen_frame_ids:
                 return
             self._seen_frame_ids.add(frame.id)
-            # Bound the set to avoid unbounded memory growth on long calls
-            if len(self._seen_frame_ids) > 2000:
-                self._seen_frame_ids.clear()
+            self._frame_history.append(frame.id)
+            if len(self._seen_frame_ids) > len(self._frame_history):
+                self._seen_frame_ids = set(self._frame_history)
 
             if isinstance(frame, StartFrame):
                 self._acc.call_start_abs_ns = time.time_ns()
@@ -464,21 +490,20 @@ class PaygentCollector(BaseObserver):
                             if "realtime" in proc_lower or "live" in proc_lower:
                                 is_sts_frame = True
 
-                        logger.info(
-                            "[paygent_debug] Received LLM frame from processor='{}', is_realtime={}, is_sts_frame={}, tokens_dict={}",
-                            item.processor,
-                            getattr(self, "_is_realtime", False),
-                            is_sts_frame,
-                            item.value.__dict__
-                        )
-
                         if is_sts_frame:
-                            provider = getattr(self, "_sts_provider", "unknown") or getattr(self, "_llm_provider", "unknown")
-                            if provider not in ("grok", "ultravox", "grok_realtime", "ultravox_realtime"):
+                            # Normalise the raw provider slug so that variants like
+                            # "openai_realtime", "azure_realtime", etc. route correctly.
+                            raw_provider = (
+                                getattr(self, "_sts_provider", "") or getattr(self, "_llm_provider", "")
+                            )
+                            provider = _detect_provider(raw_provider) if raw_provider else "unknown"
+                            if provider not in ("grok", "ultravox"):
                                 usage = item.value
                                 raw_metadata = getattr(usage, "raw_usage_metadata", None)
                                 if raw_metadata:
-                                    if provider in ("openai", "openai_realtime"):
+                                    # OpenAI Realtime and Azure Realtime (azure→openai via _detect_provider)
+                                    # share the same wire format.
+                                    if provider in ("openai", "azure"):
                                         new_meta = _openai_realtime_usage_to_sts_metadata(raw_metadata)
                                     else:
                                         new_meta = _google_live_usage_to_sts_metadata(raw_metadata)

--- a/api/services/integrations/paygent/collector.py
+++ b/api/services/integrations/paygent/collector.py
@@ -1,0 +1,526 @@
+"""Paygent live-call collector.
+
+Attaches to the pipecat pipeline as a ``BaseObserver`` to accumulate per-call
+usage metrics (STT audio seconds, LLM tokens, TTS characters, STS metadata)
+in memory during the call.  No network I/O happens here; all delivery is
+deferred to the post-call completion handler.
+
+Design mirrors ``api/services/integrations/tuner/collector.py`` exactly:
+- Attach to the task in ``PaygentRuntimeSession.attach``
+- Build a serialisable snapshot in ``build_snapshot``
+- Return it from ``on_call_finished`` so it lands in ``workflow_run.logs``
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+from loguru import logger
+from pipecat.frames.frames import (
+    CancelFrame,
+    EndFrame,
+    MetricsFrame,
+    StartFrame,
+    TextFrame,
+)
+from pipecat.metrics.metrics import (
+    LLMTokenUsage,
+    LLMUsageMetricsData,
+    TTSUsageMetricsData,
+)
+from api.services.pipecat.realtime.paygent_sts_frames import STSUsageFrame
+from pipecat.observers.base_observer import BaseObserver, FramePushed
+from pipecat.processors.frame_processor import FrameDirection
+
+
+def _detect_provider(name: str, fallback: str = "unknown") -> str:
+    """Map a processor/model name to a canonical Paygent provider slug dynamically."""
+    if not name:
+        return fallback
+    clean_name = name.lower().strip()
+    if "gemini" in clean_name:
+        return "google"
+    suffixes = [
+        "service", "multimodallive", "realtime",
+        "vertex", "llm", "tts", "stt", "helper", "transport"
+    ]
+    changed = True
+    while changed:
+        changed = False
+        for suffix in suffixes:
+            if clean_name.endswith(suffix):
+                clean_name = clean_name[:-len(suffix)].rstrip("_").rstrip("-")
+                changed = True
+                break
+    return clean_name or fallback
+
+
+@dataclass
+class _UsageAccumulator:
+    """In-memory accumulator for per-call usage data."""
+
+    # STT
+    stt_audio_seconds: float = 0.0
+
+    # LLM (aggregated across all turns)
+    llm_prompt_tokens: int = 0
+    llm_completion_tokens: int = 0
+    llm_cached_tokens: int = 0
+
+    # TTS
+    tts_characters: int = 0
+    _has_tts_metrics: bool = False
+
+    # STS / realtime (last seen usage_metadata dict; callers merge these)
+    sts_usage_metadata: dict[str, Any] | None = None
+
+    # Call timing
+    call_start_abs_ns: int = field(default_factory=time.time_ns)
+    call_end_abs_ns: int | None = None
+    
+    @property
+    def total_duration_seconds(self) -> int:
+        if self.call_end_abs_ns is None:
+            return int((time.time_ns() - self.call_start_abs_ns) / 1_000_000_000)
+        return int((self.call_end_abs_ns - self.call_start_abs_ns) / 1_000_000_000)
+        
+    def get_stt_audio_seconds(self) -> float:
+        duration = float(self.total_duration_seconds)
+        return duration
+
+    def add_llm(self, usage: LLMTokenUsage) -> None:
+        self.llm_prompt_tokens += usage.prompt_tokens or 0
+        self.llm_completion_tokens += usage.completion_tokens or 0
+        self.llm_cached_tokens += (usage.cache_read_input_tokens or 0) + (
+            usage.cache_creation_input_tokens or 0
+        )
+
+    def add_tts_metrics(self, data: Any) -> None:
+        if not self._has_tts_metrics:
+            self._has_tts_metrics = True
+            self.tts_characters = 0  # Ignore manual count if metrics emit natively
+        
+        # Extremely robust extraction
+        val = 0
+        if isinstance(data, (int, float)):
+            val = data
+        elif hasattr(data, "value"):
+            val = getattr(data, "value", 0) or 0
+        elif hasattr(data, "characters"):
+            val = getattr(data, "characters", 0) or 0
+        elif isinstance(data, dict):
+            val = data.get("value") or data.get("characters") or 0
+            
+        try:
+            self.tts_characters += int(val or 0)
+        except Exception:
+            pass
+
+    def add_tts_manual(self, text: str) -> None:
+        if not self._has_tts_metrics:
+            self.tts_characters += len(text)
+
+    def finalize(self) -> None:
+        if self.call_end_abs_ns is None:
+            self.call_end_abs_ns = time.time_ns()
+
+
+def _google_live_usage_to_sts_metadata(usage: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Pure Python translation of Google GenAI Live usage_metadata to
+    Paygent's canonical speech-to-speech /api/v1/voice/speech-to-speech API schema.
+    """
+    if not usage:
+        return {"schemaVersion": 1}
+
+    def _get_val(obj, *keys):
+        if not obj:
+            return None
+        for k in keys:
+            if isinstance(obj, dict):
+                if k in obj: return obj[k]
+            else:
+                if hasattr(obj, k): return getattr(obj, k)
+        return None
+
+    def _get_list(obj, *keys):
+        val = _get_val(obj, *keys)
+        if val is None:
+            return None
+        return list(val) if not isinstance(val, list) else val
+
+    def _optional_int(obj, *keys):
+        val = _get_val(obj, *keys)
+        if val is not None:
+            try:
+                return int(val)
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    def _modality_token_count(details, modality_name):
+        if not details:
+            return 0
+        want = modality_name.upper()
+        total = 0
+        for d in details:
+            try:
+                mod = _get_val(d, "modality")
+                if mod is None:
+                    continue
+                label = _get_val(mod, "name") or _get_val(mod, "value") or mod
+                if str(label).upper() != want:
+                    continue
+                tc = _get_val(d, "token_count", "tokenCount")
+                total += int(tc or 0)
+            except Exception:
+                continue
+        return total
+
+    prompt_details = _get_list(usage, "prompt_tokens_details", "promptTokensDetails")
+    response_details = _get_list(usage, "response_tokens_details", "responseTokensDetails")
+    tool_details = _get_list(usage, "tool_use_prompt_tokens_details", "toolUsePromptTokensDetails")
+    cache_details = _get_list(usage, "cache_tokens_details", "cacheTokensDetails")
+
+    # input side: TEXT + DOCUMENT + AUDIO + IMAGE + VIDEO
+    text_in = _modality_token_count(prompt_details, "TEXT") + _modality_token_count(tool_details, "TEXT")
+    audio_in = _modality_token_count(prompt_details, "AUDIO") + _modality_token_count(tool_details, "AUDIO")
+    image_in = _modality_token_count(prompt_details, "IMAGE") + _modality_token_count(tool_details, "IMAGE")
+    video_in = _modality_token_count(prompt_details, "VIDEO") + _modality_token_count(tool_details, "VIDEO")
+    doc_as_text = _modality_token_count(prompt_details, "DOCUMENT") + _modality_token_count(tool_details, "DOCUMENT")
+    text_in += doc_as_text
+
+    # fallback aggregate mapping
+    tutc = _optional_int(usage, "tool_use_prompt_token_count", "toolUsePromptTokenCount")
+    if tutc is not None and not tool_details:
+        text_in += int(tutc)
+
+    ptc = _optional_int(usage, "prompt_token_count", "promptTokenCount")
+    if ptc is not None and not prompt_details and not tool_details:
+        text_in += int(ptc)
+
+    # output side: TEXT + DOCUMENT + AUDIO + VIDEO
+    text_out = _modality_token_count(response_details, "TEXT") + _modality_token_count(response_details, "DOCUMENT")
+    audio_out = _modality_token_count(response_details, "AUDIO") + _modality_token_count(response_details, "VIDEO")
+
+    rtc = _optional_int(usage, "response_token_count", "responseTokenCount")
+    if text_out == 0 and audio_out == 0 and rtc is not None:
+        # Default fallback to audio output for STS audio connection
+        audio_out = int(rtc)
+
+    # Cache breakdowns
+    cached_text = _modality_token_count(cache_details, "TEXT") + _modality_token_count(cache_details, "DOCUMENT")
+    cached_audio = _modality_token_count(cache_details, "AUDIO") + _modality_token_count(cache_details, "VIDEO")
+    cached_image = _modality_token_count(cache_details, "IMAGE")
+    cached_legacy = _optional_int(usage, "cached_content_token_count", "cachedContentTokenCount")
+
+    # Build response payload
+    out = {"schemaVersion": 1}
+
+    # Input Side
+    inp = {}
+    if text_in > 0: inp["text"] = {"tokens": text_in}
+    if audio_in > 0: inp["audio"] = {"tokens": audio_in}
+    if image_in > 0: inp["image"] = {"tokens": image_in}
+    if video_in > 0: inp["video"] = {"tokens": video_in}
+    if inp: out["input"] = inp
+
+    # Output Side
+    o = {}
+    if text_out > 0: o["text"] = {"tokens": text_out}
+    if audio_out > 0: o["audio"] = {"tokens": audio_out}
+    if o: out["output"] = o
+
+    # Cached breakdown
+    has_split = bool(cached_text or cached_audio or cached_image)
+    if cached_legacy is not None and cached_legacy > 0 and not has_split:
+        out["cached"] = {"tokens": int(cached_legacy)}
+    elif has_split:
+        cd = {}
+        if cached_text > 0: cd["text"] = {"tokens": cached_text}
+        if cached_audio > 0: cd["audio"] = {"tokens": cached_audio}
+        if cached_image > 0: cd["image"] = {"tokens": cached_image}
+        if cd: out["cached"] = cd
+
+    return out
+
+
+
+def _openai_realtime_usage_to_sts_metadata(usage: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Pure Python translation of OpenAI Realtime usage_metadata to
+    Paygent's canonical speech-to-speech /api/v1/voice/speech-to-speech API schema.
+    """
+    if not usage:
+        return {"schemaVersion": 1}
+
+    def _get_val(obj, *keys):
+        if not obj:
+            return None
+        for k in keys:
+            if isinstance(obj, dict):
+                if k in obj: return obj[k]
+            else:
+                if hasattr(obj, k): return getattr(obj, k)
+        return None
+
+    total_in = int(_get_val(usage, "input_tokens", "inputTokens") or 0)
+    total_out = int(_get_val(usage, "output_tokens", "outputTokens") or 0)
+
+    in_details = _get_val(usage, "input_token_details", "inputTokenDetails") or {}
+    out_details = _get_val(usage, "output_token_details", "outputTokenDetails") or {}
+
+    audio_in = int(_get_val(in_details, "audio_tokens", "audioTokens") or 0)
+    text_in = int(_get_val(in_details, "text_tokens", "textTokens") or 0)
+    image_in = int(_get_val(in_details, "image_tokens", "imageTokens") or 0)
+
+    cached_total = int(_get_val(usage, "cached_tokens", "cachedTokens") or _get_val(in_details, "cached_tokens", "cachedTokens") or 0)
+
+    cached_details = _get_val(in_details, "cached_tokens_details", "cachedTokensDetails") or {}
+    cached_audio = int(_get_val(cached_details, "audio_tokens", "audioTokens") or 0)
+    cached_text = int(_get_val(cached_details, "text_tokens", "textTokens") or 0)
+    cached_image = int(_get_val(cached_details, "image_tokens", "imageTokens") or 0)
+
+    if not (cached_audio or cached_text or cached_image):
+        cached_audio = int(_get_val(in_details, "cached_audio_tokens", "cachedAudioTokens") or 0)
+        cached_text = int(_get_val(in_details, "cached_text_tokens", "cachedTextTokens") or 0)
+        cached_image = int(_get_val(in_details, "cached_image_tokens", "cachedImageTokens") or 0)
+
+    audio_out = int(_get_val(out_details, "audio_tokens", "audioTokens") or 0)
+    text_out = int(_get_val(out_details, "text_tokens", "textTokens") or 0)
+
+    if not (text_in or audio_in or image_in) and total_in > 0:
+        text_in = total_in - cached_total
+
+    out = {"schemaVersion": 1}
+    inp = {}
+    if text_in > 0: inp["text"] = {"tokens": text_in}
+    if audio_in > 0: inp["audio"] = {"tokens": audio_in}
+    if image_in > 0: inp["image"] = {"tokens": image_in}
+    if inp: out["input"] = inp
+
+    o = {}
+    if text_out > 0: o["text"] = {"tokens": text_out}
+    if audio_out > 0: o["audio"] = {"tokens": audio_out}
+    if o: out["output"] = o
+
+    has_split = bool(cached_text or cached_audio or cached_image)
+    if cached_total > 0 and not has_split:
+        out["cached"] = {"tokens": int(cached_total)}
+    elif has_split:
+        cd = {}
+        if cached_text > 0: cd["text"] = {"tokens": cached_text}
+        if cached_audio > 0: cd["audio"] = {"tokens": cached_audio}
+        if cached_image > 0: cd["image"] = {"tokens": cached_image}
+        if cd: out["cached"] = cd
+
+    return out
+
+
+def _merge_sts_metadata(existing: dict, new: dict) -> dict:
+    if not existing:
+        return new
+    out = {"schemaVersion": 1}
+    for key in ("input", "output", "cached"):
+        e_val = existing.get(key, {})
+        n_val = new.get(key, {})
+        if not e_val and not n_val:
+            continue
+        
+        merged_cat = {}
+        if "tokens" in e_val or "tokens" in n_val:
+            merged_cat["tokens"] = e_val.get("tokens", 0) + n_val.get("tokens", 0)
+            out[key] = merged_cat
+            continue
+            
+        for modality in ("text", "audio", "image", "video"):
+            e_mod = e_val.get(modality, {}).get("tokens", 0)
+            n_mod = n_val.get(modality, {}).get("tokens", 0)
+            total = e_mod + n_mod
+            if total > 0:
+                merged_cat[modality] = {"tokens": total}
+        if merged_cat:
+            out[key] = merged_cat
+            
+    # retain any other keys, summing up numeric ones to keep metadata consistent
+    for k, v in existing.items():
+        if k not in ("schemaVersion", "input", "output", "cached"):
+            out[k] = v
+    for k, v in new.items():
+        if k not in ("schemaVersion", "input", "output", "cached"):
+            if k in out and isinstance(out[k], (int, float)) and isinstance(v, (int, float)):
+                out[k] = out[k] + v
+            else:
+                out[k] = v
+            
+    return out
+
+class PaygentCollector(BaseObserver):
+    """Pipecat observer that accumulates usage data for a single call.
+
+    Accumulates:
+    - LLM token usage from ``MetricsFrame / LLMUsageMetricsData``
+    - TTS character usage from ``MetricsFrame / TTSUsageMetricsData``
+    - STT audio seconds from ``MetricsFrame`` (when exposed by the pipeline)
+    - Call start / end timestamps for ``total_duration_seconds``
+
+    Does **not** do any network I/O.
+    """
+
+    def __init__(
+        self,
+        *,
+        workflow_run_id: int,
+        is_realtime: bool,
+        stt_provider: str = "",
+        stt_model: str = "",
+        llm_provider: str = "",
+        llm_model: str = "",
+        tts_provider: str = "",
+        tts_model: str = "",
+        sts_provider: str = "",
+        sts_model: str = "",
+    ) -> None:
+        super().__init__()
+        self._workflow_run_id = workflow_run_id
+        self._is_realtime = is_realtime
+        self._stt_provider = stt_provider
+        self._stt_model = stt_model
+        self._llm_provider = llm_provider
+        self._llm_model = llm_model
+        self._tts_provider = tts_provider
+        self._tts_model = tts_model
+        self._sts_provider = sts_provider
+        self._sts_model = sts_model
+        self._acc = _UsageAccumulator()
+        self._call_disposition: str = "completed"
+        # Dedup guard – pipecat sometimes re-delivers frames
+        self._seen_frame_ids: set[int] = set()
+
+    # ------------------------------------------------------------------
+    # Public hooks
+    # ------------------------------------------------------------------
+
+    def set_call_disposition(self, disposition: str | None) -> None:
+        if disposition:
+            self._call_disposition = disposition
+
+    def build_snapshot(self) -> dict[str, Any]:
+        """Return a JSON-serialisable dict stored in ``workflow_run.logs``."""
+        self._acc.finalize()
+        stt_audio_sec = self._acc.get_stt_audio_seconds()
+
+        return {
+            "workflow_run_id": self._workflow_run_id,
+            "is_realtime": self._is_realtime,
+            "stt_provider": self._stt_provider,
+            "stt_model": self._stt_model,
+            "stt_audio_seconds": stt_audio_sec,
+            "llm_provider": self._llm_provider,
+            "llm_model": self._llm_model,
+            "llm_prompt_tokens": self._acc.llm_prompt_tokens,
+            "llm_completion_tokens": self._acc.llm_completion_tokens,
+            "llm_cached_tokens": self._acc.llm_cached_tokens,
+            "tts_provider": self._tts_provider,
+            "tts_model": self._tts_model,
+            "tts_characters": self._acc.tts_characters,
+            "sts_provider": self._sts_provider,
+            "sts_model": self._sts_model,
+            "sts_usage_metadata": self._acc.sts_usage_metadata,
+            "call_disposition": self._call_disposition,
+            "total_duration_seconds": self._acc.total_duration_seconds,
+        }
+
+    # ------------------------------------------------------------------
+    # BaseObserver implementation
+    # ------------------------------------------------------------------
+
+    async def on_push_frame(self, data: FramePushed) -> None:  # type: ignore[override]
+        try:
+            # Only process downstream frames; ignore upstream (mic → STT direction)
+            if data.direction != FrameDirection.DOWNSTREAM:
+                return
+
+            frame = data.frame
+
+            # Dedup
+            if frame.id in self._seen_frame_ids:
+                return
+            self._seen_frame_ids.add(frame.id)
+            # Bound the set to avoid unbounded memory growth on long calls
+            if len(self._seen_frame_ids) > 2000:
+                self._seen_frame_ids.clear()
+
+            if isinstance(frame, StartFrame):
+                self._acc.call_start_abs_ns = time.time_ns()
+
+            elif isinstance(frame, MetricsFrame):
+                for item in frame.data:
+                    if isinstance(item, LLMUsageMetricsData):
+                        is_sts_frame = False
+                        proc_lower = (item.processor or "").lower()
+                        if getattr(self, "_is_realtime", False):
+                            if "realtime" in proc_lower or "live" in proc_lower:
+                                is_sts_frame = True
+
+                        logger.info(
+                            "[paygent_debug] Received LLM frame from processor='{}', is_realtime={}, is_sts_frame={}, tokens_dict={}",
+                            item.processor,
+                            getattr(self, "_is_realtime", False),
+                            is_sts_frame,
+                            item.value.__dict__
+                        )
+
+                        if is_sts_frame:
+                            provider = getattr(self, "_sts_provider", "unknown") or getattr(self, "_llm_provider", "unknown")
+                            if provider not in ("grok", "ultravox", "grok_realtime", "ultravox_realtime"):
+                                usage = item.value
+                                raw_metadata = getattr(usage, "raw_usage_metadata", None)
+                                if raw_metadata:
+                                    if provider in ("openai", "openai_realtime"):
+                                        new_meta = _openai_realtime_usage_to_sts_metadata(raw_metadata)
+                                    else:
+                                        new_meta = _google_live_usage_to_sts_metadata(raw_metadata)
+                                else:
+                                    prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+                                    completion_tokens = getattr(usage, "completion_tokens", 0) or 0
+                                    cached_tokens = (getattr(usage, "cache_read_input_tokens", 0) or getattr(usage, "cached_tokens", 0) or 0)
+                                    new_meta = {"schemaVersion": 1}
+                                    if prompt_tokens > 0:
+                                        new_meta.setdefault("input", {})["text"] = {"tokens": prompt_tokens}
+                                    if completion_tokens > 0:
+                                        new_meta.setdefault("output", {})["text"] = {"tokens": completion_tokens}
+                                    if cached_tokens > 0:
+                                        new_meta["cached"] = {"tokens": cached_tokens}
+                                    
+                                    if hasattr(usage, "__dict__"):
+                                        for k, v in vars(usage).items():
+                                            if not k.startswith("_") and v is not None and k not in new_meta:
+                                                new_meta[k] = v
+                                
+                                self._acc.sts_usage_metadata = _merge_sts_metadata(
+                                    self._acc.sts_usage_metadata or {}, new_meta
+                                )
+                        else:
+                            self._acc.add_llm(item.value)
+                    elif isinstance(item, TTSUsageMetricsData):
+                        chars_val = getattr(item, "value", 0) or 0
+                        self._acc.add_tts_metrics(chars_val)
+                    # STT usage is exposed as a float in TTSUsageMetricsData-like
+                    # structure by some providers; we also pull from the aggregator
+                    # snapshot at call-finish (see runtime.py) for robustness.
+
+            elif isinstance(frame, STSUsageFrame):
+                self._acc.sts_usage_metadata = _merge_sts_metadata(
+                    self._acc.sts_usage_metadata or {}, frame.usage_metadata
+                )
+
+            elif isinstance(frame, TextFrame):
+                # Fallback character counting for providers that don't emit metrics (like Cartesia)
+                self._acc.add_tts_manual(frame.text)
+
+            elif isinstance(frame, (EndFrame, CancelFrame)):
+                self._acc.finalize()
+        except Exception as exc:
+            pass

--- a/api/services/integrations/paygent/completion.py
+++ b/api/services/integrations/paygent/completion.py
@@ -1,0 +1,150 @@
+"""Paygent post-call completion handler.
+
+Reads the ``paygent_snapshot`` that the runtime session stored in
+``workflow_run.logs``, reconstructs the full ``PaygentCallSnapshot``, and
+drives the ordered REST delivery sequence via ``client.deliver()``.
+
+Mirrors ``tuner/completion.py`` exactly:
+- validate each node with Pydantic
+- skip disabled nodes
+- read runtime snapshot from ``context.workflow_run.logs``
+- build a ``PaygentDeliveryConfig`` per node
+- call ``deliver(config, snapshot)``
+- collect results keyed by ``paygent_{node_id}``
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from loguru import logger
+
+from api.services.integrations.base import IntegrationCompletionContext
+
+from .client import PaygentCallSnapshot, PaygentDeliveryConfig, deliver
+from .node import PaygentNodeData
+
+_DEFAULT_BASE_URL = "https://cp-api.withpaygent.com"
+
+
+def _build_snapshot(
+    raw: dict[str, Any],
+    *,
+    workflow_run_id: int,
+) -> PaygentCallSnapshot:
+    """Reconstruct a ``PaygentCallSnapshot`` from the persisted log dict."""
+    return PaygentCallSnapshot(
+        # session_id == str(workflow_run_id) — consistent with Tuner's call_id
+        session_id=str(raw.get("workflow_run_id", workflow_run_id)),
+        agent_id=raw.get("agent_id", ""),          # filled from node config below
+        customer_id=raw.get("customer_id", ""),    # filled from node config below
+        is_realtime=raw.get("is_realtime", False),
+        stt_provider=raw.get("stt_provider", ""),
+        stt_model=raw.get("stt_model", ""),
+        stt_audio_seconds=float(raw.get("stt_audio_seconds", 0.0)),
+        llm_provider=raw.get("llm_provider", ""),
+        llm_model=raw.get("llm_model", ""),
+        llm_prompt_tokens=int(raw.get("llm_prompt_tokens", 0)),
+        llm_completion_tokens=int(raw.get("llm_completion_tokens", 0)),
+        llm_cached_tokens=int(raw.get("llm_cached_tokens", 0)),
+        tts_provider=raw.get("tts_provider", ""),
+        tts_model=raw.get("tts_model", ""),
+        tts_characters=int(raw.get("tts_characters", 0)),
+        sts_provider=raw.get("sts_provider", ""),
+        sts_model=raw.get("sts_model", ""),
+        sts_usage_metadata=raw.get("sts_usage_metadata"),
+        call_disposition=raw.get("call_disposition", "completed"),
+        total_duration_seconds=int(raw.get("total_duration_seconds", 0)),
+    )
+
+
+async def run_completion(
+    nodes: list[dict[str, Any]],
+    context: IntegrationCompletionContext,
+) -> dict[str, Any]:
+    """Post-call completion handler: deliver usage data to Paygent REST API."""
+    results: dict[str, Any] = {}
+
+    raw_snapshot: dict[str, Any] | None = (context.workflow_run.logs or {}).get(
+        "paygent_snapshot"
+    )
+
+    for node in nodes:
+        node_id = node.get("id", "unknown")
+
+        # ---- Validate the node config via Pydantic -------------------------
+        try:
+            node_data = PaygentNodeData.model_validate(node.get("data", {}))
+        except Exception:
+            results[f"paygent_{node_id}"] = {"error": "validation_failed"}
+            continue
+
+        if not node_data.paygent_enabled:
+            continue
+
+        # ---- Guard: runtime snapshot must exist ----------------------------
+        if not raw_snapshot:
+            results[f"paygent_{node_id}"] = {"error": "missing_runtime_snapshot"}
+            continue
+
+        # ---- Build typed objects -------------------------------------------
+        snapshot = _build_snapshot(raw_snapshot, workflow_run_id=context.workflow_run_id)
+        # Inject node-level credentials into the snapshot
+        snapshot.agent_id = (node_data.paygent_agent_id or "").strip()
+        snapshot.customer_id = (node_data.paygent_customer_id or "").strip()
+        snapshot.indicator = (node_data.paygent_indicator or "per-minute-call").strip()
+
+        # Fallback to usage_info if snapshot has 0s (Pipecat metrics might be missing)
+        usage_info = context.workflow_run.usage_info or {}
+        # Only fallback to pipeline-level llm usage if this is NOT a realtime pipeline.
+        # In realtime pipelines, the collector properly segregates STS and LLM tokens; 
+        # falling back here would duplicate the STS tokens into the LLM bucket.
+        if snapshot.llm_prompt_tokens == 0 and snapshot.llm_completion_tokens == 0 and not snapshot.is_realtime:
+            for key, val in usage_info.get("llm", {}).items():
+                snapshot.llm_prompt_tokens += val.get("prompt_tokens", 0)
+                snapshot.llm_completion_tokens += val.get("completion_tokens", 0)
+                snapshot.llm_cached_tokens += val.get("cache_read_input_tokens", 0) + val.get("cache_creation_input_tokens", 0)
+                if not snapshot.llm_provider:
+                    parts = key.split("|||")
+                    if len(parts) == 2:
+                        snapshot.llm_provider, snapshot.llm_model = parts
+        
+        if snapshot.tts_characters == 0:
+            for key, val in usage_info.get("tts", {}).items():
+                snapshot.tts_characters += val
+                if not snapshot.tts_provider:
+                    parts = key.split("|||")
+                    if len(parts) == 2:
+                        snapshot.tts_provider, snapshot.tts_model = parts
+
+        if snapshot.stt_audio_seconds == 0:
+            for key, val in usage_info.get("stt", {}).items():
+                snapshot.stt_audio_seconds += val
+                if not snapshot.stt_provider:
+                    parts = key.split("|||")
+                    if len(parts) == 2:
+                        snapshot.stt_provider, snapshot.stt_model = parts
+
+        try:
+            config = PaygentDeliveryConfig(
+                api_key=(node_data.paygent_api_key or "").strip(),
+                agent_id=snapshot.agent_id,
+                customer_id=snapshot.customer_id,
+            )
+        except Exception as exc:
+            results[f"paygent_{node_id}"] = {"error": f"invalid_config: {exc}"}
+            continue
+
+        # ---- REST delivery -------------------------------------------------
+        try:
+            delivery_result = await deliver(config, snapshot)
+            results[f"paygent_{node_id}"] = {
+                **delivery_result,
+                "agent_id": snapshot.agent_id,
+                "customer_id": snapshot.customer_id,
+                "exported_at": datetime.now(UTC).isoformat(),
+            }
+        except Exception as exc:
+            results[f"paygent_{node_id}"] = {"error": str(exc)}
+
+    return results

--- a/api/services/integrations/paygent/completion.py
+++ b/api/services/integrations/paygent/completion.py
@@ -34,8 +34,10 @@ def _build_snapshot(
 ) -> PaygentCallSnapshot:
     """Reconstruct a ``PaygentCallSnapshot`` from the persisted log dict."""
     return PaygentCallSnapshot(
-        # session_id == str(workflow_run_id) — consistent with Tuner's call_id
-        session_id=str(raw.get("workflow_run_id", workflow_run_id)),
+        # session_id is always the authoritative workflow_run_id; the persisted
+        # snapshot value is never used to override it, preventing billing drift
+        # if the log is stale or corrupted.
+        session_id=str(workflow_run_id),
         agent_id=raw.get("agent_id", ""),          # filled from node config below
         customer_id=raw.get("customer_id", ""),    # filled from node config below
         is_realtime=raw.get("is_realtime", False),
@@ -96,34 +98,60 @@ async def run_completion(
 
         # Fallback to usage_info if snapshot has 0s (Pipecat metrics might be missing)
         usage_info = context.workflow_run.usage_info or {}
-        # Only fallback to pipeline-level llm usage if this is NOT a realtime pipeline.
-        # In realtime pipelines, the collector properly segregates STS and LLM tokens; 
-        # falling back here would duplicate the STS tokens into the LLM bucket.
-        if snapshot.llm_prompt_tokens == 0 and snapshot.llm_completion_tokens == 0 and not snapshot.is_realtime:
-            for key, val in usage_info.get("llm", {}).items():
-                snapshot.llm_prompt_tokens += val.get("prompt_tokens", 0)
-                snapshot.llm_completion_tokens += val.get("completion_tokens", 0)
-                snapshot.llm_cached_tokens += val.get("cache_read_input_tokens", 0) + val.get("cache_creation_input_tokens", 0)
-                if not snapshot.llm_provider:
+        try:
+            # Only fallback to pipeline-level llm usage if this is NOT a realtime pipeline.
+            # In realtime pipelines, the collector properly segregates STS and LLM tokens;
+            # falling back here would duplicate the STS tokens into the LLM bucket.
+            if snapshot.llm_prompt_tokens == 0 and snapshot.llm_completion_tokens == 0 and not snapshot.is_realtime:
+                llm_providers: list[str] = []
+                llm_models: list[str] = []
+                for key, val in usage_info.get("llm", {}).items():
+                    snapshot.llm_prompt_tokens += val.get("prompt_tokens", 0)
+                    snapshot.llm_completion_tokens += val.get("completion_tokens", 0)
+                    snapshot.llm_cached_tokens += val.get("cache_read_input_tokens", 0) + val.get("cache_creation_input_tokens", 0)
                     parts = key.split("|||")
                     if len(parts) == 2:
-                        snapshot.llm_provider, snapshot.llm_model = parts
-        
-        if snapshot.tts_characters == 0:
-            for key, val in usage_info.get("tts", {}).items():
-                snapshot.tts_characters += val
-                if not snapshot.tts_provider:
-                    parts = key.split("|||")
-                    if len(parts) == 2:
-                        snapshot.tts_provider, snapshot.tts_model = parts
+                        llm_providers.append(parts[0])
+                        llm_models.append(parts[1])
+                if not snapshot.llm_provider and llm_providers:
+                    snapshot.llm_provider = ",".join(dict.fromkeys(llm_providers))
+                if not snapshot.llm_model and llm_models:
+                    snapshot.llm_model = ",".join(dict.fromkeys(llm_models))
 
-        if snapshot.stt_audio_seconds == 0:
-            for key, val in usage_info.get("stt", {}).items():
-                snapshot.stt_audio_seconds += val
-                if not snapshot.stt_provider:
+            if snapshot.tts_characters == 0:
+                tts_providers: list[str] = []
+                tts_models: list[str] = []
+                for key, val in usage_info.get("tts", {}).items():
+                    snapshot.tts_characters += val
                     parts = key.split("|||")
                     if len(parts) == 2:
-                        snapshot.stt_provider, snapshot.stt_model = parts
+                        tts_providers.append(parts[0])
+                        tts_models.append(parts[1])
+                if not snapshot.tts_provider and tts_providers:
+                    snapshot.tts_provider = ",".join(dict.fromkeys(tts_providers))
+                if not snapshot.tts_model and tts_models:
+                    snapshot.tts_model = ",".join(dict.fromkeys(tts_models))
+
+            if snapshot.stt_audio_seconds == 0:
+                stt_providers: list[str] = []
+                stt_models: list[str] = []
+                for key, val in usage_info.get("stt", {}).items():
+                    snapshot.stt_audio_seconds += val
+                    parts = key.split("|||")
+                    if len(parts) == 2:
+                        stt_providers.append(parts[0])
+                        stt_models.append(parts[1])
+                if not snapshot.stt_provider and stt_providers:
+                    snapshot.stt_provider = ",".join(dict.fromkeys(stt_providers))
+                if not snapshot.stt_model and stt_models:
+                    snapshot.stt_model = ",".join(dict.fromkeys(stt_models))
+
+                # 3rd fallback: if STT audio seconds is still 0 in a standard (non-realtime) call,
+                # fall back to the call's total wall-clock duration.
+                if snapshot.stt_audio_seconds == 0 and not snapshot.is_realtime:
+                    snapshot.stt_audio_seconds = float(snapshot.total_duration_seconds)
+        except Exception as exc:
+            logger.warning("[paygent] Failed to apply usage_info fallback for run {}: {}", context.workflow_run_id, exc)
 
         try:
             config = PaygentDeliveryConfig(

--- a/api/services/integrations/paygent/node.py
+++ b/api/services/integrations/paygent/node.py
@@ -127,6 +127,8 @@ class PaygentNodeData(BaseNodeData):
             missing.append("paygent_agent_id")
         if not self.paygent_customer_id or not self.paygent_customer_id.strip():
             missing.append("paygent_customer_id")
+        if not self.paygent_indicator or not self.paygent_indicator.strip():
+            missing.append("paygent_indicator")
 
         if missing:
             fields = ", ".join(missing)

--- a/api/services/integrations/paygent/node.py
+++ b/api/services/integrations/paygent/node.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pydantic import model_validator
+
+from api.services.integrations.base import IntegrationNodeRegistration
+from api.services.workflow.node_data import BaseNodeData
+from api.services.workflow.node_specs._base import (
+    GraphConstraints,
+    NodeCategory,
+    NodeExample,
+    PropertyType,
+)
+from api.services.workflow.node_specs.model_spec import (
+    build_spec,
+    node_spec,
+    spec_field,
+)
+
+
+@node_spec(
+    name="paygent",
+    display_name="Paygent",
+    description="Cost Tracking and Billing",
+    llm_hint=(
+        "Paygent is a post-call usage-tracking and billing integration. "
+        "It does not participate in the conversation graph and should not be connected to other nodes."
+    ),
+    category=NodeCategory.integration,
+    icon="CreditCard",
+    examples=[
+        NodeExample(
+            name="paygent_tracking",
+            data={
+                "name": "Paygent Tracking",
+                "paygent_enabled": True,
+                "paygent_api_key": "pg_live_xxxxxxxxxxxxxxxx",
+                "paygent_agent_id": "my-voice-agent-prod",
+                "paygent_customer_id": "org-123",
+                "paygent_indicator": "per-minute-call",
+            },
+        )
+    ],
+    graph_constraints=GraphConstraints(
+        min_incoming=0, max_incoming=0, min_outgoing=0, max_outgoing=0, max_instances=1
+    ),
+    property_order=(
+        "name",
+        "paygent_enabled",
+        "paygent_api_key",
+        "paygent_agent_id",
+        "paygent_customer_id",
+        "paygent_indicator",
+    ),
+    field_overrides={
+        "name": {
+            "spec_default": "Paygent",
+            "description": "Short identifier for this Paygent configuration.",
+        },
+        "paygent_enabled": {
+            "display_name": "Enabled",
+            "description": "When false, Dograh skips all Paygent tracking for this call.",
+        },
+        "paygent_api_key": {
+            "display_name": "Paygent API Key",
+            "description": "API key used to authenticate requests to the Paygent REST API.",
+            "required": True,
+        },
+        "paygent_agent_id": {
+            "display_name": "Agent ID",
+            "description": "The agent identifier registered in your Paygent account.",
+            "required": True,
+        },
+        "paygent_customer_id": {
+            "display_name": "Customer ID",
+            "description": "Your Paygent customer / organisation ID.",
+            "required": True,
+        },
+        "paygent_indicator": {
+            "display_name": "Indicator",
+            "description": "The indicator event name sent at the end of the call (e.g. per-minute-call).",
+            "required": True,
+            "spec_default": "per-minute-call",
+        },
+    },
+)
+class PaygentNodeData(BaseNodeData):
+    paygent_enabled: bool = spec_field(
+        default=True,
+        ui_type=PropertyType.boolean,
+        display_name="Enabled",
+        description="When false, Dograh skips all Paygent tracking for this call.",
+    )
+    paygent_api_key: str | None = spec_field(
+        default=None,
+        ui_type=PropertyType.string,
+        display_name="Paygent API Key",
+        description="API key used to authenticate requests to the Paygent REST API.",
+    )
+    paygent_agent_id: str | None = spec_field(
+        default=None,
+        ui_type=PropertyType.string,
+        display_name="Agent ID",
+        description="The agent identifier registered in your Paygent account.",
+    )
+    paygent_customer_id: str | None = spec_field(
+        default=None,
+        ui_type=PropertyType.string,
+        display_name="Customer ID",
+        description="Your Paygent customer / organisation ID.",
+    )
+    paygent_indicator: str = spec_field(
+        default="per-minute-call",
+        ui_type=PropertyType.string,
+        display_name="Indicator",
+        description="The indicator event name sent at the end of the call (e.g. per-minute-call).",
+    )
+
+    @model_validator(mode="after")
+    def _validate_enabled_config(self) -> "PaygentNodeData":
+        if not self.paygent_enabled:
+            return self
+
+        missing: list[str] = []
+        if not self.paygent_api_key or not self.paygent_api_key.strip():
+            missing.append("paygent_api_key")
+        if not self.paygent_agent_id or not self.paygent_agent_id.strip():
+            missing.append("paygent_agent_id")
+        if not self.paygent_customer_id or not self.paygent_customer_id.strip():
+            missing.append("paygent_customer_id")
+
+        if missing:
+            fields = ", ".join(missing)
+            raise ValueError(
+                f"Paygent node is enabled but missing required fields: {fields}"
+            )
+
+        return self
+
+
+SPEC = build_spec(PaygentNodeData)
+
+NODE = IntegrationNodeRegistration(
+    type_name="paygent",
+    data_model=PaygentNodeData,
+    node_spec=SPEC,
+    sensitive_fields=("paygent_api_key",),
+)

--- a/api/services/integrations/paygent/runtime.py
+++ b/api/services/integrations/paygent/runtime.py
@@ -1,0 +1,142 @@
+"""Paygent runtime session.
+
+Wires the ``PaygentCollector`` into the live pipecat pipeline exactly the way
+``TunerRuntimeSession`` wires ``TunerCollector``.
+
+Lifecycle:
+  1. ``create_runtime_sessions`` scans the workflow graph for an enabled
+     ``paygent`` node and, if found, builds a collector from context metadata.
+  2. ``attach`` hooks the collector into the task as a pipeline observer so it
+     receives all ``MetricsFrame`` events during the call.
+  3. ``on_call_finished`` seals the snapshot and returns it to the generic
+     integration framework, which persists it in ``workflow_run.logs`` under
+     the key ``"paygent_snapshot"``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from api.services.configuration.registry import ServiceProviders
+from api.services.integrations.base import (
+    IntegrationRuntimeContext,
+    IntegrationRuntimeSession,
+)
+
+from .collector import PaygentCollector
+
+
+def _label(provider: str | None, model: str | None) -> str:
+    """Compose a human-readable ``provider/model`` label."""
+    if provider and model:
+        return f"{provider}/{model}"
+    return model or provider or ""
+
+
+def _resolve_model_labels(
+    context: IntegrationRuntimeContext,
+) -> tuple[str, str, str, str, str, str, str, str]:
+    """Return (stt_provider, stt_model, llm_provider, llm_model,
+               tts_provider, tts_model, sts_provider, sts_model).
+
+    Mirrors the logic in ``tuner/runtime.py:_resolve_model_labels``.
+    """
+    user_config = context.user_config
+
+    if context.is_realtime and user_config.realtime:
+        realtime_provider = getattr(user_config.realtime, "provider", "") or ""
+        realtime_model = getattr(user_config.realtime, "model", "") or ""
+        llm_provider = getattr(user_config.llm, "provider", "") or ""
+        llm_model = getattr(user_config.llm, "model", "") or ""
+        return (
+            "",              # stt_provider  (no separate STT in realtime)
+            "",              # stt_model
+            llm_provider,
+            llm_model,
+            "",              # tts_provider  (no separate TTS in realtime)
+            "",              # tts_model
+            realtime_provider,
+            realtime_model,
+        )
+
+    return (
+        getattr(user_config.stt, "provider", "") or "",
+        getattr(user_config.stt, "model", "") or "",
+        getattr(user_config.llm, "provider", "") or "",
+        getattr(user_config.llm, "model", "") or "",
+        getattr(user_config.tts, "provider", "") or "",
+        getattr(user_config.tts, "model", "") or "",
+        "",  # sts_provider
+        "",  # sts_model
+    )
+
+
+class PaygentRuntimeSession(IntegrationRuntimeSession):
+    """Thin wrapper that connects the collector to the pipeline task."""
+
+    name = "paygent"
+
+    def __init__(self, collector: PaygentCollector) -> None:
+        self._collector = collector
+
+    # --- IntegrationRuntimeSession protocol --------------------------------
+
+    def attach(self, task: Any) -> None:
+        """Register the collector as a pipeline observer."""
+        task.add_observer(self._collector)
+
+    async def on_call_finished(
+        self,
+        *,
+        gathered_context: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Seal the snapshot and hand it to the framework for persistence."""
+        self._collector.set_call_disposition(
+            gathered_context.get("call_disposition")
+        )
+        snapshot = self._collector.build_snapshot()
+        return {"paygent_snapshot": snapshot}
+
+
+# ---------------------------------------------------------------------------
+# Runtime session factory (called by the generic integration framework)
+# ---------------------------------------------------------------------------
+
+
+def create_runtime_sessions(
+    context: IntegrationRuntimeContext,
+) -> list[IntegrationRuntimeSession]:
+    """Return a ``PaygentRuntimeSession`` if a live, enabled paygent node exists."""
+    paygent_nodes = [
+        node
+        for node in context.workflow_graph.nodes.values()
+        if node.node_type == "paygent"
+        and getattr(node.data, "paygent_enabled", True)
+    ]
+    if not paygent_nodes:
+        return []
+
+    (
+        stt_provider,
+        stt_model,
+        llm_provider,
+        llm_model,
+        tts_provider,
+        tts_model,
+        sts_provider,
+        sts_model,
+    ) = _resolve_model_labels(context)
+
+    collector = PaygentCollector(
+        workflow_run_id=context.workflow_run_id,
+        is_realtime=context.is_realtime,
+        stt_provider=stt_provider,
+        stt_model=stt_model,
+        llm_provider=llm_provider,
+        llm_model=llm_model,
+        tts_provider=tts_provider,
+        tts_model=tts_model,
+        sts_provider=sts_provider,
+        sts_model=sts_model,
+    )
+
+    return [PaygentRuntimeSession(collector)]

--- a/api/services/pipecat/realtime/gemini_live.py
+++ b/api/services/pipecat/realtime/gemini_live.py
@@ -266,3 +266,19 @@ class DograhGeminiLiveLLMService(GeminiLiveLLMService):
         # a handle (e.g. node transitions before any handle was issued) are
         # followed by a function-call-result LLMContextFrame which feeds the
         # updated-context branch in _handle_context.
+
+    async def _handle_msg_usage_metadata(self, message):
+        """Intercept the usage metadata message for detailed STS multimodal extraction."""
+        # Allow Pipecat to process and emit standard LLM metrics
+        await super()._handle_msg_usage_metadata(message)
+        
+        try:
+            if getattr(message, "usage_metadata", None):
+                from api.services.pipecat.realtime.paygent_sts_frames import STSUsageFrame, extract_google_live_sts_usage
+                
+                # Extract highly accurate custom multimodal metadata
+                sts_meta = extract_google_live_sts_usage(message.usage_metadata)
+                if sts_meta:
+                    await self.push_frame(STSUsageFrame(usage_metadata=sts_meta))
+        except Exception as e:
+            logger.error(f"[paygent] Failed to extract custom Gemini STS usage: {e}")

--- a/api/services/pipecat/realtime/openai_realtime.py
+++ b/api/services/pipecat/realtime/openai_realtime.py
@@ -317,6 +317,18 @@ class DograhOpenAIRealtimeLLMService(OpenAIRealtimeLLMService):
         except Exception as e:
             logger.error(f"Failed to process function call arguments: {e}")
 
+    async def _handle_evt_response_done(self, evt):
+        # Allow Pipecat to process and emit standard LLM metrics
+        await super()._handle_evt_response_done(evt)
+
+        try:
+            from api.services.pipecat.realtime.paygent_sts_frames import STSUsageFrame, extract_openai_realtime_sts_usage
+            sts_meta = extract_openai_realtime_sts_usage(evt)
+            if sts_meta:
+                await self.push_frame(STSUsageFrame(usage_metadata=sts_meta))
+        except Exception as e:
+            logger.error(f"[paygent] Failed to extract custom STS usage: {e}")
+
     # ------------------------------------------------------------------
     # Transcription: broadcast with finalized=True for every
     # completed-transcription event from OpenAI.

--- a/api/services/pipecat/realtime/paygent_sts_frames.py
+++ b/api/services/pipecat/realtime/paygent_sts_frames.py
@@ -1,0 +1,174 @@
+from pipecat.frames.frames import Frame
+from dataclasses import dataclass
+
+@dataclass
+class STSUsageFrame(Frame):
+    """Custom frame to carry rich multimodal usage from realtime models."""
+    usage_metadata: dict
+
+def extract_openai_realtime_sts_usage(evt) -> dict:
+    """Extract full audio and text token details from OpenAI response.done event."""
+    usage = getattr(evt.response, "usage", None)
+    if not usage:
+        return {}
+
+    total_in = getattr(usage, "input_tokens", 0)
+    total_out = getattr(usage, "output_tokens", 0)
+    total = getattr(usage, "total_tokens", 0)
+
+    in_details = getattr(usage, "input_token_details", None)
+    out_details = getattr(usage, "output_token_details", None)
+
+    # Inputs
+    audio_in = getattr(in_details, "audio_tokens", 0) if in_details else 0
+    text_in = getattr(in_details, "text_tokens", 0) if in_details else 0
+    cached_total = getattr(in_details, "cached_tokens", 0) if in_details else getattr(usage, "cache_read_input_tokens", 0)
+
+    # Outputs
+    audio_out = getattr(out_details, "audio_tokens", 0) if out_details else 0
+    text_out = getattr(out_details, "text_tokens", 0) if out_details else 0
+
+    # Fallback
+    if not (text_in or audio_in) and total_in > 0:
+        text_in = total_in - cached_total
+
+    meta = {"schemaVersion": 1}
+    meta["prompt_tokens"] = total_in
+    meta["completion_tokens"] = total_out
+    meta["total_tokens"] = total
+    
+    if cached_total > 0:
+        meta["cache_read_input_tokens"] = cached_total
+
+    input_side = {}
+    if text_in > 0:
+        input_side["text"] = {"tokens": text_in}
+    if audio_in > 0:
+        input_side["audio"] = {"tokens": audio_in}
+    
+    output_side = {}
+    if text_out > 0:
+        output_side["text"] = {"tokens": text_out}
+    if audio_out > 0:
+        output_side["audio"] = {"tokens": audio_out}
+    
+    if input_side:
+        meta["input"] = input_side
+    if output_side:
+        meta["output"] = output_side
+    
+    if cached_total > 0:
+        meta["cached"] = {"tokens": cached_total}
+        
+    return meta
+
+def _get_list(usage, *keys):
+    for k in keys:
+        v = usage.get(k) if isinstance(usage, dict) else getattr(usage, k, None)
+        if v is not None:
+            return list(v) if not isinstance(v, list) else v
+    return None
+
+def _optional_int(usage, *keys):
+    for k in keys:
+        v = usage.get(k) if isinstance(usage, dict) else getattr(usage, k, None)
+        if v is not None:
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                return None
+    return None
+
+def _modality_token_count(details, modality_name):
+    if not details:
+        return 0
+    want = modality_name.upper()
+    total = 0
+    for d in details:
+        try:
+            mod = getattr(d, "modality", None)
+            if mod is None and isinstance(d, dict):
+                mod = d.get("modality")
+            if mod is None:
+                continue
+            label = getattr(mod, "name", None) or getattr(mod, "value", None) or mod
+            if str(label).upper() != want:
+                continue
+            tc = getattr(d, "token_count", None)
+            if tc is None and isinstance(d, dict):
+                tc = d.get("tokenCount") or d.get("token_count")
+            total += int(tc or 0)
+        except Exception:
+            continue
+    return total
+
+def extract_google_live_sts_usage(usage) -> dict:
+    """Extract full multimodal usage from Google Live UsageMetadata object/dict."""
+    if usage is None:
+        return {}
+
+    prompt_details = _get_list(usage, "prompt_tokens_details", "promptTokensDetails")
+    response_details = _get_list(usage, "response_tokens_details", "responseTokensDetails")
+    tool_details = _get_list(usage, "tool_use_prompt_tokens_details", "toolUsePromptTokensDetails")
+    cache_details = _get_list(usage, "cache_tokens_details", "cacheTokensDetails")
+
+    text_in = _modality_token_count(prompt_details, "TEXT") + _modality_token_count(tool_details, "TEXT") + _modality_token_count(prompt_details, "DOCUMENT") + _modality_token_count(tool_details, "DOCUMENT")
+    audio_in = _modality_token_count(prompt_details, "AUDIO") + _modality_token_count(tool_details, "AUDIO")
+    image_in = _modality_token_count(prompt_details, "IMAGE") + _modality_token_count(tool_details, "IMAGE")
+    video_in = _modality_token_count(prompt_details, "VIDEO") + _modality_token_count(tool_details, "VIDEO")
+
+    tutc = _optional_int(usage, "tool_use_prompt_token_count", "toolUsePromptTokenCount")
+    if tutc is not None and not tool_details:
+        text_in += int(tutc)
+
+    ptc = _optional_int(usage, "prompt_token_count", "promptTokenCount")
+    if ptc is not None and not prompt_details and not tool_details:
+        text_in += int(ptc)
+
+    text_out = _modality_token_count(response_details, "TEXT") + _modality_token_count(response_details, "DOCUMENT")
+    audio_out = _modality_token_count(response_details, "AUDIO") + _modality_token_count(response_details, "VIDEO")
+
+    rtc = _optional_int(usage, "response_token_count", "responseTokenCount")
+    if text_out == 0 and audio_out == 0 and rtc is not None:
+        audio_out = int(rtc)
+
+    cached_text = _modality_token_count(cache_details, "TEXT") + _modality_token_count(cache_details, "DOCUMENT")
+    cached_audio = _modality_token_count(cache_details, "AUDIO") + _modality_token_count(cache_details, "VIDEO")
+    cached_image = _modality_token_count(cache_details, "IMAGE")
+    cached_legacy = _optional_int(usage, "cached_content_token_count", "cachedContentTokenCount")
+
+    meta = {"schemaVersion": 1}
+    
+    total_prompt = ptc or text_in + audio_in + image_in + video_in
+    total_completion = rtc or text_out + audio_out
+    
+    meta["prompt_tokens"] = total_prompt
+    meta["completion_tokens"] = total_completion
+    meta["total_tokens"] = _optional_int(usage, "total_token_count", "totalTokenCount") or (total_prompt + total_completion)
+
+    cached_total = cached_legacy or (cached_text + cached_audio + cached_image)
+    if cached_total and cached_total > 0:
+        meta["cache_read_input_tokens"] = cached_total
+
+    input_side = {}
+    if text_in > 0: input_side["text"] = {"tokens": text_in}
+    if audio_in > 0: input_side["audio"] = {"tokens": audio_in}
+    if image_in > 0: input_side["image"] = {"tokens": image_in}
+    if video_in > 0: input_side["video"] = {"tokens": video_in}
+    
+    output_side = {}
+    if text_out > 0: output_side["text"] = {"tokens": text_out}
+    if audio_out > 0: output_side["audio"] = {"tokens": audio_out}
+    
+    if input_side: meta["input"] = input_side
+    if output_side: meta["output"] = output_side
+    
+    if cached_text or cached_audio or cached_image:
+        meta["cached"] = {}
+        if cached_text > 0: meta["cached"]["text"] = {"tokens": cached_text}
+        if cached_audio > 0: meta["cached"]["audio"] = {"tokens": cached_audio}
+        if cached_image > 0: meta["cached"]["image"] = {"tokens": cached_image}
+    elif cached_legacy and cached_legacy > 0:
+        meta["cached"] = {"tokens": int(cached_legacy)}
+
+    return meta

--- a/api/services/pipecat/realtime/paygent_sts_frames.py
+++ b/api/services/pipecat/realtime/paygent_sts_frames.py
@@ -1,20 +1,27 @@
 from pipecat.frames.frames import Frame
 from dataclasses import dataclass
 
+
 @dataclass
 class STSUsageFrame(Frame):
     """Custom frame to carry rich multimodal usage from realtime models."""
     usage_metadata: dict
 
+
 def extract_openai_realtime_sts_usage(evt) -> dict:
-    """Extract full audio and text token details from OpenAI response.done event."""
+    """Extract full audio and text token details from OpenAI response.done event.
+
+    Preserves per-modality cached token breakdown (text, audio, image) from
+    ``input_token_details.cached_tokens_details`` when available, consistent
+    with the collector's ``_openai_realtime_usage_to_sts_metadata`` helper.
+    """
     usage = getattr(evt.response, "usage", None)
     if not usage:
         return {}
 
-    total_in = getattr(usage, "input_tokens", 0)
-    total_out = getattr(usage, "output_tokens", 0)
-    total = getattr(usage, "total_tokens", 0)
+    total_in = getattr(usage, "input_tokens", 0) or 0
+    total_out = getattr(usage, "output_tokens", 0) or 0
+    total = getattr(usage, "total_tokens", 0) or 0
 
     in_details = getattr(usage, "input_token_details", None)
     out_details = getattr(usage, "output_token_details", None)
@@ -22,45 +29,77 @@ def extract_openai_realtime_sts_usage(evt) -> dict:
     # Inputs
     audio_in = getattr(in_details, "audio_tokens", 0) if in_details else 0
     text_in = getattr(in_details, "text_tokens", 0) if in_details else 0
-    cached_total = getattr(in_details, "cached_tokens", 0) if in_details else getattr(usage, "cache_read_input_tokens", 0)
+    image_in = getattr(in_details, "image_tokens", 0) if in_details else 0
+
+    # Cache: prefer per-modality details; fall back to aggregate total
+    cached_details = getattr(in_details, "cached_tokens_details", None) if in_details else None
+    cached_audio = getattr(cached_details, "audio_tokens", 0) if cached_details else 0
+    cached_text = getattr(cached_details, "text_tokens", 0) if cached_details else 0
+    cached_image = getattr(cached_details, "image_tokens", 0) if cached_details else 0
+
+    # Also check flat per-modality fields (alternative SDK shapes)
+    if not (cached_audio or cached_text or cached_image) and in_details:
+        cached_audio = getattr(in_details, "cached_audio_tokens", 0) or 0
+        cached_text = getattr(in_details, "cached_text_tokens", 0) or 0
+        cached_image = getattr(in_details, "cached_image_tokens", 0) or 0
+
+    cached_total = (
+        int(getattr(in_details, "cached_tokens", 0) or 0)
+        if in_details
+        else int(getattr(usage, "cache_read_input_tokens", 0) or 0)
+    )
 
     # Outputs
     audio_out = getattr(out_details, "audio_tokens", 0) if out_details else 0
     text_out = getattr(out_details, "text_tokens", 0) if out_details else 0
 
-    # Fallback
-    if not (text_in or audio_in) and total_in > 0:
+    # Fallback: when no per-modality input split is available, treat non-cached as text
+    if not (text_in or audio_in or image_in) and total_in > 0:
         text_in = total_in - cached_total
 
-    meta = {"schemaVersion": 1}
+    meta: dict = {"schemaVersion": 1}
     meta["prompt_tokens"] = total_in
     meta["completion_tokens"] = total_out
     meta["total_tokens"] = total
-    
+
     if cached_total > 0:
         meta["cache_read_input_tokens"] = cached_total
 
-    input_side = {}
+    input_side: dict = {}
     if text_in > 0:
         input_side["text"] = {"tokens": text_in}
     if audio_in > 0:
         input_side["audio"] = {"tokens": audio_in}
-    
-    output_side = {}
+    if image_in > 0:
+        input_side["image"] = {"tokens": image_in}
+    if input_side:
+        meta["input"] = input_side
+
+    output_side: dict = {}
     if text_out > 0:
         output_side["text"] = {"tokens": text_out}
     if audio_out > 0:
         output_side["audio"] = {"tokens": audio_out}
-    
-    if input_side:
-        meta["input"] = input_side
     if output_side:
         meta["output"] = output_side
-    
-    if cached_total > 0:
+
+    # Emit per-modality cached breakdown when available; fall back to aggregate total
+    has_split = bool(cached_text or cached_audio or cached_image)
+    if has_split:
+        cached_side: dict = {}
+        if cached_text > 0:
+            cached_side["text"] = {"tokens": cached_text}
+        if cached_audio > 0:
+            cached_side["audio"] = {"tokens": cached_audio}
+        if cached_image > 0:
+            cached_side["image"] = {"tokens": cached_image}
+        if cached_side:
+            meta["cached"] = cached_side
+    elif cached_total > 0:
         meta["cached"] = {"tokens": cached_total}
-        
+
     return meta
+
 
 def _get_list(usage, *keys):
     for k in keys:
@@ -68,6 +107,7 @@ def _get_list(usage, *keys):
         if v is not None:
             return list(v) if not isinstance(v, list) else v
     return None
+
 
 def _optional_int(usage, *keys):
     for k in keys:
@@ -78,6 +118,7 @@ def _optional_int(usage, *keys):
             except (TypeError, ValueError):
                 return None
     return None
+
 
 def _modality_token_count(details, modality_name):
     if not details:
@@ -102,8 +143,16 @@ def _modality_token_count(details, modality_name):
             continue
     return total
 
+
 def extract_google_live_sts_usage(usage) -> dict:
-    """Extract full multimodal usage from Google Live UsageMetadata object/dict."""
+    """Extract full multimodal usage from Google Live UsageMetadata object/dict.
+
+    Correctly accounts for:
+    - Tool-use tokens added into ``prompt_tokens`` (``tool_use_prompt_token_count``).
+    - Thinking-model tokens (``thoughts_token_count`` / ``thinking_token_count``)
+      added into ``completion_tokens``.
+    - Accurate ``total_tokens`` reflecting all of the above.
+    """
     if usage is None:
         return {}
 
@@ -112,62 +161,113 @@ def extract_google_live_sts_usage(usage) -> dict:
     tool_details = _get_list(usage, "tool_use_prompt_tokens_details", "toolUsePromptTokensDetails")
     cache_details = _get_list(usage, "cache_tokens_details", "cacheTokensDetails")
 
-    text_in = _modality_token_count(prompt_details, "TEXT") + _modality_token_count(tool_details, "TEXT") + _modality_token_count(prompt_details, "DOCUMENT") + _modality_token_count(tool_details, "DOCUMENT")
+    text_in = (
+        _modality_token_count(prompt_details, "TEXT")
+        + _modality_token_count(tool_details, "TEXT")
+        + _modality_token_count(prompt_details, "DOCUMENT")
+        + _modality_token_count(tool_details, "DOCUMENT")
+    )
     audio_in = _modality_token_count(prompt_details, "AUDIO") + _modality_token_count(tool_details, "AUDIO")
     image_in = _modality_token_count(prompt_details, "IMAGE") + _modality_token_count(tool_details, "IMAGE")
     video_in = _modality_token_count(prompt_details, "VIDEO") + _modality_token_count(tool_details, "VIDEO")
 
+    # Fallback: when no per-modality prompt details exist, use aggregate counts
     tutc = _optional_int(usage, "tool_use_prompt_token_count", "toolUsePromptTokenCount")
-    if tutc is not None and not tool_details:
+    ptc = _optional_int(usage, "prompt_token_count", "promptTokenCount")
+
+    if not prompt_details and not tool_details:
+        # Neither modality list is present: use scalar fallbacks
+        if ptc is not None:
+            text_in += int(ptc)
+        if tutc is not None:
+            text_in += int(tutc)
+    elif tutc is not None and not tool_details:
+        # Prompt details exist but tool_details don't — add tool aggregate
         text_in += int(tutc)
 
-    ptc = _optional_int(usage, "prompt_token_count", "promptTokenCount")
-    if ptc is not None and not prompt_details and not tool_details:
-        text_in += int(ptc)
+    text_out = (
+        _modality_token_count(response_details, "TEXT")
+        + _modality_token_count(response_details, "DOCUMENT")
+    )
+    audio_out = (
+        _modality_token_count(response_details, "AUDIO")
+        + _modality_token_count(response_details, "VIDEO")
+    )
 
-    text_out = _modality_token_count(response_details, "TEXT") + _modality_token_count(response_details, "DOCUMENT")
-    audio_out = _modality_token_count(response_details, "AUDIO") + _modality_token_count(response_details, "VIDEO")
+    # Thinking/reasoning tokens (Gemini 2.5+ thinking models)
+    thinking_tokens = _optional_int(
+        usage,
+        "thoughts_token_count", "thoughtsTokenCount",
+        "thinking_token_count", "thinkingTokenCount",
+    ) or 0
 
     rtc = _optional_int(usage, "response_token_count", "responseTokenCount")
     if text_out == 0 and audio_out == 0 and rtc is not None:
+        # Default fallback to audio output for STS audio connection
         audio_out = int(rtc)
 
+    # Cache breakdowns
     cached_text = _modality_token_count(cache_details, "TEXT") + _modality_token_count(cache_details, "DOCUMENT")
     cached_audio = _modality_token_count(cache_details, "AUDIO") + _modality_token_count(cache_details, "VIDEO")
     cached_image = _modality_token_count(cache_details, "IMAGE")
     cached_legacy = _optional_int(usage, "cached_content_token_count", "cachedContentTokenCount")
 
-    meta = {"schemaVersion": 1}
-    
-    total_prompt = ptc or text_in + audio_in + image_in + video_in
-    total_completion = rtc or text_out + audio_out
-    
-    meta["prompt_tokens"] = total_prompt
-    meta["completion_tokens"] = total_completion
-    meta["total_tokens"] = _optional_int(usage, "total_token_count", "totalTokenCount") or (total_prompt + total_completion)
+    meta: dict = {"schemaVersion": 1}
+
+    # Use the API-reported totals when available; they are the ground truth.
+    # tool_use_prompt_token_count is included in prompt_token_count per the API spec,
+    # so we do NOT double-add it when ptc is provided.
+    reported_ptc = ptc or (text_in + audio_in + image_in + video_in)
+    # completion_tokens includes thinking tokens per billing semantics
+    reported_rtc = (rtc or (text_out + audio_out)) + thinking_tokens
+
+    meta["prompt_tokens"] = reported_ptc
+    meta["completion_tokens"] = reported_rtc
+    meta["total_tokens"] = (
+        _optional_int(usage, "total_token_count", "totalTokenCount")
+        or (reported_ptc + reported_rtc)
+    )
+
+    if thinking_tokens > 0:
+        meta["thinking_tokens"] = thinking_tokens
 
     cached_total = cached_legacy or (cached_text + cached_audio + cached_image)
     if cached_total and cached_total > 0:
         meta["cache_read_input_tokens"] = cached_total
 
-    input_side = {}
-    if text_in > 0: input_side["text"] = {"tokens": text_in}
-    if audio_in > 0: input_side["audio"] = {"tokens": audio_in}
-    if image_in > 0: input_side["image"] = {"tokens": image_in}
-    if video_in > 0: input_side["video"] = {"tokens": video_in}
-    
-    output_side = {}
-    if text_out > 0: output_side["text"] = {"tokens": text_out}
-    if audio_out > 0: output_side["audio"] = {"tokens": audio_out}
-    
-    if input_side: meta["input"] = input_side
-    if output_side: meta["output"] = output_side
-    
-    if cached_text or cached_audio or cached_image:
-        meta["cached"] = {}
-        if cached_text > 0: meta["cached"]["text"] = {"tokens": cached_text}
-        if cached_audio > 0: meta["cached"]["audio"] = {"tokens": cached_audio}
-        if cached_image > 0: meta["cached"]["image"] = {"tokens": cached_image}
+    input_side: dict = {}
+    if text_in > 0:
+        input_side["text"] = {"tokens": text_in}
+    if audio_in > 0:
+        input_side["audio"] = {"tokens": audio_in}
+    if image_in > 0:
+        input_side["image"] = {"tokens": image_in}
+    if video_in > 0:
+        input_side["video"] = {"tokens": video_in}
+    if input_side:
+        meta["input"] = input_side
+
+    output_side: dict = {}
+    if text_out > 0:
+        output_side["text"] = {"tokens": text_out}
+    if audio_out > 0:
+        output_side["audio"] = {"tokens": audio_out}
+    if thinking_tokens > 0:
+        output_side["thinking"] = {"tokens": thinking_tokens}
+    if output_side:
+        meta["output"] = output_side
+
+    has_split = bool(cached_text or cached_audio or cached_image)
+    if has_split:
+        cached_side: dict = {}
+        if cached_text > 0:
+            cached_side["text"] = {"tokens": cached_text}
+        if cached_audio > 0:
+            cached_side["audio"] = {"tokens": cached_audio}
+        if cached_image > 0:
+            cached_side["image"] = {"tokens": cached_image}
+        if cached_side:
+            meta["cached"] = cached_side
     elif cached_legacy and cached_legacy > 0:
         meta["cached"] = {"tokens": int(cached_legacy)}
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -116,7 +116,8 @@
             "tag": "NEW",
             "pages": [
               "integrations/mcp",
-              "integrations/tuner"
+              "integrations/tuner",
+              "integrations/paygent"
             ]
           }
         ]

--- a/docs/integrations/paygent.mdx
+++ b/docs/integrations/paygent.mdx
@@ -3,71 +3,103 @@ title: "Paygent Integration"
 description: "Connect Dograh to Paygent — real-time cost tracking, multimodal usage monitoring, and billing for voice agents"
 ---
 
+<iframe
+  width="100%"
+  height="400"
+  src="https://www.loom.com/embed/09fce8f875564f51821429665778e8e8"
+  title="Paygent Integration Walkthrough"
+  frameBorder="0"
+  allowFullScreen
+></iframe>
+
 ## Overview
 
-The Paygent integration node enables passive, post-call usage tracking and customer billing for your Dograh voice agents. It automatically aggregates token metrics across LLM, TTS, STT, and Speech-to-Speech (STS) realtime models and securely exports them to Paygent after each call finishes — requiring no custom code or webhook handlers.
+**Paygent** is a specialized, usage-based billing platform designed exclusively for AI voice agents. 
 
-## Features
+If you are building voice agents for clients or offering them as a SaaS product, calculating margins across different AI providers (LLMs, TTS, STT, and Speech-to-Speech models) can be incredibly complex. Paygent solves this by serving as your centralized billing engine. 
 
-- **Multimodal STS Tracking**: Full token breakdown for OpenAI Realtime and Google GenAI Live models (text, audio, image, video, thinking, and cache reads).
-- **Standard Pipeline Metrics**: Tracks STT audio seconds, LLM tokens (prompt, completion, cached), and TTS character counts.
-- **Zero-Latency Overhead**: Passive background collector executes without blocking or adding latency to live audio streams.
-- **Robust Failover**: Multi-level fallback mechanism ensures accurate billing even during pipeline metric dropouts.
+### How you charge your customers
+
+Instead of building custom tracking infrastructure, you simply connect your Dograh workflow to Paygent. As your agents handle calls, Dograh passively calculates the exact multimodal token usage and audio duration. 
+
+This data is securely exported to Paygent after every call, where your custom pricing margins (rate cards) are applied. This seamless flow allows you to automatically invoice your end-users for the exact infrastructure they consume — turning your AI agents into a scalable, profitable business with zero engineering overhead.
 
 ## Prerequisites
 
 - A [Paygent account](https://withpaygent.com)
-- An active Agent ID and Customer ID in your Paygent account
 - A Dograh voice agent workflow
 
 ## Setup
 
-### 1. Gather your Paygent credentials
+### 1. Create an agent and configure pricing in Paygent
 
-You'll need the following credentials from your Paygent account:
+Before connecting Dograh, you must register your agent in Paygent and define how you want to charge your customers.
 
-| Credential | Description |
+Log in to [Paygent](https://withpaygent.com) and click **Create Agent**. You will be prompted to define your agent's core details, including the **Agent Name** and **Agent ID**:
+
+<img
+  src="/images/paygent-create-agent-image-1.webp"
+  alt="Creating a new agent in Paygent - Agent Name and ID"
+/>
+
+Next, set the **Indicator Name**. This is the billing event identifier you will pass from Dograh (e.g. `per-minute-call`) to tell Paygent which rate to apply for this agent's calls:
+
+<img
+  src="/images/paygent-create-agent-image-2.webp"
+  alt="Setting your indicator name in Paygent"
+/>
+
+Finally, you will configure your **Pricing Strategy**. Paygent allows you to set custom markup rates (rate cards) for every modality. You can define exact margins for Speech-to-Text (STT) seconds, LLM tokens, Text-to-Speech (TTS) characters, and total call minutes:
+
+<img
+  src="/images/paygent-create-agent-image-3.webp"
+  alt="Configuring custom pricing margins and rate cards in Paygent"
+/>
+
+Once your pricing is configured, confirm your setup. You will use the **Agent ID** and **Indicator** from this process to connect your Dograh workflow.
+
+### 2. Gather your Paygent credentials
+
+You'll need three core values from your Paygent dashboard to link your Dograh agent:
+
+| Credential | Where to find it / Description |
 |---|---|
-| **Paygent API Key** | Secret API key used to authenticate requests to Paygent (`pg_live_...`) |
-| **Agent ID** | The unique agent identifier registered in Paygent |
-| **Customer ID** | Your organisation or customer ID in Paygent |
-| **Indicator** | The billing event indicator name (default: `per-minute-call`) |
+| **Paygent API Key** | Your workspace API key used to authenticate requests (`pg_live_...`) |
+| **Agent ID** | The unique identifier configured for your agent in Step 1 |
+| **Customer ID** | Your Paygent organisation or customer ID |
 
-### 2. Add the Paygent node to your workflow
+### 3. Add the Paygent node to your workflow
 
-1. In your Dograh workflow editor, click **Add node**.
-2. Scroll to the **Integrations** category.
-3. Select **Paygent**.
+In your Dograh workflow editor, click **Add node** and scroll to the **Integrations** section. Select **Paygent**. The node will appear on your canvas with a **Not configured** badge.
 
-> **Note:** Paygent is an integration node and does not connect to conversation graph nodes. It operates passively at the workflow level.
+### 4. Configure the node
 
-### 3. Configure the node
+Click on the Paygent node and fill in the following fields:
 
-Click on the Paygent node and fill in the configuration fields:
-
-- **Enabled**: Toggle on to activate post-call cost export.
-- **Paygent API Key**: Your `pg_live_...` secret key.
-- **Agent ID**: Your registered Paygent Agent ID.
-- **Customer ID**: Your Paygent Customer / Organisation ID.
-- **Indicator**: Event indicator name sent to Paygent (e.g. `per-minute-call`).
+- **Paygent API Key** — Your `pg_live_...` secret key
+- **Agent ID** — The unique agent identifier from Paygent
+- **Customer ID** — Your Paygent organisation ID
+- **Indicator** — The billing event name (defaults to `per-minute-call`)
+- **Enabled** — Toggle on to activate the export
 
 Click **Save**, then **Publish** your workflow.
 
-### 4. Verify post-call export
+### 5. Verify the connection
 
-Make a test call through your agent. Once the call ends, log into your Paygent dashboard to confirm the billing event and multimodal usage breakdown appear under your configured Agent ID.
+Make a test call through your agent. Once the call completes, check your Paygent dashboard. The billing event and detailed multimodal usage breakdown should appear under your configured Agent ID within a few moments, with your configured pricing margins automatically applied.
 
 ## Disabling the integration
 
-To temporarily pause exporting usage data to Paygent, open the Paygent node in your workflow editor and toggle **Enabled** off. Save and publish your workflow. Your credentials remain preserved for when you re-enable tracking.
+To temporarily stop exporting usage data to Paygent, open the Paygent node configuration and toggle **Enabled** off. Your credentials are preserved — toggle it back on anytime to resume tracking.
 
 ## Troubleshooting
 
-| Issue | Cause & Solution |
+| Issue | Solution |
 |---|---|
-| **Validation error on node save** | Ensure API Key, Agent ID, Customer ID, and Indicator are all non-empty strings without leading/trailing whitespace. |
-| **Usage data not appearing in Paygent** | Verify your API key has permission to create call events in Paygent and that the workflow has been **Published**. |
-| **Missing realtime STS tokens** | For OpenAI Realtime or Google Live models, verify the pipeline is running in realtime mode (`is_realtime=True`). |
+| Usage data not appearing in Paygent | Verify all credentials are correct with no extra whitespace |
+| Node shows "Not configured" | Open the node and fill in API Key, Agent ID, Customer ID, and Indicator |
+| Workflow not sending data | Make sure the workflow is published, not just saved as a draft |
+| Missing realtime STS tokens | For OpenAI Realtime or Google Live models, verify the pipeline is running in realtime mode (`is_realtime=True`) |
 
 ## Learn more
 

--- a/docs/integrations/paygent.mdx
+++ b/docs/integrations/paygent.mdx
@@ -1,0 +1,74 @@
+---
+title: "Paygent Integration"
+description: "Connect Dograh to Paygent — real-time cost tracking, multimodal usage monitoring, and billing for voice agents"
+---
+
+## Overview
+
+The Paygent integration node enables passive, post-call usage tracking and customer billing for your Dograh voice agents. It automatically aggregates token metrics across LLM, TTS, STT, and Speech-to-Speech (STS) realtime models and securely exports them to Paygent after each call finishes — requiring no custom code or webhook handlers.
+
+## Features
+
+- **Multimodal STS Tracking**: Full token breakdown for OpenAI Realtime and Google GenAI Live models (text, audio, image, video, thinking, and cache reads).
+- **Standard Pipeline Metrics**: Tracks STT audio seconds, LLM tokens (prompt, completion, cached), and TTS character counts.
+- **Zero-Latency Overhead**: Passive background collector executes without blocking or adding latency to live audio streams.
+- **Robust Failover**: Multi-level fallback mechanism ensures accurate billing even during pipeline metric dropouts.
+
+## Prerequisites
+
+- A [Paygent account](https://withpaygent.com)
+- An active Agent ID and Customer ID in your Paygent account
+- A Dograh voice agent workflow
+
+## Setup
+
+### 1. Gather your Paygent credentials
+
+You'll need the following credentials from your Paygent account:
+
+| Credential | Description |
+|---|---|
+| **Paygent API Key** | Secret API key used to authenticate requests to Paygent (`pg_live_...`) |
+| **Agent ID** | The unique agent identifier registered in Paygent |
+| **Customer ID** | Your organisation or customer ID in Paygent |
+| **Indicator** | The billing event indicator name (default: `per-minute-call`) |
+
+### 2. Add the Paygent node to your workflow
+
+1. In your Dograh workflow editor, click **Add node**.
+2. Scroll to the **Integrations** category.
+3. Select **Paygent**.
+
+> **Note:** Paygent is an integration node and does not connect to conversation graph nodes. It operates passively at the workflow level.
+
+### 3. Configure the node
+
+Click on the Paygent node and fill in the configuration fields:
+
+- **Enabled**: Toggle on to activate post-call cost export.
+- **Paygent API Key**: Your `pg_live_...` secret key.
+- **Agent ID**: Your registered Paygent Agent ID.
+- **Customer ID**: Your Paygent Customer / Organisation ID.
+- **Indicator**: Event indicator name sent to Paygent (e.g. `per-minute-call`).
+
+Click **Save**, then **Publish** your workflow.
+
+### 4. Verify post-call export
+
+Make a test call through your agent. Once the call ends, log into your Paygent dashboard to confirm the billing event and multimodal usage breakdown appear under your configured Agent ID.
+
+## Disabling the integration
+
+To temporarily pause exporting usage data to Paygent, open the Paygent node in your workflow editor and toggle **Enabled** off. Save and publish your workflow. Your credentials remain preserved for when you re-enable tracking.
+
+## Troubleshooting
+
+| Issue | Cause & Solution |
+|---|---|
+| **Validation error on node save** | Ensure API Key, Agent ID, Customer ID, and Indicator are all non-empty strings without leading/trailing whitespace. |
+| **Usage data not appearing in Paygent** | Verify your API key has permission to create call events in Paygent and that the workflow has been **Published**. |
+| **Missing realtime STS tokens** | For OpenAI Realtime or Google Live models, verify the pipeline is running in realtime mode (`is_realtime=True`). |
+
+## Learn more
+
+- [Paygent](https://withpaygent.com) — Usage-based billing platform for AI agents


### PR DESCRIPTION
# Pull Request: Paygent Cost Tracking & Billing Integration

## Overview

This PR introduces a robust, passive cost-tracking and billing integration for **Paygent**. The integration operates asynchronously after a voice session completes, collecting STT audio usage, LLM token usage, TTS character counts, and multimodal STS token metrics without introducing any overhead to active WebRTC or SIP call processing.

## What This PR Adds

### Backend Integration

Introduces a new `api/services/integrations/paygent/` module containing:

* `__init__.py` – Package registration
* `client.py` – Dedicated HTTP client for delivering usage metrics to Paygent
* `collector.py` – Passive `BaseObserver` that gathers usage metrics during a session
* `completion.py` – Post-call completion hook that validates and submits metrics sequentially
* `node.py` – Pydantic node definitions for the frontend builder
* `runtime.py` – Runtime registration of the collector into active voice pipelines



# Why `services/pipecat/realtime/` Was Modified

Supporting multimodal realtime providers requires more than standard LLM token accounting. Providers such as OpenAI Realtime and Gemini Live expose separate token counts for text and audio, each with different pricing models.

The realtime handlers are the only location where the raw provider usage metadata is still available before it is normalized.

To preserve this information, this PR introduces a lightweight `STSUsageFrame` that carries detailed billing metadata downstream without modifying Pipecat's native token accounting.

---

# Safety & Fault Tolerance

This implementation was designed to be completely passive.

* No additional work is performed during the active media pipeline.
* Custom hooks execute only after Pipecat's native processing has completed successfully.
* All provider-specific extraction logic is wrapped in `try/except Exception` blocks.
* If a provider changes its response schema, the integration simply logs a warning and continues without affecting the live call.
* `STSUsageFrame` imports are performed lazily to keep service initialization clean and avoid unnecessary startup dependencies.

---

# Result

This PR provides complete post-call usage tracking across STT, LLM, TTS, and realtime STS providers while remaining isolated from the live conversation pipeline and preserving existing Pipecat behavior.

Once this PR is approved, I'll proceed with the documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a passive Paygent usage and billing integration that runs after each call. Tracks STT, LLM, TTS, and realtime STS usage (OpenAI Realtime, Gemini Live) and sends it to Paygent without impacting calls.

- New Features
  - New `api/services/integrations/paygent/*`: runtime collector, post-call completion, HTTP client, and a builder node.
  - `STSUsageFrame` with multimodal STS usage; emitted by `realtime/openai_realtime.py` on `response.done` and `realtime/gemini_live.py` from usage metadata.
  - Paygent node in the builder with `paygent_api_key`, `paygent_agent_id`, `paygent_customer_id`, `paygent_indicator`; optional, single-instance.
  - Docs: added `docs/integrations/paygent.mdx`, linked in `docs/docs.json`, and aligned step 1 with the new 3-step agent creation UI.

- Bug Fixes
  - STT audio seconds now reflect true STT audio; for non-realtime only, fall back to wall-clock if missing.
  - Skip LLM usage fallback on realtime runs to avoid double counting with STS tokens.
  - Replaced set-reset with bounded LRU dedup in the collector to prevent double-counting on long calls.
  - Removed verbose debug logs from the collector.

<sup>Written for commit eeaad3258a0c4bcbf34b8bb3272e91ec618ba7c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds post-call usage reporting and billing through Paygent. The main changes are:

- A Paygent integration node with credential validation and secret masking.
- Runtime collection for STT, LLM, TTS, and realtime STS usage.
- Sequential post-call delivery to the Paygent API.
- OpenAI Realtime and Gemini Live usage extraction.
- Paygent setup documentation and navigation.

<h3>Confidence Score: 4/5</h3>

Failed Paygent requests can report success, and non-realtime calls can submit incorrect STT duration.

HTTP and network errors are swallowed before delivery results are assembled. Missing STT measurements fall back to full wall-clock duration. The remaining integration structure follows the existing registration and completion flow.

api/services/integrations/paygent/client.py and api/services/integrations/paygent/completion.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the asynchronous transport harness to reproduce HTTP 503 and ReadTimeout failures against the Paygent client.
- Validated that two failed requests per scenario were recorded as delivered, with delivered\_steps including session\_init and set\_indicator, an empty errors list, and an overall status ok.
- Installed Python 3.13 and prepared a collector-to-completion harness to simulate a 37-second non-realtime call with zero STT usage when the environment lacked a Python executable.
- Ran baseline and post-change verification, confirming all six assertions passed and no outbound socket connections occurred, aided by minimal environment scaffolding for the CPython 3.13 target.

<a href="https://app.greptile.com/trex/runs/14220239/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/services/integrations/paygent/client.py | Adds ordered Paygent API delivery, but request failures are still recorded as successful steps. |
| api/services/integrations/paygent/collector.py | Collects LLM, TTS, and STS metrics, but the STT accumulator has no population path. |
| api/services/integrations/paygent/completion.py | Builds and delivers post-call snapshots, but missing STT metrics fall back to full call duration. |
| api/services/integrations/paygent/node.py | Registers the Paygent node, validates enabled credentials, and marks the API key as sensitive. |
| api/services/pipecat/realtime/paygent_sts_frames.py | Defines detailed STS usage frames and provider-specific metadata extraction. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `api/services/integrations/paygent/collector.py`, line 824-831 ([link](https://github.com/dograh-hq/dograh/blob/0c13c84f9c837418e7c0d194092254db99505daa/api/services/integrations/paygent/collector.py#L824-L831)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Debug logging left in production code**

   `logger.info("[paygent_debug] ...")` fires on every LLM frame and serializes `item.value.__dict__` — which may contain raw token usage objects. In a live voice pipeline this generates one log line per LLM turn on every call. The `[paygent_debug]` prefix indicates this was added for local debugging and not meant for production.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `api/services/integrations/paygent/collector.py`, line 806-811 ([link](https://github.com/dograh-hq/dograh/blob/0c13c84f9c837418e7c0d194092254db99505daa/api/services/integrations/paygent/collector.py#L806-L811)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dedup set clear can cause double-counting on long calls**

   When `len(self._seen_frame_ids) > 2000`, the set is wiped entirely. Any frame arriving after the clear with an ID that was previously seen will be processed again — accumulating tokens, TTS characters, or STS metadata twice. For long calls with rich pipelines (multiple LLM turns, TTS segments), 2000 frames is reachable. A sliding window via a `deque` would preserve recency without the all-or-nothing reset.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["docs(paygent): align step 1 with 3-step ..."](https://github.com/dograh-hq/dograh/commit/eeaad3258a0c4bcbf34b8bb3272e91ec618ba7c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41063730)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->