### PR TITLE
fix: gate OSS email/password auth endpoints outside local auth mode

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -19,11 +19,14 @@ from api.utils.auth import create_jwt_token, hash_password, verify_password
 router = APIRouter(
     prefix="/auth",
     tags=["auth"],
-    dependencies=[Depends(require_local_auth)],
 )
 
 
-@router.post("/signup", response_model=AuthResponse)
+@router.post(
+    "/signup",
+    response_model=AuthResponse,
+    dependencies=[Depends(require_local_auth)],
+)
 async def signup(request: SignupRequest):
     # Check if email is already taken
     existing_user = await db_client.get_user_by_email(request.email)
@@ -90,7 +93,11 @@ async def signup(request: SignupRequest):
     )
 
 
-@router.post("/login", response_model=AuthResponse)
+@router.post(
+    "/login",
+    response_model=AuthResponse,
+    dependencies=[Depends(require_local_auth)],
+)
 async def login(request: LoginRequest):
     # Look up user by email
     user = await db_client.get_user_by_email(request.email)

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -5,7 +5,11 @@ from api.db import db_client
 from api.db.models import UserModel
 from api.enums import OrganizationConfigurationKey, PostHogEvent
 from api.schemas.auth import AuthResponse, LoginRequest, SignupRequest, UserResponse
-from api.services.auth.depends import create_user_configuration_with_mps_key, get_user
+from api.services.auth.depends import (
+    create_user_configuration_with_mps_key,
+    get_user,
+    require_local_auth,
+)
 from api.services.configuration.ai_model_configuration import (
     convert_legacy_ai_model_configuration_to_v2,
 )
@@ -15,6 +19,7 @@ from api.utils.auth import create_jwt_token, hash_password, verify_password
 router = APIRouter(
     prefix="/auth",
     tags=["auth"],
+    dependencies=[Depends(require_local_auth)],
 )
 
 

--- a/api/services/auth/depends.py
+++ b/api/services/auth/depends.py
@@ -20,6 +20,19 @@ from api.services.posthog_client import (
 )
 from api.utils.auth import decode_jwt_token
 
+
+async def require_local_auth() -> None:
+    """Reject email/password auth requests outside OSS (local) deployments.
+
+    The auth router stays mounted in every mode so the OpenAPI spec — and the
+    clients generated from it — don't vary with AUTH_PROVIDER; the gate has to
+    happen at request time. Without it, the SaaS deployment accepts
+    unauthenticated signups that mint oss_* users bypassing Stack Auth.
+    """
+    if AUTH_PROVIDER != "local":
+        raise HTTPException(status_code=404, detail="Not found")
+
+
 POSTHOG_ORGANIZATION_GROUP_TYPE = "organization"
 POSTHOG_ORGANIZATION_USES_MPS_BILLING_V2_PROPERTY = "uses_mps_billing_v2"
 

--- a/api/tests/test_auth_routes.py
+++ b/api/tests/test_auth_routes.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes.auth import router
+from api.services.auth import depends as auth_depends
+from api.services.auth.depends import get_user
+
+
+def _make_test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def test_stack_mode_hides_email_password_auth_routes(monkeypatch):
+    monkeypatch.setattr(auth_depends, "AUTH_PROVIDER", "stack")
+    client = TestClient(_make_test_app())
+
+    signup_response = client.post(
+        "/auth/signup",
+        json={
+            "email": "user@example.com",
+            "password": "password123",
+            "name": "User",
+        },
+    )
+    login_response = client.post(
+        "/auth/login",
+        json={
+            "email": "user@example.com",
+            "password": "password123",
+        },
+    )
+
+    assert signup_response.status_code == 404
+    assert signup_response.json() == {"detail": "Not found"}
+    assert login_response.status_code == 404
+    assert login_response.json() == {"detail": "Not found"}
+
+
+def test_stack_mode_keeps_current_user_route_available(monkeypatch):
+    monkeypatch.setattr(auth_depends, "AUTH_PROVIDER", "stack")
+    app = _make_test_app()
+    app.dependency_overrides[get_user] = lambda: SimpleNamespace(
+        id=7,
+        email="user@example.com",
+        selected_organization_id=42,
+        provider_id="stack-user-1",
+    )
+    client = TestClient(app)
+
+    response = client.get("/auth/me")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": 7,
+        "email": "user@example.com",
+        "name": None,
+        "organization_id": 42,
+        "provider_id": "stack-user-1",
+    }


### PR DESCRIPTION
The /auth signup/login/me routes were mounted unconditionally, so the SaaS deployment accepted unauthenticated signups that created oss_* provider-id users (and auto-provisioned MPS service keys) bypassing Stack Auth entirely.

Gate them with a router-level dependency that 404s when AUTH_PROVIDER is not "local", rather than conditionally mounting the router, so the OpenAPI spec and the clients generated from it stay identical across deployment modes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate email/password signup and login to OSS (local) mode only. Prevents SaaS from creating `oss_*` users or minting MPS keys outside Stack Auth, while keeping `/auth/me` available and the OpenAPI surface unchanged.

- **Bug Fixes**
  - Applied `require_local_auth` to `/auth/signup` and `/auth/login`; return 404 when `AUTH_PROVIDER` != `local`.
  - Kept `/auth/me` accessible under Stack Auth; added tests to verify 404 for signup/login and success for `/auth/me`.

<sup>Written for commit 76db7c2611b0749f1fdd8f511240c41bdc7c402e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates local email/password auth routes outside local auth mode. The main changes are:

- Added `require_local_auth` to reject signup and login when `AUTH_PROVIDER` is not `local`.
- Kept the `/auth` router mounted so the OpenAPI shape remains stable across deployments.
- Added tests for stack-mode 404s on signup/login and continued access to `/auth/me`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to auth route gating and includes tests for the blocked and still-available routes. No correctness or security issues were identified in the changed code.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a pre-change stack probe against the initial auth routes code to establish baseline behavior.
- Ran a post-change stack probe against the updated auth routes code to compare how the changes affected routing and OpenAPI presence.
- Executed the auth routes test suite with pytest, observing that signup and login returned 404 while me returned 200, with exit code 0.
- Confirmed that the post-change probe and the pytest results align on endpoint outcomes and OpenAPI availability, with signup/login failing and me succeeding.

<a href="https://app.greptile.com/trex/runs/13398041/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/routes/auth.py | Adds the local-auth dependency to signup and login while leaving the current-user route on the existing authenticated path. |
| api/services/auth/depends.py | Introduces `require_local_auth`, returning 404 for email/password auth handlers when `AUTH_PROVIDER` is not `local`. |
| api/tests/test_auth_routes.py | Adds route-level tests for stack mode hiding signup/login while keeping `/auth/me` available. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client
participant AuthRoute as /auth/signup or /auth/login
participant Gate as require_local_auth
participant Handler as Signup/Login handler
participant DB as db_client

Client->>AuthRoute: POST credentials
AuthRoute->>Gate: Resolve dependency
alt "AUTH_PROVIDER != local"
    Gate-->>Client: 404 Not found
else "AUTH_PROVIDER == local"
    Gate-->>AuthRoute: allow request
    AuthRoute->>Handler: execute route handler
    Handler->>DB: user lookup/create/authentication
    Handler-->>Client: AuthResponse
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client
participant AuthRoute as /auth/signup or /auth/login
participant Gate as require_local_auth
participant Handler as Signup/Login handler
participant DB as db_client

Client->>AuthRoute: POST credentials
AuthRoute->>Gate: Resolve dependency
alt "AUTH_PROVIDER != local"
    Gate-->>Client: 404 Not found
else "AUTH_PROVIDER == local"
    Gate-->>AuthRoute: allow request
    AuthRoute->>Handler: execute route handler
    Handler->>DB: user lookup/create/authentication
    Handler-->>Client: AuthResponse
end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: keep current user route available i..."](https://github.com/dograh-hq/dograh/commit/76db7c2611b0749f1fdd8f511240c41bdc7c402e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42057664)</sub>

<!-- /greptile_comment -->