### PR TITLE
docs: fix dead entry points, add first-agent tutorial, explain unexplained features

### DIFF
--- a/docs/configurations/interruption.mdx
+++ b/docs/configurations/interruption.mdx
@@ -9,6 +9,18 @@ Interruption handling controls whether the user can "barge in" and interrupt the
 
 ![Allow Interruption Toggle](../images/allow-interruption.png)
 
+## What is VAD?
+
+VAD (Voice Activity Detection) is what makes barge-in possible — it's the model that listens to the incoming audio stream and decides whether the caller is currently speaking. Dograh's pipeline runs [Silero VAD](https://github.com/snakers4/silero-vad) on every call to detect the start and end of user speech in real time.
+
+When **Allow Interruption** is enabled on a node, VAD is what triggers the interrupt: the moment it detects the caller has started talking, the bot's speech is cut off and the pipeline starts processing the new input. When interruption is disabled, VAD output for the user's mic is ignored until the bot finishes speaking.
+
+VAD also feeds turn-taking more generally — it's part of how Dograh decides a caller has finished a turn and the agent should respond, independent of whether interruption is enabled.
+
+<Note>
+**Valid sample rates**: Dograh's pipeline runs VAD at either **8000 Hz** or **16000 Hz** — no other value is accepted. The overall pipeline sample rate is capped at 16 kHz to satisfy this. This only matters if you're integrating a [custom telephony provider](/integrations/telephony/custom#audio-format-considerations); telephony providers built into Dograh (Twilio, Vonage, Plivo, etc.) already negotiate a supported rate for you.
+</Note>
+
 ## How It Works
 
 Each node in your workflow has an **Allow Interruption** toggle:

--- a/docs/configurations/interruption.mdx
+++ b/docs/configurations/interruption.mdx
@@ -11,7 +11,7 @@ Interruption handling controls whether the user can "barge in" and interrupt the
 
 ## What is VAD?
 
-VAD (Voice Activity Detection) is what makes barge-in possible — it's the model that listens to the incoming audio stream and decides whether the caller is currently speaking. Dograh's pipeline runs [Silero VAD](https://github.com/snakers4/silero-vad) on every call to detect the start and end of user speech in real time.
+VAD (Voice Activity Detection) is what makes barge-in possible — it's the model that listens to the incoming audio stream and decides whether the caller is currently speaking. Dograh's pipeline runs [Silero VAD](https://github.com/snakers4/silero-vad) by default to detect the start and end of user speech in real time. Some realtime providers (such as OpenAI Realtime, Azure Realtime, and Grok Voice Agent) supply their own VAD signals, so local Silero VAD is skipped for those calls.
 
 When **Allow Interruption** is enabled on a node, VAD is what triggers the interrupt: the moment it detects the caller has started talking, the bot's speech is cut off and the pipeline starts processing the new input. When interruption is disabled, VAD output for the user's mic is ignored until the bot finishes speaking.
 

--- a/docs/configurations/tracing.mdx
+++ b/docs/configurations/tracing.mdx
@@ -108,6 +108,8 @@ Every time an LLM call is made, the **entire conversation history up to that poi
 
 ## Setting Up Langfuse Tracing
 
+[Langfuse](https://langfuse.com/docs) is an open-source LLM observability platform — it stores and visualizes traces (prompts, responses, tool calls) so you can debug and iterate on LLM-powered applications outside of Dograh's own trace viewer.
+
 We provide seamless integration with Langfuse for tracing if you want to use your own account. This enables you to use the [playground feature of Langfuse](https://langfuse.com/docs/prompt-management/features/playground). This works on both managed and self-hosted Dograh deployments.
 
 **Setup steps:**

--- a/docs/contribution/introduction.mdx
+++ b/docs/contribution/introduction.mdx
@@ -1,4 +1,50 @@
 ---
 title: Contribution
-description: If you would like to set up Dograh development environment in your IDE and use a coding agent like Claude/ Codex to make changes to the codebase, you can follow this document to help setup the right development environment for yourself.
+description: How the Dograh codebase is laid out, and how to get a local dev environment running so you can contribute.
 ---
+
+Dograh is an open-source, full-stack voice agent platform: a Next.js UI, a FastAPI backend, Postgres/Redis/MinIO for storage, and a [Pipecat](https://github.com/pipecat-ai/pipecat)-based pipeline (checked in as a git submodule) that drives the actual voice conversation.
+
+## Repository layout
+
+| Path | What's there |
+| --- | --- |
+| `ui/` | Next.js frontend — the workflow builder, dashboard, and agent editor |
+| `api/` | FastAPI backend — REST API, campaign orchestration, ARI/telephony integration, ARQ background workers |
+| `pipecat/` | Git submodule for the voice pipeline (STT → LLM → TTS) |
+| `docs/` | This documentation site, built with Mintlify |
+| `sdk/` | Python/TypeScript SDKs for driving Dograh programmatically |
+| `scripts/` | Setup, deployment, and update scripts referenced throughout these docs |
+| `deploy/` | nginx and coturn config templates used by remote deployment |
+
+## Setting up a dev environment
+
+There are two supported paths:
+
+1. **[Devcontainer setup](/contribution/setup)** (recommended) — a VS Code / Dev Containers environment that bootstraps Postgres, Redis, MinIO, the Python venv, and UI dependencies for you.
+2. **[Host-managed setup](/contribution/host-managed-setup)** — run everything directly on your machine if you'd rather not use a devcontainer.
+
+If you cloned `dograh-hq/dograh` directly instead of forking first, see [Fork Workflow](/contribution/fork-workflow) to fix up your `origin`/`upstream` remotes.
+
+## Contribution flow
+
+1. Fork the repo and clone your fork.
+2. Set up your dev environment ([devcontainer](/contribution/setup) or [host-managed](/contribution/host-managed-setup)).
+3. Create a branch, make your change.
+4. Push to your fork (`origin`) and open a pull request against `dograh-hq/dograh:main`.
+5. A maintainer reviews and merges.
+
+Bug reports and feature ideas go through [GitHub Issues](https://github.com/dograh-hq/dograh/issues) and [Ideas](https://github.com/orgs/dograh-hq/discussions/categories/ideas). Issues tagged `good first issue` are a good place to start. For questions while you're working, use the [Dograh Community Slack](https://join.slack.com/t/dograh-community/shared_invite/zt-3zjb5vwvl-j7hRz3_F1SOn5cH~jm5f5g).
+
+## Where to start
+
+- **First time setting up?** Go to [Setup](/contribution/setup).
+- **Contributing to these docs?** Docs live in `docs/`, written in MDX, previewed with `mint dev` inside that folder.
+- **Working on the voice pipeline?** You'll be in `pipecat/` and `api/` — remember to `git submodule update --init --recursive` after pulling submodule bumps.
+- **Deploying your own build instead of contributing upstream?** See [Deployments](/deployment/introduction) instead.
+
+## Related
+
+- [Setup](/contribution/setup)
+- [Devcontainer Workflow](/contribution/devcontainer)
+- [Fork Workflow](/contribution/fork-workflow)

--- a/docs/core-concepts/context-and-variables.mdx
+++ b/docs/core-concepts/context-and-variables.mdx
@@ -89,11 +89,42 @@ You are speaking with the caller at {{caller_number}}.
 
 ### gathered_context
 
-Data the agent collects *during* the call. You configure what to extract in the agent node's extraction settings — each variable has a name, type, and a prompt that tells the LLM what to look for.
+Data the agent extracts *during* the call — the opposite direction of `initial_context`. Use it to turn a conversation into structured data: what the customer wants, whether they confirmed something, a value they gave you out loud.
+
+#### How it gets populated
+
+Turn on **extraction** on an [Agent](/voice-agent/agent) or [End Call](/voice-agent/end-call) node and define one or more variables to extract. Each variable has:
+
+| Field | Description |
+|---|---|
+| `name` | The key it will appear under in `gathered_context` |
+| `type` | `string`, `number`, or `boolean` |
+| `prompt` | A natural-language description of what to look for, e.g. *"Did the customer confirm the appointment?"* |
 
 <img src="../images/extracted_variables.png" alt="Extracted variables" style={{border: "1px solid #d1d5db", borderRadius: "8px", maxWidth: "100%"}} />
 
-`gathered_context` is returned in the run record after the call completes and is available in [webhook payloads](/developer/webhooks) for downstream processing. It is **not** available as a template variable in Agent prompts — prompts can only reference `initial_context` fields.
+When the conversation reaches that node, the LLM reads the transcript so far and fills in each variable based on its `prompt`. If a value can't be determined from the conversation, the variable is left empty rather than guessed — leave the `prompt` specific enough that the LLM knows exactly what counts as a match.
+
+You can add extraction to more than one node. Each node's extracted variables are merged into the same `gathered_context` object as the call progresses, keyed by `name` — reuse a `name` at a later node if you want to overwrite an earlier value.
+
+#### How to reference it downstream
+
+`gathered_context` is **not available in Agent prompts** — a prompt can only reference `initial_context` fields, because extraction typically happens after the conversation that would use it. To act on extracted data, send it out via a node instead:
+
+| Where | Syntax | Notes |
+|---|---|---|
+| [Webhook node](/voice-agent/webhook) payload | `{{gathered_context.field_name}}` | Prefixed, since the payload template can also reference `initial_context` |
+| [Run record](/developer/webhooks#payload-context-variables) (API / dashboard) | `gathered_context` object | Returned after the run completes, alongside `recording_url` and `transcript_url` |
+
+```json
+{
+  "customer": "{{initial_context.customer_name}}",
+  "resolution": "{{gathered_context.resolution}}",
+  "callback_requested": "{{gathered_context.wants_callback}}"
+}
+```
+
+See [Webhook Payloads](/developer/webhooks) for the full list of variables available alongside `gathered_context` in a payload template.
 
 ## Data flow example
 

--- a/docs/deployment/introduction.mdx
+++ b/docs/deployment/introduction.mdx
@@ -1,11 +1,35 @@
 ---
 title: "Deployments"
-description: "Options to deploy Dograh Voice Agent Platform on your own infrastructure."
+description: "Options for self-hosting Dograh — from a local Docker install to a production remote server with a custom domain."
 ---
 
-### Deployment Options
-You can deploy Dograh Platform using Docker on a remote server using Docker, either using terminal commands, or using PaaS like Heroku, Coolify. 
+Dograh is self-hosted with Docker. Everything ships as two images (`dograh-api` and `dograh-ui`) plus Postgres, Redis, and MinIO, orchestrated with Docker Compose. Pick the deployment path that matches what you're trying to do:
 
-- [Docker](docker)
-- [Custom Domain](custom-domain)
-- [Heroku](heroku)
+| Path | Use it when | Guide |
+| --- | --- | --- |
+| **Local Docker** | You want to try Dograh on your own machine. No public URL, no telephony. | [Docker → Option 1](/deployment/docker#option-1%3A-local-docker-deployment) |
+| **Remote server** | You want a real server reachable from the internet, with HTTPS out of the box (via a free `sslip.io` certificate — no domain required). | [Docker → Option 2](/deployment/docker#option-2%3A-remote-server-deployment) |
+| **Custom domain** | You already have a remote deployment and want your own domain (e.g. `voice.yourcompany.com`) instead of the `sslip.io` URL. | [Custom Domain](/deployment/custom-domain) |
+| **Heroku** | One-click PaaS deployment. | [Heroku](/deployment/heroku) — coming soon |
+
+Browsers only grant microphone access over HTTPS, so every path above ends with the app served over HTTPS — either via a `sslip.io`/Let's Encrypt certificate, a self-signed certificate, or your own domain's certificate.
+
+## After you deploy
+
+Once the platform is running, these guides cover keeping it running:
+
+- [**Authentication**](/deployment/authentication) — switch from the built-in local email/password provider to Stack Auth for social login.
+- [**Scaling**](/deployment/scaling) — run multiple FastAPI workers behind nginx for higher call throughput.
+- [**Update**](/deployment/update) — move an existing deployment to a newer Dograh version.
+
+## Where to start
+
+1. **Kicking the tires?** Start with [local Docker](/deployment/docker#option-1%3A-local-docker-deployment) — running in a few minutes, no server needed.
+2. **Putting it in front of real callers?** Use [remote server deployment](/deployment/docker#option-2%3A-remote-server-deployment), then layer on a [custom domain](/deployment/custom-domain) if you want one.
+3. **Already running and need to upgrade?** Go straight to [Update](/deployment/update).
+4. **Expecting high call volume?** Read [Scaling](/deployment/scaling) once your base deployment is live.
+
+## Related
+
+- [Contribution: Setup](/contribution/setup) — for developing on Dograh itself rather than deploying it
+- [Environment Variables](/developer/environment-variables)

--- a/docs/deployment/introduction.mdx
+++ b/docs/deployment/introduction.mdx
@@ -12,7 +12,7 @@ Dograh is self-hosted with Docker. Everything ships as two images (`dograh-api` 
 | **Custom domain** | You already have a remote deployment and want your own domain (e.g. `voice.yourcompany.com`) instead of the `sslip.io` URL. | [Custom Domain](/deployment/custom-domain) |
 | **Heroku** | One-click PaaS deployment. | [Heroku](/deployment/heroku) — coming soon |
 
-Browsers treat microphone access as a secure-context feature, so the deployed app must be served over HTTPS (or accessed at localhost/127.0.0.1 over HTTP, which is a secure context). Local Docker uses `http://localhost:3010` and therefore does not need a certificate.
+Browsers treat microphone access as a secure-context feature, so the app must be served over HTTPS — or accessed at localhost/127.0.0.1 over HTTP, which is also a secure context. Local Docker uses `http://localhost:3010` and therefore does not need a certificate.
 
 ## After you deploy
 

--- a/docs/deployment/introduction.mdx
+++ b/docs/deployment/introduction.mdx
@@ -7,12 +7,12 @@ Dograh is self-hosted with Docker. Everything ships as two images (`dograh-api` 
 
 | Path | Use it when | Guide |
 | --- | --- | --- |
-| **Local Docker** | You want to try Dograh on your own machine. No public URL, no telephony. | [Docker → Option 1](/deployment/docker#option-1%3A-local-docker-deployment) |
-| **Remote server** | You want a real server reachable from the internet, with HTTPS out of the box (via a free `sslip.io` certificate — no domain required). | [Docker → Option 2](/deployment/docker#option-2%3A-remote-server-deployment) |
+| **Local Docker** | You want to try Dograh on your own machine. No public URL, no telephony. | [Docker → Option 1](/deployment/docker#option-1-local-docker-deployment) |
+| **Remote server** | You want a real server reachable from the internet, with HTTPS out of the box (via a free `sslip.io` certificate — no domain required). | [Docker → Option 2](/deployment/docker#option-2-remote-server-deployment) |
 | **Custom domain** | You already have a remote deployment and want your own domain (e.g. `voice.yourcompany.com`) instead of the `sslip.io` URL. | [Custom Domain](/deployment/custom-domain) |
 | **Heroku** | One-click PaaS deployment. | [Heroku](/deployment/heroku) — coming soon |
 
-Browsers only grant microphone access over HTTPS, so every path above ends with the app served over HTTPS — either via a `sslip.io`/Let's Encrypt certificate, a self-signed certificate, or your own domain's certificate.
+Browsers treat microphone access as a secure-context feature, so the deployed app must be served over HTTPS (or accessed at localhost/127.0.0.1 over HTTP, which is a secure context). Local Docker uses `http://localhost:3010` and therefore does not need a certificate.
 
 ## After you deploy
 
@@ -24,8 +24,8 @@ Once the platform is running, these guides cover keeping it running:
 
 ## Where to start
 
-1. **Kicking the tires?** Start with [local Docker](/deployment/docker#option-1%3A-local-docker-deployment) — running in a few minutes, no server needed.
-2. **Putting it in front of real callers?** Use [remote server deployment](/deployment/docker#option-2%3A-remote-server-deployment), then layer on a [custom domain](/deployment/custom-domain) if you want one.
+1. **Kicking the tires?** Start with [local Docker](/deployment/docker#option-1-local-docker-deployment) — running in a few minutes, no server needed.
+2. **Putting it in front of real callers?** Use [remote server deployment](/deployment/docker#option-2-remote-server-deployment), then layer on a [custom domain](/deployment/custom-domain) if you want one.
 3. **Already running and need to upgrade?** Go straight to [Update](/deployment/update).
 4. **Expecting high call volume?** Read [Scaling](/deployment/scaling) once your base deployment is live.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -21,6 +21,7 @@
                 "group": "Introduction",
                 "pages": [
                   "getting-started/index",
+                  "getting-started/first-agent",
                   "getting-started/prerequisites",
                   "getting-started/troubleshooting"
                 ]

--- a/docs/getting-started/first-agent.mdx
+++ b/docs/getting-started/first-agent.mdx
@@ -6,7 +6,7 @@ description: "Build and talk to a working voice agent in five minutes using Web 
 This is the fastest path to a working voice agent. You'll create an agent, get a generated conversation flow, and talk to it in your browser — no phone number, no telephony provider, no configuration.
 
 <Note>
-Using the hosted platform, go to [app.dograh.com](https://app.dograh.com). Self-hosting locally? Use `http://localhost:3010` instead, and follow [Getting Started](/getting-started/index) first to get the platform running.
+Using the hosted platform, go to [app.dograh.com](https://app.dograh.com). Self-hosting locally? Use `http://localhost:3010` instead, and follow [Getting Started](/getting-started) first to get the platform running.
 </Note>
 
 ## Step 1: Create an agent

--- a/docs/getting-started/first-agent.mdx
+++ b/docs/getting-started/first-agent.mdx
@@ -1,0 +1,60 @@
+---
+title: "Your First Agent in 5 Minutes"
+description: "Build and talk to a working voice agent in five minutes using Web Calls — no telephony setup required."
+---
+
+This is the fastest path to a working voice agent. You'll create an agent, get a generated conversation flow, and talk to it in your browser — no phone number, no telephony provider, no configuration.
+
+<Note>
+Using the hosted platform, go to [app.dograh.com](https://app.dograh.com). Self-hosting locally? Use `http://localhost:3010` instead, and follow [Getting Started](/getting-started/index) first to get the platform running.
+</Note>
+
+## Step 1: Create an agent
+
+Go to [app.dograh.com/workflow](https://app.dograh.com/workflow) and create a new agent.
+
+![Create a Voice Agent](../images/create-a-voice-agent.png)
+
+You'll be asked for:
+
+- **Direction** — Inbound (agent receives calls) or Outbound (agent makes calls). Pick either; it only affects the starting prompt.
+- **Use case** — a description of what the agent should do, e.g. *"Book a haircut appointment, ask for preferred date and time, confirm before ending the call."*
+
+This description is sent to an LLM to generate a starting workflow. The more specific you are, the better the generated prompts and pathways will be.
+
+## Step 2: Land in the workflow editor
+
+After generation, you're dropped into the [Voice Agent Builder](/voice-agent/introduction) with a graph already built for you — typically a **Start Call** node, one or more **Agent** nodes with prompts for your use case, and an **End Call** node, connected by pathways.
+
+You don't need to understand the full [graph model](/voice-agent/introduction#the-graph-model) yet — the generated agent works out of the box. You can come back and customize prompts once you've heard it talk.
+
+## Step 3: Talk to it with a Web Call
+
+In the agent editor, start a **Web Call**. This runs the full pipeline — speech-to-text, LLM, text-to-speech — straight from your browser microphone, exactly like a real phone call would, just without a phone number.
+
+While the call is active, you can watch:
+
+- The **live transcript** as the conversation happens
+- **Node transitions** as the agent moves through the graph
+- Any **tool calls** the agent makes
+
+Talk to it like a real caller would. Try to get it off-script — say something unexpected — and see how it responds.
+
+## Step 4: Iterate
+
+Didn't go the way you wanted? Open the node whose behavior you want to change and edit its prompt directly. Save, then start a new Web Call to hear the change immediately. No redeploy, no restart.
+
+Common first tweaks:
+
+- Adjust tone or wording in an **Agent** node's prompt
+- Add shared instructions (tone, objection handling) to the [**Global**](/voice-agent/global) node
+- Add a [**Webhook**](/voice-agent/webhook) node to send call results somewhere once you're happy with the flow
+
+## Next Steps
+
+You have a working agent that runs entirely in the browser. From here:
+
+- **Take real calls** — connect a [telephony provider](/integrations/telephony/overview) and trigger calls via [API Trigger](/voice-agent/api-trigger) or inbound routing.
+- **Learn the graph model in depth** — see [Voice Agent Builder](/voice-agent/introduction) for all node types and how pathways work.
+- **Give it tools** — let the agent call external APIs or transfer calls with [Tools](/voice-agent/tools/introduction).
+- **Embed it on a website** — skip telephony entirely and let website visitors talk to the agent via [Add to Website](/voice-agent/add-to-website).

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -60,4 +60,4 @@ Please check [Prerequisites](getting-started/prerequisites) for the system requi
 
 ## Next Steps
 
-You can see how to configure the inference provider in [Inference Provider](/configurations/inference-providers).
+Once the platform is running, build your first agent in [Your First Agent in 5 Minutes](/getting-started/first-agent) — no telephony setup required. Or configure an [inference provider](/configurations/inference-providers) first if you're bringing your own LLM keys.

--- a/docs/integrations/telephony/cloudonix.mdx
+++ b/docs/integrations/telephony/cloudonix.mdx
@@ -50,7 +50,7 @@ Watch this step-by-step guide to set up Cloudonix with Dograh AI:
    - Domain ID
    - Application Name — *optional*. Leave blank and Dograh will auto-create a Voice Application on save (with the application `url` and CXML runtime already configured) and store its name on this configuration.
 5. Click **Save Configuration**
-6. Open the configuration you just created and add at least one **phone number** (with country code in E.164 format, e.g. `+1234567890`). The default caller ID is used for outbound calls.
+6. Open the configuration you just created and add at least one **phone number** (with country code, in [E.164](https://en.wikipedia.org/wiki/E.164) format — `+` then country code then number, no spaces or dashes, e.g. `+1234567890`). The default caller ID is used for outbound calls.
 
    <Note>
      If Dograh auto-created the Voice Application for you, you still need to

--- a/docs/integrations/telephony/custom.mdx
+++ b/docs/integrations/telephony/custom.mdx
@@ -3,6 +3,15 @@ title: "Custom Telephony Provider"
 description: "Build your own telephony provider integration for Dograh AI"
 ---
 
+## Prerequisites
+
+This guide assumes familiarity with two libraries the provider interface is built on:
+
+- **[Pipecat](https://docs.pipecat.ai)** — the open-source real-time voice/multimodal pipeline framework Dograh's call pipeline is built on. Its [`FastAPIWebsocketTransport`](https://docs.pipecat.ai/server/services/transport/fastapi-websocket) is what streams audio between the telephony provider and Dograh's pipeline — you'll be constructing one of these in your transport factory. If you haven't built a Pipecat transport or frame serializer before, skim their [transports guide](https://docs.pipecat.ai/server/base-classes/transport) first.
+- **[Pydantic](https://docs.pydantic.dev)** — used for the request/response schemas that define a provider's stored credentials (`config.py` below). If you're new to Pydantic, its [models documentation](https://docs.pydantic.dev/latest/concepts/models/) covers everything used here (`BaseModel`, `Field`, `Literal` discriminators).
+
+You don't need deep expertise in either — enough to read a `BaseModel` and a Pipecat transport class is sufficient to follow this guide.
+
 ## Overview
 
 A telephony provider is implemented as a **self-registering package** under `api/services/telephony/providers/<name>/`. The package contributes everything Dograh needs to wire the provider in — the provider class, transport factory, audio config, request/response schemas, optional HTTP routes, and the form metadata used to render its configuration UI — through a single `ProviderSpec` registered at import time.
@@ -350,7 +359,7 @@ Each provider declares its wire format through its `AudioConfig`. Common shapes:
 - **Vonage**: 16 kHz Linear PCM as binary frames
 - **Asterisk ARI**: 8 kHz Linear PCM via externalMedia
 
-The pipeline sample rate is capped at 16 kHz to satisfy VAD; transports handle resampling between the wire format and the pipeline's internal rate.
+The pipeline sample rate is capped at 16 kHz to satisfy [VAD](/configurations/interruption#what-is-vad), which only accepts 8000 Hz or 16000 Hz; transports handle resampling between the wire format and the pipeline's internal rate.
 
 ## Testing
 

--- a/docs/integrations/telephony/overview.mdx
+++ b/docs/integrations/telephony/overview.mdx
@@ -79,7 +79,7 @@ Dograh resolves the org from the webhook's account credentials and the agent fro
 <AccordionGroup>
   <Accordion title="Calls not connecting">
     - Verify credentials are correctly configured
-    - Check phone number format (E.164 with country code, e.g. `+1234567890`)
+    - Check phone number format ([E.164](https://en.wikipedia.org/wiki/E.164) — the international standard: a `+`, then country code, then the number, no spaces or dashes, e.g. `+1234567890`)
     - Ensure webhook URLs are publicly accessible
     - Review provider-specific error logs
   </Accordion>

--- a/docs/integrations/telephony/plivo.mdx
+++ b/docs/integrations/telephony/plivo.mdx
@@ -35,7 +35,7 @@ Before setting up Plivo integration, you'll need:
    - Auth Token
    - Application ID — *optional*. Leave blank and Dograh will auto-create a Plivo Application on save (with the `answer_url` already configured) and store its Application ID on this configuration.
 4. Click **Save Configuration**
-5. Open the configuration you just created and add at least one **phone number** (with country code in E.164 format, e.g. `+1234567890`). The default caller ID is used for outbound calls.
+5. Open the configuration you just created and add at least one **phone number** (with country code, in [E.164](https://en.wikipedia.org/wiki/E.164) format — `+` then country code then number, no spaces or dashes, e.g. `+1234567890`). The default caller ID is used for outbound calls.
 
    <Note>
      If Dograh auto-created the Plivo Application for you, you still need to

--- a/docs/integrations/telephony/telnyx.mdx
+++ b/docs/integrations/telephony/telnyx.mdx
@@ -34,7 +34,7 @@ Before setting up Telnyx integration, you'll need:
    - API Key
    - Call Control App ID (Connection ID) — *optional*. Leave blank and Dograh will auto-create a Call Control Application on save (with the inbound webhook URL already configured) and store its Connection ID on this configuration.
 4. Click **Save Configuration**
-5. Open the configuration you just created and add at least one **phone number** (with country code in E.164 format, e.g. `+1234567890`). The default caller ID is used for outbound calls.
+5. Open the configuration you just created and add at least one **phone number** (with country code, in [E.164](https://en.wikipedia.org/wiki/E.164) format — `+` then country code then number, no spaces or dashes, e.g. `+1234567890`). The default caller ID is used for outbound calls.
 
    <Note>
      If Dograh auto-created the Call Control Application for you, you still

--- a/docs/integrations/telephony/twilio.mdx
+++ b/docs/integrations/telephony/twilio.mdx
@@ -33,7 +33,7 @@ Before setting up Twilio integration, you'll need:
    - Account SID
    - Auth Token
 4. Click **Save Configuration**
-5. Open the configuration you just created and add at least one **phone number** (with country code in E.164 format, e.g. `+1234567890`). The default caller ID is used for outbound calls.
+5. Open the configuration you just created and add at least one **phone number** (with country code, in [E.164](https://en.wikipedia.org/wiki/E.164) format — `+` then country code then number, no spaces or dashes, e.g. `+1234567890`). The default caller ID is used for outbound calls.
 
 ### Step 3: Test Your Configuration
 

--- a/docs/integrations/telephony/vobiz.mdx
+++ b/docs/integrations/telephony/vobiz.mdx
@@ -35,7 +35,7 @@ Before setting up Vobiz integration, you'll need:
    - Auth Token
    - Application ID — *optional*. Leave blank and Dograh will auto-create a Vobiz Application on save (with the `answer_url` already configured) and store its Application ID on this configuration.
 4. Click **Save Configuration**
-5. Open the configuration you just created and add at least one **phone number** (with country code in E.164 format, e.g. `+1234567890`). The default caller ID is used for outbound calls.
+5. Open the configuration you just created and add at least one **phone number** (with country code, in [E.164](https://en.wikipedia.org/wiki/E.164) format — `+` then country code then number, no spaces or dashes, e.g. `+1234567890`). The default caller ID is used for outbound calls.
 
    <Note>
      If Dograh auto-created the Vobiz Application for you, you still need to

--- a/docs/integrations/telephony/vonage.mdx
+++ b/docs/integrations/telephony/vonage.mdx
@@ -148,7 +148,7 @@ Vonage uses higher quality audio (16kHz) which provides:
   
   <Accordion title="Invalid phone number error">
     - Remove the '+' prefix for Vonage (use `14155551234` not `+14155551234`)
-    - Ensure numbers are in E.164 format without the '+'
+    - Ensure numbers are in [E.164](https://en.wikipedia.org/wiki/E.164) format (country code + number, no spaces or dashes) without the '+'
     - Verify numbers are active in your Vonage account
   </Accordion>
   
@@ -156,7 +156,7 @@ Vonage uses higher quality audio (16kHz) which provides:
     - Verify WebSocket connection is established
     - Check audio pipeline is configured for 16kHz PCM
     - Monitor WebSocket for binary audio frames
-    - Review VAD (Voice Activity Detection) settings
+    - Review [VAD (Voice Activity Detection)](/configurations/interruption#what-is-vad) behavior — this is what detects when the caller starts and stops speaking
   </Accordion>
   
   <Accordion title="Calls disconnecting early">
@@ -209,6 +209,6 @@ Check [Vonage pricing](https://www.vonage.com/communications-apis/voice/pricing/
 ## Next Steps
 
 - Test your Vonage integration with a simple workflow
-- Configure VAD settings for optimal voice detection
+- Review [VAD and interruption behavior](/configurations/interruption) for your workflow's nodes
 - Set up monitoring and alerts
 - Explore advanced features like call recording

--- a/docs/voice-agent/introduction.mdx
+++ b/docs/voice-agent/introduction.mdx
@@ -1,10 +1,53 @@
 ---
 title: "Voice Agent Builder"
-description: "Dograh provides UI components to build a voice Agent. The voice agent can be created by going to https://app.dograh.com/workflow and then Creating a new Agent."
+description: "Dograh's voice agent builder lets you design a conversation as a graph of nodes and pathways. Learn the graph model, the available node types, and where to start."
 ---
 
 ![Create a Voice Agent](../images/create-a-voice-agent.png)
 
-We provide an Agent which quickly helps you get started by creating a voice agent with default prompts and pathways. You can provide inputs like whether you need an "Inbound" or "Outbound" voice agent. You can also provide your use case, and description of what the voice agent should be doing. Your inputs will be sent to an LLM to generate the voice agent, so the better you can describe your use case, the better the starting agent will be created for you. 
+The Voice Agent Builder is a visual, graph-based editor for designing what your voice agent says and does during a call. Instead of writing one giant prompt, you break the conversation into **nodes** (stages of the conversation) connected by **pathways** (the routes the LLM can take between stages, based on how the conversation is going).
 
-Once you create your Voice Agent using our Agent builder, you would be taken to the Agent, where you would have an option to test the agent using "Web Call" or "Phone Call". You can also modify the prompts of the Agent to suit it to your use case better. 
+You can create a new agent from the [dashboard](https://app.dograh.com/workflow). Describe whether you need an "Inbound" or "Outbound" agent and your use case — this is sent to an LLM to generate a starting workflow with default prompts and pathways, which you can then edit.
+
+## The graph model
+
+A workflow is a directed graph:
+
+- **Nodes** represent a stage of the conversation or an action (e.g. greet the caller, collect an address, transfer the call).
+- **Pathways (edges)** connect nodes and represent the routes the LLM can take depending on what the caller says. The LLM decides at runtime which pathway to follow.
+
+Every workflow needs exactly one **Start Call** node and typically ends at an **End Call** node, with **Agent** nodes and other node types in between. See [Editing a Workflow](/voice-agent/editing-a-workflow) for how nodes, pathways, and node-level toggles fit together.
+
+## Node types
+
+| Node | What it does |
+| --- | --- |
+| [**Start Call**](/voice-agent/start-call) | Starts the call and configures the agent's greeting. Exactly one per workflow. |
+| [**Agent**](/voice-agent/agent) | Holds the prompt that drives conversation at a given stage; connects to other nodes via pathways. |
+| [**Global**](/voice-agent/global) | Common instructions (tone, objection handling) appended to every node with "Add Global Prompt" enabled. |
+| [**QA**](/voice-agent/qa) | Runs automated post-call quality analysis against criteria you define. |
+| [**API Trigger**](/voice-agent/api-trigger) | Exposes an endpoint so external systems (n8n, Zapier, your backend) can start outbound calls. |
+| [**End Call**](/voice-agent/end-call) | Configures the agent's final message before the call is terminated. Exactly one per workflow. |
+| [**Webhook**](/voice-agent/webhook) | Sends call results to an external system (CRM, Zapier, n8n) when a run ends. |
+
+Beyond nodes, you can extend an agent with:
+
+- [**Tools**](/voice-agent/tools/introduction) — let the LLM call external APIs, transfer calls, or invoke MCP servers mid-conversation.
+- [**Knowledge Base**](/voice-agent/knowledge-base) — attach documents the agent can reference during a call.
+- [**Pre-Call Data Fetch**](/voice-agent/pre-call-data-fetch) — enrich context with an HTTP call before the agent starts speaking.
+- [**Pre-recorded Audio**](/voice-agent/pre-recorded-audio) — mix in real recordings alongside LLM-generated speech.
+- [**Template Variables**](/voice-agent/template-variables) — reference `initial_context` and `gathered_context` values in prompts and payloads.
+
+## Where to start
+
+1. **New to Dograh?** Follow [Editing a Workflow](/voice-agent/editing-a-workflow) to learn the fundamentals of nodes and pathways.
+2. **Want to test immediately?** Use a [Web Call](/core-concepts/calls-and-runs#web-calls) from the agent editor — no telephony setup required.
+3. **Ready to go live?** Configure a [telephony provider](/integrations/telephony/overview) and add an [API Trigger](/voice-agent/api-trigger) or set up inbound routing.
+4. **Need the call to hit your systems?** Add a [Webhook](/voice-agent/webhook) node to sync results to your CRM or automation tool.
+5. **Want to embed the agent on a website?** See [Add to Website](/voice-agent/add-to-website).
+
+## Related
+
+- [Core Concepts: Workflows and Agents](/core-concepts/workflows-and-agents)
+- [Core Concepts: Context & Variables](/core-concepts/context-and-variables)
+- [Editing a Workflow](/voice-agent/editing-a-workflow)

--- a/docs/voice-agent/introduction.mdx
+++ b/docs/voice-agent/introduction.mdx
@@ -16,18 +16,18 @@ A workflow is a directed graph:
 - **Nodes** represent a stage of the conversation or an action (e.g. greet the caller, collect an address, transfer the call).
 - **Pathways (edges)** connect nodes and represent the routes the LLM can take depending on what the caller says. The LLM decides at runtime which pathway to follow.
 
-Every workflow needs exactly one **Start Call** node and typically ends at an **End Call** node, with **Agent** nodes and other node types in between. See [Editing a Workflow](/voice-agent/editing-a-workflow) for how nodes, pathways, and node-level toggles fit together.
+A workflow should have only one **Start Call** node and typically ends at an **End Call** node, with **Agent** nodes and other node types in between. See [Editing a Workflow](/voice-agent/editing-a-workflow) for how nodes, pathways, and node-level toggles fit together.
 
 ## Node types
 
 | Node | What it does |
 | --- | --- |
-| [**Start Call**](/voice-agent/start-call) | Starts the call and configures the agent's greeting. Exactly one per workflow. |
+| [**Start Call**](/voice-agent/start-call) | Starts the call and configures the agent's greeting. Should have only one per workflow. |
 | [**Agent**](/voice-agent/agent) | Holds the prompt that drives conversation at a given stage; connects to other nodes via pathways. |
 | [**Global**](/voice-agent/global) | Common instructions (tone, objection handling) appended to every node with "Add Global Prompt" enabled. |
 | [**QA**](/voice-agent/qa) | Runs automated post-call quality analysis against criteria you define. |
 | [**API Trigger**](/voice-agent/api-trigger) | Exposes an endpoint so external systems (n8n, Zapier, your backend) can start outbound calls. |
-| [**End Call**](/voice-agent/end-call) | Configures the agent's final message before the call is terminated. Exactly one per workflow. |
+| [**End Call**](/voice-agent/end-call) | Configures the agent's final message before the call is terminated. Should have only one per workflow. |
 | [**Webhook**](/voice-agent/webhook) | Sends call results to an external system (CRM, Zapier, n8n) when a run ends. |
 
 Beyond nodes, you can extend an agent with:

--- a/docs/voice-agent/tools/call-transfer.mdx
+++ b/docs/voice-agent/tools/call-transfer.mdx
@@ -30,7 +30,7 @@ The Call Transfer tool performs **blind transfers** where no call context is sha
 ### Destination Formats
 
 **For Twilio:**
-- **Phone numbers**: E.164 format: `+1234567890`
+- **Phone numbers**: [E.164](https://en.wikipedia.org/wiki/E.164) format (`+` then country code then number, no spaces or dashes): `+1234567890`
 - Must be a valid reachable phone number
 
 **For Telnyx:**


### PR DESCRIPTION
First-pass docs audit after going through the full docs as a new user.

**Dead entry points fixed**
- `/voice-agent/introduction` — full rewrite with node type table, graph model explanation, where-to-start section
- `/deployment/introduction` — overview with deployment path comparison table, post-deploy guides
- `/contribution/introduction` — repo layout, two setup paths, contribution flow

**New tutorial**
- `getting-started/first-agent` — "Your First Agent in 5 Minutes" using Web Calls, no telephony needed
- Wired into nav and linked from getting-started index

**Unexplained features**
- `gathered_context` — extraction config, multi-node merge behavior, downstream reference syntax, example payload
- VAD — new dedicated section on interruption page with Silero VAD explanation and valid sample rates, linked from Vonage and custom provider pages
- Pipecat + Pydantic — prerequisites section added to custom telephony page

**Assumed prior knowledge**
- E.164 — inline definition added at first mention across all 8 telephony pages
- Langfuse — one-liner + link added to tracing page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves onboarding and core docs: adds a 5‑minute “Your First Agent” tutorial (Web Calls, no telephony), clarifies `gathered_context` and VAD, and rewrites Voice Agent and Deployments intros with clear paths and HTTPS guidance. Fixes dead entry points, anchors, and wording issues.

- **New Features**
  - New tutorial: “Your First Agent in 5 Minutes” (Web Calls); linked in nav and Getting Started.
  - Concept expansions:
    - `gathered_context`: extraction setup, multi-node merge, downstream usage with example payload.
    - VAD: Silero default, when providers supply VAD, 8 kHz/16 kHz limits; cross-linked from Vonage and custom telephony.
  - Rewrites:
    - Voice Agent Builder intro (graph model, node types, where to start).
    - Deployments intro (path comparison table, HTTPS/localhost note, post‑deploy guides).
    - Contribution intro (repo layout, setup paths, contribution flow).
  - Clarity: E.164 inline on telephony and transfer pages; quick Langfuse intro on tracing; custom telephony prerequisites (`pipecat` transports, `pydantic` models).

- **Bug Fixes**
  - Replaced dead/placeholder intro pages and added nav entry for the tutorial.
  - Fixed broken anchors/cross-links and tightened HTTPS wording; softened “single node” claims for Start/End Call to “should have only one.”

<sup>Written for commit e58d8ae5aeee3bae685310c36dd7bf0318a87e63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a docs-only audit pass that fixes several dead entry points, adds a new "Your First Agent in 5 Minutes" tutorial, and documents previously unexplained features (`gathered_context`, VAD, Pipecat/Pydantic prerequisites, E.164 format, Langfuse).

- **New tutorial** (`getting-started/first-agent.mdx`) walks users through creating an agent via Web Calls with no telephony setup; wired into nav and linked from the Getting Started index.
- **Dead intro pages rewritten**: `voice-agent/introduction`, `deployment/introduction`, and `contribution/introduction` now contain substantive content with node-type tables, deployment path comparisons, and repo layout overviews.
- **Inline clarifications** added across all 8 telephony pages (E.164 definition), the interruption page (full VAD section), `context-and-variables` (`gathered_context` extraction config + downstream reference syntax), tracing (Langfuse one-liner), and the custom telephony page (Pipecat/Pydantic prerequisites).

<h3>Confidence Score: 5/5</h3>

Documentation-only changes with no code modifications; all internal anchors, image paths, and page references verified as valid.

Every anchor introduced by this PR was verified against the target files (#what-is-vad, #audio-format-considerations, #payload-context-variables, #web-calls, #the-graph-model). Referenced pages (/voice-agent/qa, /voice-agent/add-to-website, etc.) all exist. "Grok Voice Agent" in the VAD section matches the grok_realtime.py implementation. The only open items (Heroku "coming soon" table cell, Slack invite expiry) were already raised in the previous review round.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/getting-started/first-agent.mdx | New tutorial page — anchors resolve correctly, image path is valid, frontmatter present, relative internal links use correct paths. |
| docs/core-concepts/context-and-variables.mdx | Expands gathered_context section with extraction config table, multi-node merge behavior, and downstream reference syntax; webhook anchor and page links verified as valid. |
| docs/configurations/interruption.mdx | Adds VAD section with Silero explanation, provider exceptions, and sample-rate note; "Grok Voice Agent" matches the grok_realtime.py implementation in the codebase. |
| docs/voice-agent/introduction.mdx | Full rewrite of previously empty intro; all linked node pages exist, all anchors resolve, and node-type table uses softened "should have only one" phrasing consistent with end-call.mdx. |
| docs/deployment/introduction.mdx | Rewrites placeholder page with deployment path comparison table; Heroku "coming soon" inline note in a table cell was flagged in a previous review comment. |
| docs/contribution/introduction.mdx | Rewrites placeholder intro with repo layout, two dev-environment setup paths, and contribution flow; Slack invite link expiry was flagged in a previous review comment. |
| docs/docs.json | Adds getting-started/first-agent entry to the Introduction nav group; ordering and file path match the new MDX file. |
| docs/integrations/telephony/custom.mdx | Adds Pipecat/Pydantic prerequisites section and updates VAD note with a cross-link; #audio-format-considerations anchor confirmed present in this file. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Getting Started Index] -->|"new link"| B["Your First Agent in 5 Minutes\n(first-agent.mdx)"]
    B --> C[Step 1: Create agent\napp.dograh.com/workflow]
    C --> D[Step 2: Land in workflow editor\nStart Call → Agent nodes → End Call]
    D --> E[Step 3: Start a Web Call\nbrowser mic, live transcript]
    E --> F{Happy with result?}
    F -->|No| G[Step 4: Edit node prompt\nsave → new Web Call]
    G --> E
    F -->|Yes| H[Next Steps]
    H --> I[Connect telephony provider]
    H --> J[Add Webhook node]
    H --> K[Embed on website]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Getting Started Index] -->|"new link"| B["Your First Agent in 5 Minutes\n(first-agent.mdx)"]
    B --> C[Step 1: Create agent\napp.dograh.com/workflow]
    C --> D[Step 2: Land in workflow editor\nStart Call → Agent nodes → End Call]
    D --> E[Step 3: Start a Web Call\nbrowser mic, live transcript]
    E --> F{Happy with result?}
    F -->|No| G[Step 4: Edit node prompt\nsave → new Web Call]
    G --> E
    F -->|Yes| H[Next Steps]
    H --> I[Connect telephony provider]
    H --> J[Add Webhook node]
    H --> K[Embed on website]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `docs/contribution/introduction.mdx`, line 81 ([link](https://github.com/dograh-hq/dograh/blob/01191184850890eed7d1b45a7506a279b47b5bd7/docs/contribution/introduction.mdx#L81)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Slack invite link will expire**

   The Slack invite URL (`https://join.slack.com/t/dograh-community/shared_invite/zt-3zjb5vwvl-...`) is a one-time-use or time-limited invite link. Once it expires, every visitor hitting this page will get an "invite link has expired" error. CLAUDE.md calls out making content evergreen where possible. Consider replacing it with a permanent community link (e.g. a `https://dograh.com/community` redirect or the Slack workspace landing page) that the team controls and can update in one place.

2. `docs/deployment/introduction.mdx`, line 167 ([link](https://github.com/dograh-hq/dograh/blob/01191184850890eed7d1b45a7506a279b47b5bd7/docs/deployment/introduction.mdx#L167)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **"Coming soon" mixed into linked table cell text**

   The table cell reads `[Heroku](/deployment/heroku) — coming soon`, making the link look like a "coming soon" page. A user clicking the link will arrive at `/deployment/heroku` with no indication there whether that page is complete or still a stub. Consider either deferring the Heroku row until the page is ready, or moving the status notice outside the cell (e.g., as a `<Note>` below the table) so the destination page can stand on its own.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["docs: tighten HTTPS wording and soften s..."](https://github.com/dograh-hq/dograh/commit/e58d8ae5aeee3bae685310c36dd7bf0318a87e63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41074261)</sub>

<!-- /greptile_comment -->