### PR TITLE
Adding support for Exotel telephony

### DIFF
--- a/api/enums.py
+++ b/api/enums.py
@@ -45,6 +45,7 @@ class TelephonyCallStatus(str, Enum):
 
 class WorkflowRunMode(Enum):
     ARI = "ari"
+    EXOTEL = "exotel"
     PLIVO = "plivo"
     TWILIO = "twilio"
     VONAGE = "vonage"

--- a/api/routes/public_agent.py
+++ b/api/routes/public_agent.py
@@ -286,13 +286,33 @@ async def _execute_resolved_target(
     # (e.g. Telnyx, Cloudonix); without them the URL contains "None/None" and
     # the stream connection fails.
     try:
-        await provider.initiate_call(
+        call_result = await provider.initiate_call(
             to_number=request.phone_number,
             webhook_url=webhook_url,
             workflow_run_id=workflow_run.id,
             workflow_id=target.workflow.id,
             user_id=execution_user_id,
         )
+
+        # Store provider metadata and caller_number in workflow run context
+        gathered_context = {
+            "provider": provider.PROVIDER_NAME,
+            **(call_result.provider_metadata or {}),
+        }
+        
+        # Merge caller_number into initial_context if available
+        updated_initial_context = {
+            **(workflow_run.initial_context or {}),
+        }
+        if call_result.caller_number:
+            updated_initial_context["caller_number"] = call_result.caller_number
+            
+        await db_client.update_workflow_run(
+            run_id=workflow_run.id,
+            gathered_context=gathered_context,
+            initial_context=updated_initial_context,
+        )
+
     except Exception as e:
         logger.warning(
             f"Failed to initiate call for workflow run {workflow_run.id}: {e}"

--- a/api/schemas/telephony_config.py
+++ b/api/schemas/telephony_config.py
@@ -20,6 +20,10 @@ from api.services.telephony.providers.cloudonix.config import (
     CloudonixConfigurationRequest,
     CloudonixConfigurationResponse,
 )
+from api.services.telephony.providers.exotel.config import (
+    ExotelConfigurationRequest,
+    ExotelConfigurationResponse,
+)
 from api.services.telephony.providers.plivo.config import (
     PlivoConfigurationRequest,
     PlivoConfigurationResponse,
@@ -48,6 +52,7 @@ TelephonyConfigRequest = Annotated[
     Union[
         ARIConfigurationRequest,
         CloudonixConfigurationRequest,
+        ExotelConfigurationRequest,
         PlivoConfigurationRequest,
         TelnyxConfigurationRequest,
         TwilioConfigurationRequest,
@@ -73,6 +78,7 @@ class TelephonyConfigurationResponse(BaseModel):
     cloudonix: Optional[CloudonixConfigurationResponse] = None
     ari: Optional[ARIConfigurationResponse] = None
     telnyx: Optional[TelnyxConfigurationResponse] = None
+    exotel: Optional[ExotelConfigurationResponse] = None
 
 
 # ---------------------------------------------------------------------------
@@ -136,6 +142,8 @@ __all__ = [
     "ARIConfigurationResponse",
     "CloudonixConfigurationRequest",
     "CloudonixConfigurationResponse",
+    "ExotelConfigurationRequest",
+    "ExotelConfigurationResponse",
     "PlivoConfigurationRequest",
     "PlivoConfigurationResponse",
     "TelephonyConfigRequest",

--- a/api/services/telephony/providers/__init__.py
+++ b/api/services/telephony/providers/__init__.py
@@ -9,6 +9,7 @@ or run_pipeline.
 from api.services.telephony.providers import (  # noqa: F401  -- import for side effects (registration)
     ari,
     cloudonix,
+    exotel,
     plivo,
     telnyx,
     twilio,

--- a/api/services/telephony/providers/exotel/__init__.py
+++ b/api/services/telephony/providers/exotel/__init__.py
@@ -1,0 +1,113 @@
+"""Exotel telephony provider package.
+
+Importing this module registers ExotelProvider with the telephony registry.
+"""
+
+from typing import Any, Dict
+
+from api.services.telephony.registry import (
+    ProviderSpec,
+    ProviderUIField,
+    ProviderUIMetadata,
+    register,
+)
+
+from .config import ExotelConfigurationRequest, ExotelConfigurationResponse
+from .provider import ExotelProvider
+from .transport import create_transport
+
+
+def _config_loader(value: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize stored credentials JSONB into the ExotelProvider constructor dict."""
+    return {
+        "provider": "exotel",
+        "api_key": value.get("api_key"),
+        "api_token": value.get("api_token"),
+        "account_sid": value.get("account_sid"),
+        "subdomain": value.get("subdomain", "api.exotel.com"),
+        "from_numbers": value.get("from_numbers", []),
+        "app_id": value.get("app_id"),
+    }
+
+
+_UI_METADATA = ProviderUIMetadata(
+    display_name="Exotel",
+    docs_url="https://developer.exotel.com/api/",
+    fields=[
+        ProviderUIField(
+            name="api_key",
+            label="API Key",
+            type="text",
+            sensitive=True,
+            description="From Exotel Dashboard → Settings → API Settings",
+        ),
+        ProviderUIField(
+            name="api_token",
+            label="API Token",
+            type="password",
+            sensitive=True,
+        ),
+        ProviderUIField(
+            name="account_sid",
+            label="Account SID",
+            type="text",
+            sensitive=False,
+            description="Your Exotel account SID / subdomain identifier",
+        ),
+        ProviderUIField(
+            name="subdomain",
+            label="API Subdomain",
+            type="text",
+            sensitive=False,
+            required=False,
+            description=(
+                "api.exotel.com (global / SEA) or "
+                "api.in.exotel.com (India-hosted). Defaults to api.exotel.com."
+            ),
+        ),
+        ProviderUIField(
+            name="from_numbers",
+            label="ExoPhone Numbers (CallerIds)",
+            type="string-array",
+            description=(
+                "Exotel virtual phone numbers used as CallerIds for outbound calls. "
+                "Add them without country code if your account expects that format."
+            ),
+        ),
+        ProviderUIField(
+            name="app_id",
+            label="App Bazaar App ID",
+            type="text",
+            sensitive=False,
+            required=True,
+            description=(
+                "App ID from Exotel App Bazaar (My Apps → App ID column). "
+                "In that app's flow, set the WebSocket URL to: "
+                "wss://{your-backend-domain}/api/v1/telephony/exotel/stream"
+            ),
+        ),
+    ],
+)
+
+SPEC = ProviderSpec(
+    name="exotel",
+    provider_cls=ExotelProvider,
+    config_loader=_config_loader,
+    transport_factory=create_transport,
+    transport_sample_rate=8000,  # μ-law 8 kHz
+    config_request_cls=ExotelConfigurationRequest,
+    config_response_cls=ExotelConfigurationResponse,
+    ui_metadata=_UI_METADATA,
+    # AccountSid is present on all Exotel inbound webhooks.
+    account_id_credential_field="account_sid",
+)
+
+register(SPEC)
+
+__all__ = [
+    "SPEC",
+    "ExotelConfigurationRequest",
+    "ExotelConfigurationResponse",
+    "ExotelProvider",
+    "create_transport",
+]

--- a/api/services/telephony/providers/exotel/config.py
+++ b/api/services/telephony/providers/exotel/config.py
@@ -1,0 +1,45 @@
+"""Exotel telephony configuration schemas."""
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ExotelConfigurationRequest(BaseModel):
+    """Request schema for Exotel configuration."""
+
+    provider: Literal["exotel"] = Field(default="exotel")
+    api_key: str = Field(..., description="Exotel API Key (from Dashboard → Settings → API Settings)")
+    api_token: str = Field(..., description="Exotel API Token")
+    account_sid: str = Field(..., description="Exotel Account SID (subdomain/account identifier)")
+    subdomain: str = Field(
+        default="api.exotel.com",
+        description=(
+            "Exotel API subdomain. Use 'api.exotel.com' for global (SEA), "
+            "'api.in.exotel.com' for India-hosted accounts."
+        ),
+    )
+    from_numbers: List[str] = Field(
+        default_factory=list,
+        description="List of Exotel ExoPhone numbers (CallerIds) used for outbound calls",
+    )
+    app_id: str = Field(
+        ...,
+        description=(
+            "Exotel App ID (from App Bazaar → My Apps → App ID column). "
+            "Used to build the Url for outbound calls: "
+            "http://my.exotel.com/{account_sid}/exoml/start_voice/{app_id}"
+        ),
+    )
+
+
+class ExotelConfigurationResponse(BaseModel):
+    """Response schema for Exotel configuration with masked sensitive fields."""
+
+    provider: Literal["exotel"] = Field(default="exotel")
+    api_key: str  # Masked
+    api_token: str  # Masked
+    account_sid: str
+    subdomain: str
+    from_numbers: List[str]
+    app_id: str = ""

--- a/api/services/telephony/providers/exotel/provider.py
+++ b/api/services/telephony/providers/exotel/provider.py
@@ -1,0 +1,494 @@
+"""
+Exotel implementation of the TelephonyProvider interface.
+
+Exotel Voice v1 API:
+  Base URL: https://{api_key}:{api_token}@{subdomain}/v1/Accounts/{account_sid}/
+  Outbound: POST /Calls/connect
+  Call details: GET /Calls/{CallSid}.json
+
+Audio format: 8 kHz μ-law (same wire format as Twilio / Plivo).
+"""
+
+import json
+import random
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import aiohttp
+from fastapi import HTTPException
+from loguru import logger
+
+from api.db import db_client
+from api.enums import WorkflowRunMode
+from api.services.telephony.base import (
+    CallInitiationResult,
+    NormalizedInboundData,
+    ProviderSyncResult,
+    TelephonyProvider,
+)
+from api.utils.common import get_backend_endpoints
+from api.utils.telephony_address import normalize_telephony_address
+
+if TYPE_CHECKING:
+    from fastapi import WebSocket
+
+
+class ExotelProvider(TelephonyProvider):
+    """
+    Exotel Voice v1 implementation of TelephonyProvider.
+
+    Credentials required:
+      - api_key     : from Exotel Dashboard → Settings → API Settings
+      - api_token   : same location
+      - account_sid : your Exotel account SID / subdomain identifier
+      - subdomain   : e.g. api.exotel.com (global) or api.in.exotel.com (India)
+    """
+
+    PROVIDER_NAME = WorkflowRunMode.EXOTEL.value
+    WEBHOOK_ENDPOINT = "exotel-xml"  # path under /api/v1/telephony
+
+    def __init__(self, config: Dict[str, Any]):
+        self.api_key = config.get("api_key", "")
+        self.api_token = config.get("api_token", "")
+        self.account_sid = config.get("account_sid", "")
+        self.subdomain = config.get("subdomain", "api.exotel.com")
+        self.from_numbers = config.get("from_numbers", [])
+        self.app_id = config.get("app_id")
+
+        if isinstance(self.from_numbers, str):
+            self.from_numbers = [self.from_numbers]
+
+        self._base_url = (
+            f"https://{self.api_key}:{self.api_token}"
+            f"@{self.subdomain}/v1/Accounts/{self.account_sid}"
+        )
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
+
+    def _calls_url(self) -> str:
+        return f"{self._base_url}/Calls"
+
+    def _call_url(self, call_sid: str) -> str:
+        return f"{self._base_url}/Calls/{call_sid}.json"
+
+    # -------------------------------------------------------------------------
+    # Outbound
+    # -------------------------------------------------------------------------
+
+    async def initiate_call(
+        self,
+        to_number: str,
+        webhook_url: str,
+        workflow_run_id: Optional[int] = None,
+        from_number: Optional[str] = None,
+        **kwargs: Any,
+    ) -> CallInitiationResult:
+        """Initiate an outbound call via Exotel Calls/connect.
+
+        ``From``     — the number that gets called first (the callee / end-user).
+        ``CallerId`` — the ExoPhone (Exotel virtual number) shown as caller ID.
+        ``Url``      — Exotel app/flow URL; we point it at our answer webhook.
+        """
+        if not self.app_id:
+            raise ValueError(
+                "Exotel app_id is required. Set it to the App Bazaar App ID "
+                "(App Bazaar → My Apps → App ID column)."
+            )
+
+        caller_id = from_number or random.choice(self.from_numbers)
+
+        # Build the App Bazaar flow URL — this is what Exotel calls when the
+        # call is answered. The flow has the WebSocket URL pre-configured.
+        app_bazaar_url = (
+            f"http://my.exotel.com/{self.account_sid}/exoml/start_voice/{self.app_id}"
+        )
+
+        data: Dict[str, Any] = {
+            "From": to_number,
+            "CallerId": caller_id,
+            "Url": app_bazaar_url,
+            "CallType": "trans",  # transactional — no recording by default
+        }
+
+        if workflow_run_id:
+            backend_endpoint, _ = await get_backend_endpoints()
+            data["StatusCallback"] = (
+                f"{backend_endpoint}/api/v1/telephony/exotel/status-callback/{workflow_run_id}"
+            )
+
+        data.update(kwargs)
+
+        endpoint = f"{self._calls_url()}/connect.json"
+        log_data = {k: v for k, v in data.items()}  # shallow copy for logging
+        logger.info(
+            f"[Exotel] POST {endpoint}\n"
+            f"  From={log_data.get('From')} CallerId={log_data.get('CallerId')}\n"
+            f"  Url={log_data.get('Url')}\n"
+            f"  StatusCallback={log_data.get('StatusCallback')}"
+        )
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(endpoint, data=data) as response:
+                response_text = await response.text()
+                logger.info(
+                    f"[Exotel] Response HTTP {response.status}: {response_text[:500]}"
+                )
+                if response.status not in (200, 201, 202):
+                    logger.error(
+                        f"[Exotel] Calls/connect failed: "
+                        f"HTTP {response.status} body={response_text}"
+                    )
+                    raise HTTPException(
+                        status_code=response.status,
+                        detail=f"Failed to initiate Exotel call: {response_text}",
+                    )
+
+                try:
+                    response_data = json.loads(response_text)
+                except json.JSONDecodeError:
+                    logger.error(f"[Exotel] Non-JSON response: {response_text}")
+                    raise HTTPException(
+                        status_code=502,
+                        detail=f"Exotel returned non-JSON response: {response_text}",
+                    )
+
+                call_obj = response_data.get("Call", {})
+                call_sid = call_obj.get("Sid")
+                if not call_sid:
+                    raise HTTPException(
+                        status_code=500,
+                        detail=f"Exotel response missing Call.Sid: {response_data}",
+                    )
+
+                logger.info(
+                    f"[Exotel] Outbound call placed: Sid={call_sid} "
+                    f"Status={call_obj.get('Status')}"
+                )
+                return CallInitiationResult(
+                    call_id=call_sid,
+                    status=call_obj.get("Status", "queued"),
+                    caller_number=caller_id,
+                    provider_metadata={"call_id": call_sid},  # must be 'call_id' — matched by get_workflow_run_by_call_id
+                    raw_response=response_data,
+                )
+
+    async def get_call_status(self, call_id: str) -> Dict[str, Any]:
+        if not self.validate_config():
+            raise ValueError("Exotel provider not properly configured")
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(self._call_url(call_id)) as response:
+                if response.status != 200:
+                    error_data = await response.text()
+                    raise Exception(
+                        f"[Exotel] Failed to get call status: {error_data}"
+                    )
+                data = await response.json(content_type=None)
+                return data.get("Call", data)
+
+    async def get_call_cost(self, call_id: str) -> Dict[str, Any]:
+        try:
+            call_data = await self.get_call_status(call_id)
+            price_str = call_data.get("Price") or "0"
+            try:
+                cost = float(price_str)
+            except (ValueError, TypeError):
+                cost = 0.0
+
+            duration_str = call_data.get("Duration") or "0"
+            try:
+                duration = int(duration_str)
+            except (ValueError, TypeError):
+                duration = 0
+
+            return {
+                "cost_usd": cost,
+                "duration": duration,
+                "status": call_data.get("Status", "unknown"),
+                "price_unit": "INR",  # Exotel prices in INR
+                "raw_response": call_data,
+            }
+        except Exception as e:
+            logger.error(f"[Exotel] Exception fetching call cost for {call_id}: {e}")
+            return {"cost_usd": 0.0, "duration": 0, "status": "error", "error": str(e)}
+
+    async def get_available_phone_numbers(self) -> List[str]:
+        return self.from_numbers
+
+    def validate_config(self) -> bool:
+        return bool(
+            self.api_key
+            and self.api_token
+            and self.account_sid
+            and self.from_numbers
+            and self.app_id
+        )
+
+    # -------------------------------------------------------------------------
+    # Webhooks / answer URL
+    # -------------------------------------------------------------------------
+
+    async def verify_webhook_signature(
+        self,
+        url: str,
+        params: Dict[str, Any],
+        signature: str,
+    ) -> bool:
+        # Exotel v1 does not sign webhooks with a secret. Accept all.
+        return True
+
+    async def get_webhook_response(
+        self, workflow_id: int, user_id: int, workflow_run_id: int
+    ) -> str:
+        """Return ExoML that streams audio over WebSocket (μ-law 8 kHz)."""
+        _, wss_backend_endpoint = await get_backend_endpoints()
+        return (
+            f'<?xml version="1.0" encoding="UTF-8"?>\n'
+            f"<Response>\n"
+            f'    <Stream bidirectional="true" keepCallAlive="true" '
+            f'contentType="audio/x-mulaw;rate=8000">'
+            f"{wss_backend_endpoint}/api/v1/telephony/ws/{workflow_id}/{user_id}/{workflow_run_id}"
+            f"</Stream>\n"
+            f"</Response>"
+        )
+
+    def parse_status_callback(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize Exotel StatusCallback POST fields."""
+        status_map = {
+            "queued": "queued",
+            "in-progress": "answered",
+            "completed": "completed",
+            "failed": "failed",
+            "busy": "busy",
+            "no-answer": "no-answer",
+            "answered": "answered",
+            "terminal": "completed",
+        }
+        raw_status = (data.get("Status") or data.get("EventType") or "").lower()
+        call_sid = data.get("CallSid", "")
+        return {
+            "call_id": call_sid,
+            "status": status_map.get(raw_status, raw_status),
+            "from_number": data.get("From"),
+            "to_number": data.get("To"),
+            "direction": data.get("Direction"),
+            "duration": data.get("ConversationDuration") or data.get("Duration"),
+            "extra": data,
+        }
+
+    # -------------------------------------------------------------------------
+    # WebSocket
+    # -------------------------------------------------------------------------
+
+    async def handle_websocket(
+        self,
+        websocket: "WebSocket",
+        workflow_id: int,
+        user_id: int,
+        workflow_run_id: int,
+    ) -> None:
+        from api.services.pipecat.run_pipeline import run_pipeline_telephony
+
+        # Exotel sends a JSON "start" event first (same pattern as Plivo/Twilio).
+        # Log the raw message so we can see the exact wire format if it differs.
+        first_msg = await websocket.receive_text()
+        logger.info(f"[Exotel] First WebSocket message raw: {first_msg}")
+
+        try:
+            start_msg = json.loads(first_msg)
+        except json.JSONDecodeError:
+            logger.error(f"[Exotel] First WS message is not JSON: {first_msg}")
+            await websocket.close(code=4400, reason="Expected JSON start event")
+            return
+
+        event_type = start_msg.get("event") or start_msg.get("Event", "")
+        if event_type.lower() != "start":
+            logger.error(
+                f"[Exotel] Expected 'start' event, got: {event_type!r}. "
+                f"Full message: {start_msg}"
+            )
+            await websocket.close(code=4400, reason="Expected start event")
+            return
+
+        # Exotel may nest stream metadata under 'start' or at top level.
+        start_data = start_msg.get("start") or start_msg
+        stream_id = (
+            start_data.get("streamId")
+            or start_data.get("StreamId")
+            or start_data.get("stream_id")
+            or start_msg.get("streamId")
+            or ""
+        )
+
+        if not stream_id:
+            logger.warning(
+                f"[Exotel] Missing streamId in start event — using empty string. "
+                f"Full message: {start_msg}"
+            )
+            # Don't close — proceed with empty stream_id; Plivo serializer tolerates it.
+
+        # Prefer call_id stored on the workflow run (populated by the answer webhook).
+        workflow_run = await db_client.get_workflow_run(workflow_run_id)
+        call_id = None
+        if workflow_run and workflow_run.gathered_context:
+            call_id = workflow_run.gathered_context.get("call_id")
+
+        if not call_id:
+            call_id = (
+                start_data.get("callId")
+                or start_data.get("callSid")
+                or start_data.get("CallSid")
+                or start_data.get("call_sid")
+                or start_msg.get("callSid")
+                or start_msg.get("CallSid")
+            )
+
+        if not call_id:
+            logger.error(
+                f"[Exotel] Missing call ID for workflow run {workflow_run_id}. "
+                f"Full start message: {start_msg}"
+            )
+            await websocket.close(code=4400, reason="Missing call ID")
+            return
+
+        await run_pipeline_telephony(
+            websocket,
+            provider_name=self.PROVIDER_NAME,
+            workflow_id=workflow_id,
+            workflow_run_id=workflow_run_id,
+            user_id=user_id,
+            call_id=call_id,
+            transport_kwargs={"stream_id": stream_id, "call_id": call_id},
+        )
+
+    # -------------------------------------------------------------------------
+    # Inbound
+    # -------------------------------------------------------------------------
+
+    @classmethod
+    def can_handle_webhook(
+        cls, webhook_data: Dict[str, Any], headers: Dict[str, str]
+    ) -> bool:
+        # Exotel inbound webhooks carry CallSid and AccountSid but no
+        # provider-specific header. We match on AccountSid presence.
+        return "CallSid" in webhook_data and "AccountSid" in webhook_data
+
+    @staticmethod
+    def parse_inbound_webhook(webhook_data: Dict[str, Any]) -> NormalizedInboundData:
+        from_raw = webhook_data.get("From", "")
+        to_raw = webhook_data.get("To", "") or webhook_data.get("PhoneNumberSid", "")
+        return NormalizedInboundData(
+            provider=ExotelProvider.PROVIDER_NAME,
+            call_id=webhook_data.get("CallSid", ""),
+            from_number=normalize_telephony_address(from_raw).canonical
+            if from_raw
+            else "",
+            to_number=normalize_telephony_address(to_raw).canonical
+            if to_raw
+            else "",
+            direction=webhook_data.get("Direction", "inbound"),
+            call_status=webhook_data.get("Status", ""),
+            account_id=webhook_data.get("AccountSid"),
+            raw_data=webhook_data,
+        )
+
+    @staticmethod
+    def validate_account_id(config_data: dict, webhook_account_id: str) -> bool:
+        if webhook_account_id:
+            return config_data.get("account_sid") == webhook_account_id
+        logger.warning(
+            "[Exotel] Inbound webhook missing AccountSid — "
+            "falling back to config existence check"
+        )
+        return bool(config_data.get("account_sid"))
+
+    def normalize_phone_number(self, phone_number: str) -> str:
+        return phone_number
+
+    async def verify_inbound_signature(
+        self,
+        url: str,
+        webhook_data: Dict[str, Any],
+        headers: Dict[str, str],
+        body: str = "",
+    ) -> bool:
+        # Exotel v1 does not sign inbound webhooks.
+        return True
+
+    async def start_inbound_stream(
+        self,
+        *,
+        websocket_url: str,
+        workflow_run_id: int,
+        normalized_data: NormalizedInboundData,
+        backend_endpoint: str,
+    ):
+        from fastapi import Response
+
+        hangup_callback_attr = ""
+        if workflow_run_id:
+            hangup_url = (
+                f"{backend_endpoint}/api/v1/telephony/exotel"
+                f"/status-callback/{workflow_run_id}"
+            )
+            hangup_callback_attr = (
+                f' statusCallbackUrl="{hangup_url}" statusCallbackMethod="POST"'
+            )
+
+        exo_xml = (
+            f'<?xml version="1.0" encoding="UTF-8"?>\n'
+            f"<Response>\n"
+            f'    <Stream bidirectional="true" keepCallAlive="true" '
+            f'contentType="audio/x-mulaw;rate=8000"'
+            f"{hangup_callback_attr}>"
+            f"{websocket_url}"
+            f"</Stream>\n"
+            f"</Response>"
+        )
+        return Response(content=exo_xml, media_type="application/xml")
+
+    @staticmethod
+    def generate_error_response(error_type: str, message: str) -> tuple:
+        from fastapi import Response
+
+        exo_xml = (
+            f'<?xml version="1.0" encoding="UTF-8"?>\n'
+            f"<Response>\n"
+            f"    <Say>Sorry, there was an error processing your call. {message}</Say>\n"
+            f"    <Hangup/>\n"
+            f"</Response>"
+        )
+        return Response(content=exo_xml, media_type="application/xml")
+
+    # -------------------------------------------------------------------------
+    # Transfers (not supported)
+    # -------------------------------------------------------------------------
+
+    async def transfer_call(
+        self,
+        destination: str,
+        transfer_id: str,
+        conference_name: str,
+        timeout: int = 30,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        raise NotImplementedError("Exotel provider does not support call transfers")
+
+    def supports_transfers(self) -> bool:
+        return False
+
+    # -------------------------------------------------------------------------
+    # Optional: configure inbound (no-op — Exotel doesn't support programmatic
+    # answer-URL binding via the v1 REST API)
+    # -------------------------------------------------------------------------
+
+    async def configure_inbound(
+        self, address: str, webhook_url: Optional[str]
+    ) -> ProviderSyncResult:
+        logger.info(
+            f"[Exotel] configure_inbound called for {address} → {webhook_url}. "
+            "Exotel v1 does not support programmatic webhook binding; "
+            "configure the answer URL in the Exotel App Bazaar."
+        )
+        return ProviderSyncResult(ok=True)

--- a/api/services/telephony/providers/exotel/routes.py
+++ b/api/services/telephony/providers/exotel/routes.py
@@ -1,0 +1,223 @@
+"""Exotel telephony routes.
+
+Mounted under /api/v1/telephony by api.routes.telephony via importlib.
+
+Architecture (App Bazaar flow):
+  1. User configures an Exotel App Bazaar flow with WebSocket URL:
+       wss://{BACKEND}/api/v1/telephony/exotel/stream
+  2. When initiating an outbound call, we pass the App Bazaar URL as `Url`.
+  3. Exotel calls the number, answers, then connects to our fixed WebSocket.
+  4. We identify the call by CallSid (stored on workflow_run at initiation via
+     cost_info["call_id"] by run_pipeline_telephony, or gathered_context).
+"""
+
+import json
+
+from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
+from loguru import logger
+from pipecat.utils.run_context import set_current_run_id
+
+from api.db import db_client
+from api.services.telephony.status_processor import (
+    StatusCallbackRequest,
+    _process_status_update,
+)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Fixed WebSocket stream endpoint — URL configured in Exotel App Bazaar.
+# Exotel connects here when a call is answered (outbound or inbound).
+# ---------------------------------------------------------------------------
+
+
+@router.websocket("/exotel/stream")
+async def exotel_stream(websocket: WebSocket):
+    """
+    Fixed WebSocket endpoint pre-configured in the Exotel App Bazaar flow.
+
+    Exotel sends a 'start' event with CallSid. We look up the workflow_run
+    that has that CallSid (stored at call-initiation time) and run the
+    pipecat pipeline for it.
+    """
+    await websocket.accept()
+
+    # Exotel sends 'connected' first, then 'start' — same as Twilio.
+    # Loop until we get the 'start' event (skip 'connected' and any other preamble).
+    start_msg = None
+    for _ in range(5):  # safety limit
+        try:
+            raw = await websocket.receive_text()
+        except WebSocketDisconnect:
+            logger.warning("[Exotel stream] WebSocket disconnected before start event")
+            return
+
+        logger.info(f"[Exotel stream] Received message raw: {raw}")
+
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.error(f"[Exotel stream] Non-JSON message: {raw}")
+            await websocket.close(code=4400, reason="Expected JSON")
+            return
+
+        event_type = (msg.get("event") or msg.get("Event") or "").lower()
+
+        if event_type == "connected":
+            logger.info("[Exotel stream] Got 'connected' event, waiting for 'start'...")
+            continue
+
+        if event_type == "start":
+            start_msg = msg
+            break
+
+        logger.warning(
+            f"[Exotel stream] Unexpected event {event_type!r} before start, skipping."
+        )
+
+    if start_msg is None:
+        logger.error("[Exotel stream] Never received 'start' event from Exotel")
+        await websocket.close(code=4400, reason="Expected start event")
+        return
+
+    # Exotel may nest stream metadata under 'start' or at top level.
+    # Keys are snake_case (stream_sid, call_sid) — Twilio-compatible format.
+    start_data = start_msg.get("start") or start_msg
+    call_sid = (
+        start_data.get("call_sid")
+        or start_data.get("callSid")
+        or start_data.get("CallSid")
+        or start_msg.get("call_sid")
+        or start_msg.get("callSid")
+    )
+    stream_sid = (
+        start_data.get("stream_sid")
+        or start_data.get("streamSid")
+        or start_data.get("streamId")
+        or start_msg.get("stream_sid")
+        or start_msg.get("streamSid")
+        or ""
+    )
+    account_sid = (
+        start_data.get("account_sid")
+        or start_data.get("accountSid")
+        or start_msg.get("account_sid")
+        or ""
+    )
+
+    logger.info(
+        f"[Exotel stream] callSid={call_sid!r} streamSid={stream_sid!r} accountSid={account_sid!r}"
+    )
+
+    if not call_sid:
+        logger.error(
+            f"[Exotel stream] Missing callSid in start event. Full msg: {start_msg}"
+        )
+        await websocket.close(code=4400, reason="Missing callSid")
+        return
+
+    # ------------------------------------------------------------------
+    # 2. Look up the workflow_run by callSid
+    # ------------------------------------------------------------------
+    workflow_run = await db_client.get_workflow_run_by_call_id(call_sid)
+
+    if not workflow_run:
+        logger.error(
+            f"[Exotel stream] No workflow_run found for callSid={call_sid}. "
+            "Ensure the call was initiated via Dograh before Exotel connects."
+        )
+        await websocket.close(code=4404, reason="Workflow run not found for call")
+        return
+
+    workflow_run_id = workflow_run.id
+    workflow_id = workflow_run.workflow_id
+    set_current_run_id(workflow_run_id)
+
+    # Resolve user_id from the workflow
+    workflow = await db_client.get_workflow_by_id(workflow_id)
+    if not workflow:
+        logger.error(f"[Exotel stream] Workflow {workflow_id} not found")
+        await websocket.close(code=4404, reason="Workflow not found")
+        return
+
+    user_id = workflow.user_id
+
+    logger.info(
+        f"[Exotel stream] Matched callSid={call_sid} → "
+        f"workflow_run_id={workflow_run_id} workflow_id={workflow_id}"
+    )
+
+    # ------------------------------------------------------------------
+    # 3. Run the pipeline
+    # ------------------------------------------------------------------
+    from api.services.pipecat.run_pipeline import run_pipeline_telephony
+
+    await run_pipeline_telephony(
+        websocket,
+        provider_name="exotel",
+        workflow_id=workflow_id,
+        workflow_run_id=workflow_run_id,
+        user_id=user_id,
+        call_id=call_sid,
+        transport_kwargs={
+            "stream_id": stream_sid,
+            "call_id": call_sid,
+            "account_sid": account_sid,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Status callback — called by Exotel on call completion / state changes.
+# ---------------------------------------------------------------------------
+
+
+@router.post("/exotel/status-callback/{workflow_run_id}")
+async def handle_exotel_status_callback(
+    workflow_run_id: int,
+    request: Request,
+):
+    """Handle Exotel StatusCallback POST."""
+    set_current_run_id(workflow_run_id)
+
+    form_data = await request.form()
+    callback_data = dict(form_data)
+    logger.info(
+        f"[run {workflow_run_id}] Exotel status callback: "
+        f"{json.dumps(callback_data)}"
+    )
+
+    workflow_run = await db_client.get_workflow_run_by_id(workflow_run_id)
+    if not workflow_run:
+        logger.warning(
+            f"[run {workflow_run_id}] Exotel status callback: workflow run not found"
+        )
+        return {"status": "ignored", "reason": "workflow_run_not_found"}
+
+    workflow = await db_client.get_workflow_by_id(workflow_run.workflow_id)
+    if not workflow:
+        logger.warning(
+            f"[run {workflow_run_id}] Exotel status callback: workflow not found"
+        )
+        return {"status": "ignored", "reason": "workflow_not_found"}
+
+    from api.services.telephony.factory import get_telephony_provider_for_run
+
+    provider = await get_telephony_provider_for_run(
+        workflow_run, workflow.organization_id
+    )
+
+    parsed_data = provider.parse_status_callback(callback_data)
+    status_update = StatusCallbackRequest(
+        call_id=parsed_data["call_id"],
+        status=parsed_data["status"],
+        from_number=parsed_data.get("from_number"),
+        to_number=parsed_data.get("to_number"),
+        direction=parsed_data.get("direction"),
+        duration=parsed_data.get("duration"),
+        extra=parsed_data.get("extra", {}),
+    )
+
+    await _process_status_update(workflow_run_id, status_update)
+    return {"status": "success"}

--- a/api/services/telephony/providers/exotel/serializers.py
+++ b/api/services/telephony/providers/exotel/serializers.py
@@ -1,0 +1,164 @@
+"""Exotel frame serializer.
+
+Exotel's WebSocket streaming protocol is Twilio Media Streams-compatible:
+  - Incoming audio: {"event":"media","stream_sid":"...","media":{"payload":"<base64-mulaw>"}}
+  - Outgoing audio: {"event":"media","streamSid":"...","media":{"payload":"<base64-mulaw>"}}
+  - Clear/interrupt: {"event":"clear","streamSid":"..."}
+
+We subclass TwilioFrameSerializer to inherit the correct encode/decode logic
+and override _hang_up_call to hit Exotel's REST API instead of Twilio's.
+"""
+
+import json
+
+import aiohttp
+from loguru import logger
+from pipecat.audio.utils import create_stream_resampler
+from pipecat.frames.frames import (
+    AudioRawFrame,
+    CancelFrame,
+    EndFrame,
+    Frame,
+    InputAudioRawFrame,
+    InterruptionFrame,
+    OutputTransportMessageFrame,
+    OutputTransportMessageUrgentFrame,
+    StartFrame,
+)
+from pipecat.serializers.base_serializer import FrameSerializer
+
+import base64
+
+
+class ExotelFrameSerializer(FrameSerializer):
+    """Serializer for Exotel's Twilio-compatible WebSocket streaming protocol.
+
+    Exotel sends/receives audio using the same JSON envelope as Twilio Media Streams:
+      Incoming: {"event":"media","media":{"payload":"<base64-pcm16>"},"stream_sid":"..."}
+      Outgoing: {"event":"media","streamSid":"...","media":{"payload":"<base64-pcm16>"}}
+      Clear:    {"event":"clear","streamSid":"..."}
+
+    Auto hang-up hits Exotel's REST API (DELETE /v1/Accounts/{sid}/Calls/{call_sid}/).
+    """
+
+    class InputParams(FrameSerializer.InputParams):
+        sample_rate_hz: int = 8000
+        sample_rate: int | None = None
+        auto_hang_up: bool = False  # Exotel hangs up itself; safe to disable
+
+    def __init__(
+        self,
+        stream_id: str,         # Exotel stream_sid
+        call_id: str | None = None,
+        auth_id: str | None = None,       # Exotel api_key
+        auth_token: str | None = None,    # Exotel api_token
+        account_sid: str | None = None,   # Exotel account_sid for REST hangup
+        subdomain: str = "api.exotel.com",
+        params: "ExotelFrameSerializer.InputParams | None" = None,
+    ):
+        params = params or ExotelFrameSerializer.InputParams()
+        super().__init__(params)
+        self._params: ExotelFrameSerializer.InputParams = params
+
+        self._stream_sid = stream_id
+        self._call_sid = call_id
+        self._api_key = auth_id
+        self._api_token = auth_token
+        self._account_sid = account_sid
+        self._subdomain = subdomain
+        self._exotel_sample_rate = params.sample_rate_hz
+        self._sample_rate = 0  # Set in setup()
+
+        self._input_resampler = create_stream_resampler()
+        self._output_resampler = create_stream_resampler()
+        self._hangup_attempted = False
+
+    async def setup(self, frame: StartFrame):
+        self._sample_rate = self._params.sample_rate or frame.audio_in_sample_rate
+
+    async def serialize(self, frame: Frame) -> str | bytes | None:
+        if isinstance(frame, (EndFrame, CancelFrame)):
+            if self._params.auto_hang_up and not self._hangup_attempted:
+                self._hangup_attempted = True
+                await self._hang_up_call()
+            return None
+
+        elif isinstance(frame, InterruptionFrame):
+            return json.dumps({"event": "clear", "streamSid": self._stream_sid})
+
+        elif isinstance(frame, AudioRawFrame):
+            serialized_data = await self._output_resampler.resample(
+                frame.audio,
+                frame.sample_rate,
+                self._exotel_sample_rate
+            )
+            if not serialized_data:
+                return None
+            payload = base64.b64encode(serialized_data).decode("utf-8")
+            return json.dumps({
+                "event": "media",
+                "streamSid": self._stream_sid,
+                "media": {"payload": payload},
+            })
+
+        elif isinstance(frame, (OutputTransportMessageFrame, OutputTransportMessageUrgentFrame)):
+            if self.should_ignore_frame(frame):
+                return None
+            return json.dumps(frame.message)
+
+        return None
+
+    async def deserialize(self, data: str | bytes) -> Frame | None:
+        try:
+            message = json.loads(data)
+        except json.JSONDecodeError:
+            logger.warning(f"[Exotel] Failed to parse WebSocket message: {data[:200]}")
+            return None
+
+        event = message.get("event", "")
+
+        if event == "media":
+            media = message.get("media", {})
+            payload_b64 = media.get("payload")
+            if not payload_b64:
+                return None
+
+            payload = base64.b64decode(payload_b64)
+            deserialized = await self._input_resampler.resample(
+                payload,
+                self._exotel_sample_rate,
+                self._sample_rate
+            )
+            if not deserialized:
+                return None
+            return InputAudioRawFrame(
+                audio=deserialized, num_channels=1, sample_rate=self._sample_rate
+            )
+
+        # Ignore start/stop/connected/mark events silently
+        return None
+
+    async def _hang_up_call(self):
+        """Hang up via Exotel REST API."""
+        if not (self._api_key and self._api_token and self._account_sid and self._call_sid):
+            logger.warning("[Exotel] Cannot hang up — missing credentials or call_sid")
+            return
+        try:
+            endpoint = (
+                f"https://{self._api_key}:{self._api_token}@{self._subdomain}"
+                f"/v1/Accounts/{self._account_sid}/Calls/{self._call_sid}/"
+            )
+            async with aiohttp.ClientSession() as session:
+                async with session.delete(endpoint) as resp:
+                    if resp.status in (200, 204):
+                        logger.debug(f"[Exotel] Hung up call {self._call_sid}")
+                    else:
+                        body = await resp.text()
+                        logger.warning(
+                            f"[Exotel] Hangup returned {resp.status}: {body[:200]}"
+                        )
+        except Exception as e:
+            logger.error(f"[Exotel] Hangup failed: {e}")
+
+
+__all__ = ["ExotelFrameSerializer"]

--- a/api/services/telephony/providers/exotel/transport.py
+++ b/api/services/telephony/providers/exotel/transport.py
@@ -1,0 +1,70 @@
+"""Exotel transport factory."""
+
+from fastapi import WebSocket
+
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
+
+from api.services.pipecat.audio_config import AudioConfig
+from api.services.pipecat.audio_mixer import build_audio_out_mixer
+from api.services.telephony.factory import load_credentials_for_transport
+
+from .serializers import ExotelFrameSerializer
+
+
+async def create_transport(
+    websocket: WebSocket,
+    workflow_run_id: int,
+    audio_config: AudioConfig,
+    organization_id: int,
+    *,
+    ambient_noise_config: dict | None = None,
+    telephony_configuration_id: int | None = None,
+    stream_id: str,
+    call_id: str,
+    account_sid: str = "",
+):
+    """Create a WebSocket transport for an Exotel call leg."""
+    config = await load_credentials_for_transport(
+        organization_id, telephony_configuration_id, expected_provider="exotel"
+    )
+
+    api_key = config.get("api_key")
+    api_token = config.get("api_token")
+    cfg_account_sid = account_sid or config.get("account_sid", "")
+
+    if not api_key or not api_token:
+        raise ValueError(
+            f"Incomplete Exotel configuration for organization {organization_id}"
+        )
+
+    serializer = ExotelFrameSerializer(
+        stream_id=stream_id,
+        call_id=call_id,
+        auth_id=api_key,
+        auth_token=api_token,
+        account_sid=cfg_account_sid,
+        subdomain=config.get("subdomain", "api.exotel.com"),
+        params=ExotelFrameSerializer.InputParams(
+            sample_rate_hz=8000,
+            sample_rate=audio_config.pipeline_sample_rate,
+        ),
+    )
+
+    mixer = await build_audio_out_mixer(
+        audio_config.transport_out_sample_rate, ambient_noise_config
+    )
+
+    return FastAPIWebsocketTransport(
+        websocket=websocket,
+        params=FastAPIWebsocketParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+            audio_in_sample_rate=audio_config.transport_in_sample_rate,
+            audio_out_sample_rate=audio_config.transport_out_sample_rate,
+            audio_out_mixer=mixer,
+            serializer=serializer,
+        ),
+    )

--- a/api/services/telephony/providers/exotel/transport.py
+++ b/api/services/telephony/providers/exotel/transport.py
@@ -9,6 +9,7 @@ from pipecat.transports.websocket.fastapi import (
 
 from api.services.pipecat.audio_config import AudioConfig
 from api.services.pipecat.audio_mixer import build_audio_out_mixer
+from api.services.pipecat.transport_params import realtime_param_overrides
 from api.services.telephony.factory import load_credentials_for_transport
 
 from .serializers import ExotelFrameSerializer
@@ -22,6 +23,7 @@ async def create_transport(
     *,
     ambient_noise_config: dict | None = None,
     telephony_configuration_id: int | None = None,
+    is_realtime: bool = False,
     stream_id: str,
     call_id: str,
     account_sid: str = "",
@@ -66,5 +68,6 @@ async def create_transport(
             audio_out_sample_rate=audio_config.transport_out_sample_rate,
             audio_out_mixer=mixer,
             serializer=serializer,
+            **realtime_param_overrides(is_realtime),
         ),
     )


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Exotel telephony support with outbound calling, Twilio-compatible WebSocket streaming, and status callbacks. Also stores `call_id` and `caller_number` on workflow runs to improve tracing and UX.

- **New Features**
  - Registered new provider `exotel` and added `WorkflowRunMode.EXOTEL`.
  - Outbound calls via Exotel `Calls/connect` using App Bazaar `app_id`; returns `call_id` and `caller_number`, saved to workflow run context.
  - Fixed WebSocket endpoint `/api/v1/telephony/exotel/stream` with 8 kHz μ-law audio; custom serializer and transport for Exotel’s Twilio-style media.
  - Status callback endpoint `/api/v1/telephony/exotel/status-callback/{workflow_run_id}` normalizes updates and processes run status.
  - Added config schemas `ExotelConfigurationRequest`/`ExotelConfigurationResponse` and UI metadata; provider validation included.
  - Inbound answer XML (ExoML) generation with bidirectional `<Stream>`; signature checks are no-op (Exotel v1).

- **Migration**
  - In Exotel App Bazaar, set the WebSocket URL to: `wss://{your-backend}/api/v1/telephony/exotel/stream`.
  - In telephony settings, create an `exotel` config with: `api_key`, `api_token`, `account_sid`, optional `subdomain` (`api.exotel.com` or `api.in.exotel.com`), `from_numbers`, and `app_id`.
  - Ensure your backend is reachable for status callbacks at `/api/v1/telephony/exotel/status-callback/{workflow_run_id}`.

<sup>Written for commit a21a8707dc3de2217512cb44c9c62578c5f6bc5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Exotel as a new telephony provider. The main changes are:

- New Exotel provider registration and metadata for the generic telephony config UI.
- Exotel configuration request and response schemas.
- Exotel outbound call initiation, status callback handling, fixed stream route, serializer, and transport.
- Public-agent call initiation now stores returned provider metadata and caller number.

<h3>Confidence Score: 3/5</h3>

These issues need to be fixed before merging the Exotel provider.

Multiple security-sensitive issues affect the new Exotel path: credentials are logged, status callbacks can update runs without call/account validation, and stream starts bind globally by call id.

`api/services/telephony/providers/exotel/routes.py`; `api/services/telephony/providers/exotel/provider.py`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced a credentials leak in logs by running a focused Exotel initiate\_call harness with dummy credentials and a mocked HTTP transport.
- Generated an Exotel status callback reproduction harness to simulate unauthenticated status updates.
- Executed a direct async Exotel stream binding harness against the WebSocket route to emulate a cross-tenant scenario with a victim and attacker.
- Observed the Exotel feature state transition, where enum\_has\_exotel and registry\_has\_exotel became true and the system reports exotel as the active spec with related UI metadata.
- Compared outbound flow logs to the before/after changes and confirmed the after state shows a mocked HTTP status 200 and outbound payload details.
- Verified the provider wiring improvements by noting an HTTP 200 response, proper content type, and the credential loader and FastAPI parameters wired for Exotel.
- Validated Exotel frame serializer wiring and audio handling, with InputAudioRawFrame decoded at 8000 Hz, outbound event JSON present, credentials loader invoked, and FastAPI parameters configured, ending with exit code 0.

<a href="https://app.greptile.com/trex/runs/13183899/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/routes/public_agent.py | Persists provider call metadata after public-agent call initiation; mirrors existing initiate-call flow. |
| api/schemas/telephony_config.py | Adds Exotel request/response schemas to the telephony config union and response model. |
| api/services/telephony/providers/exotel/__init__.py | Registers Exotel provider metadata and UI fields; provider-local registration follows the registry pattern. |
| api/services/telephony/providers/exotel/provider.py | Implements Exotel outbound, webhook, inbound, and status behavior; logs a credential-bearing URL during outbound calls. |
| api/services/telephony/providers/exotel/routes.py | Adds Exotel stream and status callback routes; both accept unauthenticated provider events without binding them back to the configured account/run. |
| api/services/telephony/providers/exotel/serializers.py | Adds a μ-law WebSocket serializer for Exotel media and optional hangup support. |
| api/services/telephony/providers/exotel/transport.py | Creates Exotel FastAPI WebSocket transports using lazily loaded run-scoped credentials. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client as Trigger API
participant Provider as ExotelProvider
participant Exotel as Exotel API/App Bazaar
participant WS as /telephony/exotel/stream
participant DB as WorkflowRun DB
participant Pipe as run_pipeline_telephony

Client->>Provider: initiate_call(to_number, workflow_run_id)
Provider->>Exotel: POST /Calls/connect
Exotel-->>Provider: Call.Sid
Provider-->>DB: store gathered_context.call_id
Exotel->>WS: WebSocket connected/start(call_sid, stream_sid, account_sid)
WS->>DB: get_workflow_run_by_call_id(call_sid)
DB-->>WS: workflow_run
WS->>Pipe: run Exotel telephony pipeline
Exotel->>WS: media frames
Pipe-->>Exotel: synthesized media frames
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client as Trigger API
participant Provider as ExotelProvider
participant Exotel as Exotel API/App Bazaar
participant WS as /telephony/exotel/stream
participant DB as WorkflowRun DB
participant Pipe as run_pipeline_telephony

Client->>Provider: initiate_call(to_number, workflow_run_id)
Provider->>Exotel: POST /Calls/connect
Exotel-->>Provider: Call.Sid
Provider-->>DB: store gathered_context.call_id
Exotel->>WS: WebSocket connected/start(call_sid, stream_sid, account_sid)
WS->>DB: get_workflow_run_by_call_id(call_sid)
DB-->>WS: workflow_run
WS->>Pipe: run Exotel telephony pipeline
Exotel->>WS: media frames
Pipe-->>Exotel: synthesized media frames
```

</a>

<sub>Reviews (1): Last reviewed commit: ["exotel stream fix"](https://github.com/dograh-hq/dograh/commit/a21a8707dc3de2217512cb44c9c62578c5f6bc5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41618413)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->