### PR TITLE
docs: add missing cross-links for machine and human readability

### DIFF
--- a/docs/core-concepts/how-dograh-works.mdx
+++ b/docs/core-concepts/how-dograh-works.mdx
@@ -38,22 +38,22 @@ sequenceDiagram
 
 ## Key components
 
-**Workflows (Agents)**
+**[Workflows (Agents)](/core-concepts/workflows-and-agents)**
 The conversation logic. A workflow is a graph of nodes (conversation steps) connected by edges (conditional transitions). You define what the agent says, when it moves on, and what data it collects.
 
-**Runs**
+**[Runs](/core-concepts/calls-and-runs)**
 Every execution of a workflow creates a run. The run record holds the transcript, recording, extracted data, and cost information.
 
-**Telephony**
+**[Telephony](/integrations/telephony/overview)**
 The phone infrastructure. Dograh connects to your telephony provider (Twilio, Vonage, etc.) to place and receive calls. The audio streams between the caller and Dograh in real time.
 
-**Transcriber (STT)**
+**[Transcriber (STT)](/configurations/transcriber)**
 Converts the caller's speech to text in real time. Dograh sends the audio stream to your configured speech-to-text provider and uses the transcript to drive both the LLM and the final run record.
 
-**LLM Provider**
+**[LLM Provider](/configurations/llm)**
 Processes the transcript and the active node's prompt to generate the agent's next response. It also evaluates edge conditions to decide when to move the conversation forward.
 
-**Voice Synthesizer (TTS)**
+**[Voice Synthesizer (TTS)](/configurations/voice)**
 Converts the LLM's text response to audio and streams it back to the caller. The choice of TTS provider and voice is configurable per agent.
 
 ## How it fits together

--- a/docs/developer/environment-variables.mdx
+++ b/docs/developer/environment-variables.mdx
@@ -175,6 +175,8 @@ Tracing activates automatically as soon as credentials are available — either 
 
 ## Campaigns
 
+Controls concurrency for [Campaigns](/core-concepts/campaigns), Dograh's bulk outbound calling feature.
+
 | Variable | Default | Description |
 |---|---|---|
 | `DEFAULT_ORG_CONCURRENCY_LIMIT` | `2` | Maximum concurrent outbound calls per organization |

--- a/docs/voice-agent/pre-call-data-fetch.mdx
+++ b/docs/voice-agent/pre-call-data-fetch.mdx
@@ -3,7 +3,7 @@ title: "Pre-Call Data Fetch"
 description: "Fetch customer data from your CRM or ERP before the call starts, so your voice agent can greet callers by name and reference their account details."
 ---
 
-Pre-Call Data Fetch allows you to enrich the call context with external data before the voice agent starts speaking. When enabled on the **Start Call** node, Dograh sends an HTTP request to your API as soon as a call is initiated. While the response is loading, the caller hears a ring-back tone. Once the data arrives, it is merged into the call's [initial context](/core-concepts/context-and-variables#initial_context) and becomes available as template variables in your prompts and greetings.
+Pre-Call Data Fetch allows you to enrich the call context with external data before the voice agent starts speaking. When enabled on the [**Start Call**](/voice-agent/start-call) node, Dograh sends an HTTP request to your API as soon as a call is initiated. While the response is loading, the caller hears a ring-back tone. Once the data arrives, it is merged into the call's [initial context](/core-concepts/context-and-variables#initial_context) and becomes available as template variables in your prompts and greetings.
 
 
 ## How It Works
@@ -17,7 +17,7 @@ Pre-Call Data Fetch allows you to enrich the call context with external data bef
 
 ## Configuration
 
-Open the **Start Call** node editor and expand **Advanced Settings**. Toggle **Pre-Call Data Fetch** and configure:
+Open the [**Start Call**](/voice-agent/start-call) node editor and expand **Advanced Settings**. Toggle **Pre-Call Data Fetch** and configure:
 
 | Field | Description |
 | --- | --- |


### PR DESCRIPTION
Adds inline links at point-of-mention across 3 files — agents parse top-to-bottom and don't reach end-of-page cards, so linking at first mention ensures both AI agents and human readers can navigate without hunting.

**Changes:**
- `how-dograh-works.mdx` — all 6 key components (Telephony, Transcriber, LLM Provider, Voice Synthesizer, Workflows, Runs) now link inline at point of mention
- `pre-call-data-fetch.mdx` — both "Start Call" node mentions now link to the Start Call node page
- `environment-variables.mdx` — Campaigns section now links to the Campaigns core concept page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added inline cross-links at the first mention in three docs so readers and agents can navigate immediately. Linked all six key components in How Dograh Works, both Start Call mentions in Pre-Call Data Fetch, and Campaigns in Environment Variables.

<sup>Written for commit 4e8314067dd31f87c4f4da3d056c8acf3b941468. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds inline internal links to documentation pages. The main changes are:

- Links for key components in `how-dograh-works.mdx`.
- A Campaigns concept link in `environment-variables.mdx`.
- Start Call node links in `pre-call-data-fetch.mdx`.

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge.

The changes only add inline documentation links and one short explanatory sentence. All added internal link targets were verified to exist. No functional code paths are affected.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran Playwright-based verification to confirm that all six Key components labels became links to their intended pages.
- Captured a before-state poster frame showing the base Key components section with no inline links.
- Captured an after-state poster frame showing the head Key components section with inline links for the six components.
- Recorded the pre-change UI verification video demonstrating the before-to-after state of the Key components section.
- Recorded the post-change UI verification video demonstrating that all six labels are now linked to their respective pages.
- Compared the Start Call mentions in the before/after artifacts; before had two mentions with no hrefs, after included a linked href to /voice-agent/start-call.
- Mintlify attempt log was included to document why the validation fell back from the real UI to deterministic MDX.
- Observed the Campaigns section in the before state, where the environment showed no inline link (hasInlineCampaignsLink false).
- Observed the Campaigns section in the after state, where there is a link to /core-concepts/campaigns and hasInlineCampaignsLink is true.

<a href="https://app.greptile.com/trex/runs/13044945/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/core-concepts/how-dograh-works.mdx | Adds point-of-mention internal links for the six key component headings; linked targets exist and match the documented concepts. |
| docs/developer/environment-variables.mdx | Adds a Campaigns cross-link before the concurrency variables table; the target page exists and the text stays scoped to the section. |
| docs/voice-agent/pre-call-data-fetch.mdx | Adds Start Call cross-links at both mentions; the target page exists and the existing procedural content is unchanged. |

<sub>Reviews (1): Last reviewed commit: ["docs: add missing cross-links for machin..."](https://github.com/dograh-hq/dograh/commit/4e8314067dd31f87c4f4da3d056c8acf3b941468) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41338254)</sub>

<!-- /greptile_comment -->