### PR TITLE
fix: clean up ARI transferred call legs on participant hangup

### DIFF
--- a/api/services/telephony/ari_manager.py
+++ b/api/services/telephony/ari_manager.py
@@ -119,10 +119,19 @@ class ARIConnection:
         r = await self._get_redis()
         return await r.exists(f"{_EXT_CHANNEL_KEY_PREFIX}{channel_id}") > 0
 
-    async def _delete_ext_channel(self, channel_id: str):
+    async def _delete_ext_channel(self, channel_id: Optional[str]):
         """Remove the external media channel marker."""
+        if not channel_id:
+            return
         r = await self._get_redis()
         await r.delete(f"{_EXT_CHANNEL_KEY_PREFIX}{channel_id}")
+
+    async def _delete_transfer_channel_mapping(self, channel_id: Optional[str]):
+        """Remove transfer destination channel correlation marker."""
+        if not channel_id:
+            return
+        r = await self._get_redis()
+        await r.delete(f"ari:transfer_channel:{channel_id}")
 
     async def _set_pending_bridge(
         self,
@@ -766,6 +775,9 @@ class ARIConnection:
             ext_channel_id = ctx.get("ext_channel_id")
             bridge_id = ctx.get("bridge_id")
             transfer_state = ctx.get("transfer_state")
+            transfer_bridge_id = ctx.get("transfer_bridge_id") or bridge_id
+            transfer_caller_channel_id = ctx.get("transfer_caller_channel_id") or call_id
+            transfer_destination_channel_id = ctx.get("transfer_destination_channel_id")
 
             # Check if this is a call transfer scenario external channel. Skip full teardown if
             # transfer is in progress and this is the external media channel
@@ -796,6 +808,63 @@ class ARIConnection:
                 )
                 return
 
+            if (
+                transfer_state == "complete"
+                and transfer_bridge_id
+                and transfer_caller_channel_id
+                and transfer_destination_channel_id
+                and channel_id in (
+                    transfer_caller_channel_id,
+                    transfer_destination_channel_id,
+                )
+            ):
+                peer_channel_id = (
+                    transfer_destination_channel_id
+                    if channel_id == transfer_caller_channel_id
+                    else transfer_caller_channel_id
+                )
+                logger.info(
+                    f"[ARI org={self.organization_id}] Completed transfer participant "
+                    f"{channel_id} left Stasis; tearing down peer {peer_channel_id} "
+                    f"and bridge {transfer_bridge_id}"
+                )
+
+                # Mark terminal state before issuing ARI deletes so duplicate
+                # StasisEnd events run through the idempotent normal cleanup path.
+                ctx["transfer_state"] = "terminated"
+                await db_client.update_workflow_run(
+                    run_id=int(workflow_run_id), gathered_context=ctx
+                )
+
+                await self._delete_bridge(transfer_bridge_id)
+                if peer_channel_id and peer_channel_id != channel_id:
+                    await self._delete_channel(peer_channel_id)
+
+                keys_to_delete = [
+                    cid
+                    for cid in (
+                        transfer_caller_channel_id,
+                        transfer_destination_channel_id,
+                        ext_channel_id,
+                        channel_id,
+                    )
+                    if cid
+                ]
+                if keys_to_delete:
+                    await self._delete_channel_run(*keys_to_delete)
+
+                await self._delete_ext_channel(ext_channel_id)
+                await self._delete_transfer_channel_mapping(
+                    transfer_destination_channel_id
+                )
+
+                logger.info(
+                    f"[ARI org={self.organization_id}] Completed transfer teardown "
+                    f"finished for channel={channel_id}, peer={peer_channel_id}, "
+                    f"bridge={transfer_bridge_id}"
+                )
+                return
+
             # Normal full teardown for non-transfer scenarios (transfer_state is None or not in-progress)
             # Delete the bridge first (removes channels from it)
             if bridge_id:
@@ -815,6 +884,9 @@ class ARIConnection:
 
             # Clean up the Redis marker for external channel
             await self._delete_ext_channel(ext_channel_id)
+            await self._delete_transfer_channel_mapping(
+                transfer_destination_channel_id
+            )
 
             logger.info(
                 f"[ARI org={self.organization_id}] StasisEnd full teardown for "

--- a/api/services/telephony/providers/ari/strategies.py
+++ b/api/services/telephony/providers/ari/strategies.py
@@ -103,8 +103,16 @@ class ARIBridgeSwapStrategy(TransferStrategy):
                 f"destination={destination_channel_id}, ext_media={ext_channel_id}"
             )
 
-            # 3. Set transfer state to prevent StasisEnd auto-teardown
-            workflow_run.gathered_context["transfer_state"] = "in-progress"
+            # 3. Set transfer state to prevent StasisEnd auto-teardown and
+            # persist the transferred pair for post-handoff participant cleanup.
+            workflow_run.gathered_context.update(
+                {
+                    "transfer_state": "in-progress",
+                    "transfer_bridge_id": bridge_id,
+                    "transfer_caller_channel_id": channel_id,
+                    "transfer_destination_channel_id": destination_channel_id,
+                }
+            )
             await db_client.update_workflow_run(
                 run_id=int(workflow_run_id),
                 gathered_context=workflow_run.gathered_context,
@@ -123,6 +131,13 @@ class ARIBridgeSwapStrategy(TransferStrategy):
                     if response.status in (200, 204):
                         logger.info(
                             f"[ARI Transfer] Added destination {destination_channel_id} to bridge {bridge_id}"
+                        )
+                        # Let ari_manager route StasisEnd for the destination leg
+                        # back to this workflow after transfer context cleanup.
+                        await redis.setex(
+                            f"ari:channel:{destination_channel_id}",
+                            3600,
+                            workflow_run_id,
                         )
                     else:
                         error_text = await response.text()
@@ -169,6 +184,7 @@ class ARIBridgeSwapStrategy(TransferStrategy):
             )
 
             # 5. Clean up transfer context after successful completion
+            await redis.delete(f"ari:transfer_channel:{destination_channel_id}")
 
             call_transfer_manager = await get_call_transfer_manager()
             await call_transfer_manager.remove_transfer_context(

--- a/api/tests/telephony/test_ari_manager_transfer_teardown.py
+++ b/api/tests/telephony/test_ari_manager_transfer_teardown.py
@@ -1,0 +1,118 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from api.services.telephony import ari_manager
+from api.services.telephony.ari_manager import ARIConnection
+
+
+class _FakeDbClient:
+    def __init__(self, gathered_context):
+        self.workflow_run = SimpleNamespace(gathered_context=gathered_context)
+        self.updated_contexts = []
+
+    async def get_workflow_run_by_id(self, run_id: int):
+        return self.workflow_run
+
+    async def update_workflow_run(self, run_id: int, gathered_context: dict):
+        self.updated_contexts.append((run_id, dict(gathered_context)))
+        self.workflow_run.gathered_context = gathered_context
+
+
+class _RecordingARIConnection(ARIConnection):
+    def __init__(self):
+        super().__init__(
+            organization_id=1,
+            telephony_configuration_id=10,
+            ari_endpoint="http://asterisk.test:8088",
+            app_name="dograh",
+            app_password="secret",
+            ws_client_name="dograh_ws",
+        )
+        self.deleted_bridges = []
+        self.deleted_channels = []
+        self.deleted_channel_runs = []
+        self.deleted_ext_channels = []
+        self.deleted_transfer_channel_mappings = []
+
+    async def _delete_bridge(self, bridge_id: str):
+        self.deleted_bridges.append(bridge_id)
+
+    async def _delete_channel(self, channel_id: str):
+        self.deleted_channels.append(channel_id)
+
+    async def _delete_channel_run(self, *channel_ids: str):
+        self.deleted_channel_runs.extend(channel_ids)
+
+    async def _delete_ext_channel(self, channel_id: str | None):
+        self.deleted_ext_channels.append(channel_id)
+
+    async def _delete_transfer_channel_mapping(self, channel_id: str | None):
+        self.deleted_transfer_channel_mappings.append(channel_id)
+
+    async def _get_transfer_id_for_channel(self, channel_id: str):
+        return None
+
+    async def _handle_transfer_failed(
+        self, transfer_id: str, channel_id: str, reason: str
+    ):
+        raise AssertionError("completed transfer hangup should not publish transfer failure")
+
+
+def _completed_transfer_context():
+    return {
+        "call_id": "caller-chan",
+        "ext_channel_id": "ext-chan",
+        "bridge_id": "bridge-1",
+        "transfer_state": "complete",
+        "transfer_bridge_id": "bridge-1",
+        "transfer_caller_channel_id": "caller-chan",
+        "transfer_destination_channel_id": "dest-chan",
+    }
+
+
+@pytest.mark.asyncio
+async def test_completed_transfer_tears_down_destination_when_caller_leaves(monkeypatch):
+    fake_db = _FakeDbClient(_completed_transfer_context())
+    monkeypatch.setattr(ari_manager, "db_client", fake_db)
+    conn = _RecordingARIConnection()
+
+    await conn._handle_stasis_end("caller-chan", "123")
+
+    assert conn.deleted_bridges == ["bridge-1"]
+    assert conn.deleted_channels == ["dest-chan"]
+    assert "caller-chan" in conn.deleted_channel_runs
+    assert "dest-chan" in conn.deleted_channel_runs
+    assert conn.deleted_transfer_channel_mappings == ["dest-chan"]
+    assert fake_db.workflow_run.gathered_context["transfer_state"] == "terminated"
+
+
+@pytest.mark.asyncio
+async def test_completed_transfer_tears_down_caller_when_destination_leaves(monkeypatch):
+    fake_db = _FakeDbClient(_completed_transfer_context())
+    monkeypatch.setattr(ari_manager, "db_client", fake_db)
+    conn = _RecordingARIConnection()
+
+    await conn._handle_stasis_end("dest-chan", "123")
+
+    assert conn.deleted_bridges == ["bridge-1"]
+    assert conn.deleted_channels == ["caller-chan"]
+    assert "caller-chan" in conn.deleted_channel_runs
+    assert "dest-chan" in conn.deleted_channel_runs
+    assert conn.deleted_transfer_channel_mappings == ["dest-chan"]
+    assert fake_db.workflow_run.gathered_context["transfer_state"] == "terminated"
+
+
+@pytest.mark.asyncio
+async def test_completed_transfer_destination_destroyed_without_transfer_mapping_is_ignored():
+    conn = _RecordingARIConnection()
+    event = {
+        "type": "ChannelDestroyed",
+        "channel": {"id": "dest-chan", "state": "Up"},
+        "cause": 16,
+        "cause_txt": "Normal Clearing",
+        "tech_cause": "unknown",
+    }
+
+    await conn._handle_event(json.dumps(event))


### PR DESCRIPTION
Fixes #416 - Asterisk ARI transferred-call teardown after a successful call transfer on participant drop off.

After bridge swap, Dograh now tracks the transferred caller/destination pair and tears down the remaining participant when either side hangs up.

## Changes

- Store completed ARI transfer state in workflow run context:
  - transfer bridge ID
  - caller channel ID
  - destination channel ID
- Add `ari:channel:{destination_channel_id} -> workflow_run_id` so destination `StasisEnd` events can be routed.
- Add completed-transfer teardown handling in `ari_manager`.
- Clear stale `ari:transfer_channel:{destination_channel_id}` after successful bridge swap to avoid false `TRANSFER_FAILED` events.
- Add tests for caller-side and destination-side post-transfer hangups.

## Verification

- Tested manually with remote Asterisk ARI:
  - destination hangup disconnects caller
  - caller hangup disconnects destination
  - stale transfer-failure log no longer appears
- Ran targeted tests:
  - `pytest api/tests/telephony/test_ari_manager_transfer_teardown.py -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ARI transferred-call teardown so when either participant hangs up after a successful transfer, we cleanly disconnect the peer and remove the bridge. Prevents orphaned legs and stale transfer-failure logs.

- **Bug Fixes**
  - Persist completed transfer context in the workflow run (transfer bridge ID, caller channel ID, destination channel ID).
  - Route destination StasisEnd via Redis key `ari:channel:{destination_channel_id} -> workflow_run_id`.
  - On StasisEnd for either participant with transfer complete, delete the bridge, hang up the peer, clean Redis markers, and mark `transfer_state=terminated`.
  - Clear stale `ari:transfer_channel:{destination_channel_id}` after a successful bridge swap.
  - Added tests for caller-side and destination-side hangups; removes false TRANSFER_FAILED logs.

<sup>Written for commit 782953ea7ff7b81ccba0893cd94605273c6a940d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates ARI transfer cleanup after a successful bridge-swap transfer. The main changes are:

- Stores the transfer bridge, caller channel, and destination channel in workflow context.
- Routes destination `StasisEnd` events back to the originating workflow run.
- Tears down the remaining transferred participant and bridge when either side hangs up.
- Clears stale transfer-failure mappings after a successful bridge swap.
- Adds targeted tests for caller-side and destination-side post-transfer hangups.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are focused on ARI transfer state tracking and cleanup. Existing in-progress transfer handling is preserved. Tests cover both transferred participant hangup directions and stale transfer mapping cleanup. No functional or security issues were identified in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general-contract-validation-proof 0 and confirmed the before state showed missing transfer IDs and a None Redis mapping, while the after state shows the IDs present and the Redis mapping updated.
- Validated the post-change cleanup behavior for the transfer teardown: caller hangup deletes the dest-chan, destination hangup deletes the caller-chan, both delete bridge-1, and the transfer\_state moves to terminated.
- Reviewed the second general-contract-validation-proof 1 and confirmed the pre-change Redis and route-lookup behavior: destination route is None and a stale dest-chan remains, with ChannelDestroyed still finding tx-1.
- Cataloged and linked the four artifacts from both proofs to support review of the pre/post states and Redis/route-lookup changes.

<a href="https://app.greptile.com/trex/runs/13251807/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/services/telephony/ari_manager.py | Adds completed ARI transfer teardown on participant `StasisEnd`, including peer hangup and Redis cleanup. |
| api/services/telephony/providers/ari/strategies.py | Persists completed-transfer channel state during bridge swap and clears stale transfer-failure mappings after success. |
| api/tests/telephony/test_ari_manager_transfer_teardown.py | Adds targeted async tests for caller-side and destination-side post-transfer hangup cleanup plus stale mapping behavior. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Strategy as ARIBridgeSwapStrategy
participant Redis as Redis mappings
participant DB as Workflow run context
participant ARI as Asterisk ARI
participant Manager as ari_manager

Strategy->>DB: "Save transfer_state=in-progress and participant ids"
Strategy->>ARI: Add destination channel to transfer bridge
Strategy->>Redis: "Set ari:channel:{destination}->workflow_run_id"
Strategy->>ARI: Remove and hang up external media channel
Strategy->>Redis: "Delete ari:transfer_channel:{destination}"
ARI-->>Manager: StasisEnd for external media
Manager->>DB: "Mark transfer_state=complete"
ARI-->>Manager: StasisEnd for caller or destination
Manager->>DB: "Mark transfer_state=terminated"
Manager->>ARI: Delete bridge and peer channel
Manager->>Redis: Delete caller/destination/ext run mappings
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Strategy as ARIBridgeSwapStrategy
participant Redis as Redis mappings
participant DB as Workflow run context
participant ARI as Asterisk ARI
participant Manager as ari_manager

Strategy->>DB: "Save transfer_state=in-progress and participant ids"
Strategy->>ARI: Add destination channel to transfer bridge
Strategy->>Redis: "Set ari:channel:{destination}->workflow_run_id"
Strategy->>ARI: Remove and hang up external media channel
Strategy->>Redis: "Delete ari:transfer_channel:{destination}"
ARI-->>Manager: StasisEnd for external media
Manager->>DB: "Mark transfer_state=complete"
ARI-->>Manager: StasisEnd for caller or destination
Manager->>DB: "Mark transfer_state=terminated"
Manager->>ARI: Delete bridge and peer channel
Manager->>Redis: Delete caller/destination/ext run mappings
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: clean up ARI transferred call legs ..."](https://github.com/dograh-hq/dograh/commit/782953ea7ff7b81ccba0893cd94605273c6a940d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41773178)</sub>

<!-- /greptile_comment -->