### PR TITLE
docs: clarify Asterisk ARI websocket_client.conf URI and why /ws/ari 403s when tested directly

### DIFF
--- a/docs/integrations/telephony/asterisk-ari.mdx
+++ b/docs/integrations/telephony/asterisk-ari.mdx
@@ -107,6 +107,10 @@ The section name (e.g., `dograh`) is the **WebSocket Client Name** you'll enter 
 </Note>
 
 <Note>
+Configure the `uri` as a base URL only, without a query string. During each call, Dograh asks Asterisk to create an `externalMedia` channel and Asterisk appends `workflow_id`, `user_id`, and `workflow_run_id` through the `v()` transport data for that call. Opening `/api/v1/telephony/ws/ari` directly in a browser or with `wscat` can return HTTP 403 because those routing parameters are missing; that is expected and does not indicate a `websocket_client.conf` misconfiguration.
+</Note>
+
+<Note>
 Dograh's external media channel uses **G.711 μ-law (`ulaw`)**. Make sure any PJSIP endpoint or SIP trunk that places or receives calls through Dograh allows `ulaw` (e.g. `allow=ulaw` in the endpoint config).
 </Note>
 


### PR DESCRIPTION
## Summary

Clarifies the Asterisk ARI integration docs so the `websocket_client.conf` `uri` is documented as a base URL with no query string, and explains why opening `/api/v1/telephony/ws/ari` directly (browser or `wscat`) returns HTTP 403.

## Why this matters

In issue #467 a user testing the ARI websocket endpoint directly got a 403 and assumed their `websocket_client.conf` was misconfigured. It is not: Dograh asks Asterisk to create the `externalMedia` channel per call, and Asterisk appends the routing parameters (`workflow_id`, `user_id`, `workflow_run_id`) via the `v()` transport data. Hitting the endpoint directly omits those parameters, so the 403 is expected. The docs did not say this, so the failure mode looked like a config bug.

This adds a short note to `docs/integrations/telephony/asterisk-ari.mdx` stating that the `uri` is a base URL (no query string) and that a direct-access 403 is expected and not a misconfiguration, matching the current implementation.

Fixes #467

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the Asterisk ARI docs: set the `websocket_client.conf` `uri` to a base URL (no query string). Notes that direct requests to `/api/v1/telephony/ws/ari` may return HTTP 403 because Asterisk appends `workflow_id`, `user_id`, and `workflow_run_id` per call via `v()` transport data.

<sup>Written for commit 8069c43aa9b0d8807f7d556d1ebd65e77e410713. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR clarifies the Asterisk ARI WebSocket setup docs. The main changes are:

- Documents the `websocket_client.conf` `uri` as a base URL without a query string.
- Explains that Dograh creates the `externalMedia` channel per call.
- Notes that Asterisk appends `workflow_id`, `user_id`, and `workflow_run_id` through `v()` transport data.
- Explains that direct `/api/v1/telephony/ws/ari` access can return HTTP 403 when routing parameters are missing.

<h3>Confidence Score: 5/5</h3>

This documentation-only change is safe to merge.

The update is limited to a short MDX note, matches the surrounding Mintlify `Note` style, and accurately describes the ARI flow where `externalMedia` supplies workflow routing identifiers to the WebSocket handler.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The base docs page was captured before changes, showing the clarification note is not present in the Configure External Media Streaming section.
- The updated docs page was captured after changes, showing the clarification note is present in the same section.
- A run log was produced that records the exact command, commit IDs, route, artifact sizes, and head/base verification used to validate the before/after states.

<a href="https://app.greptile.com/trex/runs/13033795/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/integrations/telephony/asterisk-ari.mdx | Adds a documentation note clarifying ARI `websocket_client.conf` base URI usage and expected direct WebSocket 403 behavior; no issues found. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User as Reader testing /ws/ari directly
participant Docs as Asterisk ARI docs
participant Dograh as Dograh API
participant Asterisk as Asterisk externalMedia

User->>Docs: Reads websocket_client.conf guidance
Docs-->>User: Use base URI without query string
User->>Dograh: Opens /api/v1/telephony/ws/ari directly
Dograh-->>User: 403 because workflow routing params are absent
Dograh->>Asterisk: Creates externalMedia channel during a call
Asterisk->>Dograh: Connects WebSocket with v() transport data
Dograh-->>Asterisk: Accepts workflow_id, user_id, workflow_run_id routed stream
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User as Reader testing /ws/ari directly
participant Docs as Asterisk ARI docs
participant Dograh as Dograh API
participant Asterisk as Asterisk externalMedia

User->>Docs: Reads websocket_client.conf guidance
Docs-->>User: Use base URI without query string
User->>Dograh: Opens /api/v1/telephony/ws/ari directly
Dograh-->>User: 403 because workflow routing params are absent
Dograh->>Asterisk: Creates externalMedia channel during a call
Asterisk->>Dograh: Connects WebSocket with v() transport data
Dograh-->>Asterisk: Accepts workflow_id, user_id, workflow_run_id routed stream
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify Asterisk ARI websocket\_cli..."](https://github.com/dograh-hq/dograh/commit/8069c43aa9b0d8807f7d556d1ebd65e77e410713) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41317366)</sub>

<!-- /greptile_comment -->