### PR TITLE
Feat/enhanced timestamped transcript

### DIFF
--- a/api/services/pipecat/event_handlers.py
+++ b/api/services/pipecat/event_handlers.py
@@ -70,6 +70,7 @@ def register_event_handlers(
     pre_call_fetch_task: asyncio.Task | None = None,
     user_provider_id: str | None = None,
     integration_runtime_sessions: list[IntegrationRuntimeSession] | None = None,
+    include_transcript_end_timestamps: bool = False,
 ):
     """Register all event handlers for transport and task events.
 
@@ -386,7 +387,9 @@ def register_event_handlers(
             else:
                 logger.debug("Bot audio buffer is empty, skipping upload")
 
-            transcript_text = in_memory_logs_buffer.generate_transcript_text()
+            transcript_text = in_memory_logs_buffer.generate_transcript_text(
+                include_end_timestamps=include_transcript_end_timestamps
+            )
             if not transcript_text:
                 logger.debug("No transcript events in logs buffer, skipping upload")
 

--- a/api/services/pipecat/in_memory_buffers.py
+++ b/api/services/pipecat/in_memory_buffers.py
@@ -107,6 +107,10 @@ class InMemoryLogsBuffer:
         self._turn_counter = 0
         self._current_node_id: Optional[str] = None
         self._current_node_name: Optional[str] = None
+        self._user_speech_start_timestamp: Optional[str] = None
+        self._user_speech_end_timestamp: Optional[str] = None
+        self._bot_speech_start_timestamp: Optional[str] = None
+        self._bot_speech_end_timestamp: Optional[str] = None
 
     def set_current_node(self, node_id: str, node_name: str):
         """Set the current node ID and name to be injected into subsequent events."""
@@ -123,11 +127,111 @@ class InMemoryLogsBuffer:
         """Get the current node name."""
         return self._current_node_name
 
+    @staticmethod
+    def _now_iso() -> str:
+        return datetime.now(UTC).isoformat()
+
+    def mark_user_started_speaking(self):
+        """Record when the user started speaking for the current turn."""
+        self._user_speech_start_timestamp = self._now_iso()
+        self._user_speech_end_timestamp = None
+        self._update_latest_payload_start_timestamp(
+            RealtimeFeedbackType.USER_TRANSCRIPTION.value,
+            self._user_speech_start_timestamp,
+            require_final=True,
+        )
+
+    def mark_user_stopped_speaking(self):
+        """Record when the user stopped speaking and update the latest user event."""
+        self._user_speech_end_timestamp = self._now_iso()
+        self._update_latest_payload_end_timestamp(
+            RealtimeFeedbackType.USER_TRANSCRIPTION.value,
+            self._user_speech_end_timestamp,
+            require_final=True,
+        )
+
+    def mark_bot_started_speaking(self):
+        """Record when the bot started speaking for the current assistant turn."""
+        self._bot_speech_start_timestamp = self._now_iso()
+        self._bot_speech_end_timestamp = None
+        self._update_latest_payload_start_timestamp(
+            RealtimeFeedbackType.BOT_TEXT.value,
+            self._bot_speech_start_timestamp,
+        )
+
+    def mark_bot_stopped_speaking(self):
+        """Record when the bot stopped speaking and update the latest bot event."""
+        self._bot_speech_end_timestamp = self._now_iso()
+        self._update_latest_payload_end_timestamp(
+            RealtimeFeedbackType.BOT_TEXT.value,
+            self._bot_speech_end_timestamp,
+        )
+
+    def _find_latest_open_payload(
+        self, event_type: str, *, require_final: bool = False
+    ) -> dict | None:
+        for event in reversed(self._events):
+            if event.get("type") != event_type:
+                continue
+            payload = event.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            if require_final and payload.get("final") is not True:
+                continue
+            if payload.get("end_timestamp"):
+                continue
+            return payload
+        return None
+
+    def _update_latest_payload_start_timestamp(
+        self, event_type: str, start_timestamp: str, *, require_final: bool = False
+    ):
+        payload = self._find_latest_open_payload(
+            event_type, require_final=require_final
+        )
+        if payload is not None:
+            payload["timestamp"] = start_timestamp
+
+    def _update_latest_payload_end_timestamp(
+        self, event_type: str, end_timestamp: str, *, require_final: bool = False
+    ):
+        payload = self._find_latest_open_payload(
+            event_type, require_final=require_final
+        )
+        if payload is not None:
+            payload["end_timestamp"] = end_timestamp
+
+    def _event_with_speech_timestamps(self, event: dict) -> dict:
+        event_type = event.get("type")
+        payload = event.get("payload")
+        if not isinstance(payload, dict):
+            return event
+
+        payload_with_timestamps = dict(payload)
+        if (
+            event_type == RealtimeFeedbackType.USER_TRANSCRIPTION.value
+            and payload.get("final") is True
+        ):
+            if self._user_speech_start_timestamp:
+                payload_with_timestamps["timestamp"] = self._user_speech_start_timestamp
+            if self._user_speech_end_timestamp:
+                payload_with_timestamps["end_timestamp"] = self._user_speech_end_timestamp
+        elif event_type == RealtimeFeedbackType.BOT_TEXT.value:
+            if self._bot_speech_start_timestamp:
+                payload_with_timestamps["timestamp"] = self._bot_speech_start_timestamp
+            if self._bot_speech_end_timestamp:
+                payload_with_timestamps["end_timestamp"] = self._bot_speech_end_timestamp
+
+        if payload_with_timestamps == payload:
+            return event
+        return {**event, "payload": payload_with_timestamps}
+
     async def append(self, event: dict):
         """Append a feedback event to the buffer with timestamp and current node."""
+        event = self._event_with_speech_timestamps(event)
         timestamped_event = stamp_realtime_feedback_event(
             event,
-            timestamp=datetime.now(UTC).isoformat(),
+            timestamp=self._now_iso(),
             turn=self._turn_counter,
             node_id=self._current_node_id,
             node_name=self._current_node_name,
@@ -166,13 +270,15 @@ class InMemoryLogsBuffer:
                 return True
         return False
 
-    def generate_transcript_text(self) -> str:
+    def generate_transcript_text(self, *, include_end_timestamps: bool = False) -> str:
         """Generate transcript text from logged events.
 
         Filters for rtf-user-transcription (final) and rtf-bot-text events,
         formats them as '[timestamp] user/assistant: text\\n'.
         """
-        return _generate_transcript_text(self._sorted_events())
+        return _generate_transcript_text(
+            self._sorted_events(), include_end_timestamps=include_end_timestamps
+        )
 
     @property
     def is_empty(self) -> bool:

--- a/api/services/pipecat/in_memory_buffers.py
+++ b/api/services/pipecat/in_memory_buffers.py
@@ -109,6 +109,8 @@ class InMemoryLogsBuffer:
         self._current_node_name: Optional[str] = None
         self._user_speech_start_timestamp: Optional[str] = None
         self._user_speech_end_timestamp: Optional[str] = None
+        self._user_speech_start_from_vad = False
+        self._user_speech_end_from_vad = False
         self._bot_speech_start_timestamp: Optional[str] = None
         self._bot_speech_end_timestamp: Optional[str] = None
 
@@ -131,37 +133,50 @@ class InMemoryLogsBuffer:
     def _now_iso() -> str:
         return datetime.now(UTC).isoformat(timespec="milliseconds")
 
-    def mark_user_started_speaking(self):
+    def mark_user_started_speaking(
+        self, timestamp: Optional[str] = None, *, from_vad: bool = False
+    ):
         """Record when the user started speaking for the current turn."""
-        self._user_speech_start_timestamp = self._now_iso()
+        if self._user_speech_start_from_vad and not from_vad:
+            return
+
+        self._user_speech_start_timestamp = timestamp or self._now_iso()
         self._user_speech_end_timestamp = None
+        self._user_speech_start_from_vad = from_vad
+        self._user_speech_end_from_vad = False
         self._update_latest_payload_start_timestamp(
             RealtimeFeedbackType.USER_TRANSCRIPTION.value,
             self._user_speech_start_timestamp,
             require_final=True,
         )
 
-    def mark_user_stopped_speaking(self):
+    def mark_user_stopped_speaking(
+        self, timestamp: Optional[str] = None, *, from_vad: bool = False
+    ):
         """Record when the user stopped speaking and update the latest user event."""
-        self._user_speech_end_timestamp = self._now_iso()
+        if self._user_speech_end_from_vad and not from_vad:
+            return
+
+        self._user_speech_end_timestamp = timestamp or self._now_iso()
+        self._user_speech_end_from_vad = from_vad
         self._update_latest_payload_end_timestamp(
             RealtimeFeedbackType.USER_TRANSCRIPTION.value,
             self._user_speech_end_timestamp,
             require_final=True,
         )
 
-    def mark_bot_started_speaking(self):
+    def mark_bot_started_speaking(self, timestamp: Optional[str] = None):
         """Record when the bot started speaking for the current assistant turn."""
-        self._bot_speech_start_timestamp = self._now_iso()
+        self._bot_speech_start_timestamp = timestamp or self._now_iso()
         self._bot_speech_end_timestamp = None
         self._update_latest_payload_start_timestamp(
             RealtimeFeedbackType.BOT_TEXT.value,
             self._bot_speech_start_timestamp,
         )
 
-    def mark_bot_stopped_speaking(self):
+    def mark_bot_stopped_speaking(self, timestamp: Optional[str] = None):
         """Record when the bot stopped speaking and update the latest bot event."""
-        self._bot_speech_end_timestamp = self._now_iso()
+        self._bot_speech_end_timestamp = timestamp or self._now_iso()
         self._update_latest_payload_end_timestamp(
             RealtimeFeedbackType.BOT_TEXT.value,
             self._bot_speech_end_timestamp,
@@ -217,10 +232,9 @@ class InMemoryLogsBuffer:
             if self._user_speech_end_timestamp:
                 payload_with_timestamps["end_timestamp"] = self._user_speech_end_timestamp
         elif event_type == RealtimeFeedbackType.BOT_TEXT.value:
-            if self._bot_speech_start_timestamp:
+            bot_interval_is_active = self._bot_speech_end_timestamp is None
+            if bot_interval_is_active and self._bot_speech_start_timestamp:
                 payload_with_timestamps["timestamp"] = self._bot_speech_start_timestamp
-            if self._bot_speech_end_timestamp:
-                payload_with_timestamps["end_timestamp"] = self._bot_speech_end_timestamp
 
         if payload_with_timestamps == payload:
             return event

--- a/api/services/pipecat/in_memory_buffers.py
+++ b/api/services/pipecat/in_memory_buffers.py
@@ -137,7 +137,10 @@ class InMemoryLogsBuffer:
         self, timestamp: Optional[str] = None, *, from_vad: bool = False
     ):
         """Record when the user started speaking for the current turn."""
-        if self._user_speech_start_from_vad and not from_vad:
+        vad_interval_is_open = (
+            self._user_speech_start_from_vad and self._user_speech_end_timestamp is None
+        )
+        if vad_interval_is_open and not from_vad:
             return
 
         self._user_speech_start_timestamp = timestamp or self._now_iso()

--- a/api/services/pipecat/in_memory_buffers.py
+++ b/api/services/pipecat/in_memory_buffers.py
@@ -129,7 +129,7 @@ class InMemoryLogsBuffer:
 
     @staticmethod
     def _now_iso() -> str:
-        return datetime.now(UTC).isoformat()
+        return datetime.now(UTC).isoformat(timespec="milliseconds")
 
     def mark_user_started_speaking(self):
         """Record when the user started speaking for the current turn."""

--- a/api/services/pipecat/realtime_feedback_events.py
+++ b/api/services/pipecat/realtime_feedback_events.py
@@ -30,6 +30,7 @@ def build_user_transcription_event(
     text: str,
     final: bool,
     timestamp: str | None = None,
+    end_timestamp: str | None = None,
     user_id: str | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
@@ -38,6 +39,8 @@ def build_user_transcription_event(
     }
     if timestamp is not None:
         payload["timestamp"] = timestamp
+    if end_timestamp is not None:
+        payload["end_timestamp"] = end_timestamp
     if user_id is not None:
         payload["user_id"] = user_id
     return {
@@ -50,10 +53,13 @@ def build_bot_text_event(
     *,
     text: str,
     timestamp: str | None = None,
+    end_timestamp: str | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {"text": text}
     if timestamp is not None:
         payload["timestamp"] = timestamp
+    if end_timestamp is not None:
+        payload["end_timestamp"] = end_timestamp
     return {
         "type": RealtimeFeedbackType.BOT_TEXT.value,
         "payload": payload,

--- a/api/services/pipecat/realtime_feedback_observer.py
+++ b/api/services/pipecat/realtime_feedback_observer.py
@@ -52,6 +52,8 @@ from pipecat.frames.frames import (
     TranscriptionFrame,
     TTSSpeakFrame,
     TTSTextFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
     UserMuteStartedFrame,
     UserMuteStoppedFrame,
 )
@@ -138,13 +140,23 @@ class RealtimeFeedbackObserver(BaseObserver):
             return
         # Bot speaking state - WS only (ephemeral state signals, not persisted)
         elif isinstance(frame, BotStartedSpeakingFrame):
+            if self._logs_buffer:
+                self._logs_buffer.mark_bot_started_speaking()
             await self._send_ws(
                 {"type": RealtimeFeedbackType.BOT_STARTED_SPEAKING.value, "payload": {}}
             )
         elif isinstance(frame, BotStoppedSpeakingFrame):
+            if self._logs_buffer:
+                self._logs_buffer.mark_bot_stopped_speaking()
             await self._send_ws(
                 {"type": RealtimeFeedbackType.BOT_STOPPED_SPEAKING.value, "payload": {}}
             )
+        elif isinstance(frame, UserStartedSpeakingFrame):
+            if self._logs_buffer:
+                self._logs_buffer.mark_user_started_speaking()
+        elif isinstance(frame, UserStoppedSpeakingFrame):
+            if self._logs_buffer:
+                self._logs_buffer.mark_user_stopped_speaking()
         # User mute state - WS only (ephemeral state signals, not persisted)
         elif isinstance(frame, UserMuteStartedFrame):
             await self._send_ws(
@@ -314,6 +326,7 @@ def register_turn_log_handlers(
                     text=message.content,
                     final=True,
                     timestamp=message.timestamp,
+                    end_timestamp=getattr(message, "end_timestamp", None),
                 )
             )
         except Exception as e:
@@ -327,6 +340,7 @@ def register_turn_log_handlers(
                     build_bot_text_event(
                         text=message.content,
                         timestamp=message.timestamp,
+                        end_timestamp=getattr(message, "end_timestamp", None),
                     )
                 )
             except Exception as e:

--- a/api/services/pipecat/realtime_feedback_observer.py
+++ b/api/services/pipecat/realtime_feedback_observer.py
@@ -21,6 +21,7 @@ node changes.
 """
 
 import json
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Awaitable, Callable, Optional, Set
 
 from loguru import logger
@@ -56,12 +57,18 @@ from pipecat.frames.frames import (
     UserStoppedSpeakingFrame,
     UserMuteStartedFrame,
     UserMuteStoppedFrame,
+    VADUserStartedSpeakingFrame,
+    VADUserStoppedSpeakingFrame,
 )
 from pipecat.metrics.metrics import TTFBMetricsData
 from pipecat.observers.base_observer import BaseObserver, FramePushed
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.transports.base_output import BaseOutputTransport
 from pipecat.utils.enums import RealtimeFeedbackType
+
+
+def _epoch_seconds_to_utc_iso(timestamp: float) -> str:
+    return datetime.fromtimestamp(timestamp, UTC).isoformat(timespec="milliseconds")
 
 
 class RealtimeFeedbackObserver(BaseObserver):
@@ -157,6 +164,18 @@ class RealtimeFeedbackObserver(BaseObserver):
         elif isinstance(frame, UserStoppedSpeakingFrame):
             if self._logs_buffer:
                 self._logs_buffer.mark_user_stopped_speaking()
+        elif isinstance(frame, VADUserStartedSpeakingFrame):
+            if self._logs_buffer:
+                self._logs_buffer.mark_user_started_speaking(
+                    _epoch_seconds_to_utc_iso(frame.timestamp - frame.start_secs),
+                    from_vad=True,
+                )
+        elif isinstance(frame, VADUserStoppedSpeakingFrame):
+            if self._logs_buffer:
+                self._logs_buffer.mark_user_stopped_speaking(
+                    _epoch_seconds_to_utc_iso(frame.timestamp - frame.stop_secs),
+                    from_vad=True,
+                )
         # User mute state - WS only (ephemeral state signals, not persisted)
         elif isinstance(frame, UserMuteStartedFrame):
             await self._send_ws(

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -545,6 +545,10 @@ async def _run_pipeline_impl(
     max_call_duration_seconds = DEFAULT_MAX_CALL_DURATION_SECONDS
     max_user_idle_timeout = DEFAULT_MAX_USER_IDLE_TIMEOUT_SECONDS
     keyterms = None  # Dictionary words for STT boosting
+    transcript_config = run_configs.get("transcript_configuration") or {}
+    include_transcript_end_timestamps = bool(
+        transcript_config.get("include_end_timestamps", False)
+    )
 
     if run_configs:
         if "max_call_duration" in run_configs:
@@ -1045,6 +1049,7 @@ async def _run_pipeline_impl(
         pre_call_fetch_task=pre_call_fetch_task,
         user_provider_id=user_provider_id,
         integration_runtime_sessions=integration_runtime_sessions,
+        include_transcript_end_timestamps=include_transcript_end_timestamps,
     )
 
     register_audio_data_handler(audio_buffer, workflow_run_id, in_memory_audio_buffer)

--- a/api/tests/test_realtime_feedback_events.py
+++ b/api/tests/test_realtime_feedback_events.py
@@ -1,10 +1,12 @@
 from api.services.pipecat.realtime_feedback_events import (
     build_bot_text_event,
     build_function_call_end_event,
+    build_user_transcription_event,
     build_node_transition_event,
     realtime_feedback_event_sort_key,
     stamp_realtime_feedback_event,
 )
+from api.utils.transcript import generate_transcript_text
 
 
 def test_build_function_call_end_event_serializes_results():
@@ -51,3 +53,38 @@ def test_stamp_and_sort_realtime_feedback_events():
     assert events == [bot_text, node_transition]
     assert node_transition["node_id"] == "node-1"
     assert node_transition["node_name"] == "Greeting"
+
+
+def test_transcript_can_include_end_timestamps_without_changing_default_format():
+    events = [
+        stamp_realtime_feedback_event(
+            build_bot_text_event(
+                text="Can you confirm your date of birth?",
+                timestamp="2026-01-01T00:00:01+00:00",
+                end_timestamp="2026-01-01T00:00:04+00:00",
+            ),
+            timestamp="2026-01-01T00:00:05+00:00",
+            turn=0,
+        ),
+        stamp_realtime_feedback_event(
+            build_user_transcription_event(
+                text="January fifth",
+                final=True,
+                timestamp="2026-01-01T00:00:06+00:00",
+                end_timestamp="2026-01-01T00:00:08+00:00",
+            ),
+            timestamp="2026-01-01T00:00:09+00:00",
+            turn=1,
+        ),
+    ]
+
+    assert generate_transcript_text(events) == (
+        "[2026-01-01T00:00:01+00:00] assistant: Can you confirm your date of birth?\n"
+        "[2026-01-01T00:00:06+00:00] user: January fifth\n"
+    )
+    assert generate_transcript_text(events, include_end_timestamps=True) == (
+        "[2026-01-01T00:00:01+00:00 -> 2026-01-01T00:00:04+00:00] "
+        "assistant: Can you confirm your date of birth?\n"
+        "[2026-01-01T00:00:06+00:00 -> 2026-01-01T00:00:08+00:00] "
+        "user: January fifth\n"
+    )

--- a/api/tests/test_realtime_feedback_observer.py
+++ b/api/tests/test_realtime_feedback_observer.py
@@ -9,6 +9,8 @@ from pipecat.frames.frames import (
     TTSTextFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
+    VADUserStartedSpeakingFrame,
+    VADUserStoppedSpeakingFrame,
 )
 from pipecat.observers.base_observer import FramePushed
 from pipecat.processors.frame_processor import FrameDirection
@@ -212,3 +214,54 @@ async def test_observer_attaches_backend_speaking_intervals_to_logged_transcript
         bot_event["payload"]["timestamp"],
     )
     assert bot_event["payload"]["end_timestamp"]
+
+
+@pytest.mark.asyncio
+async def test_observer_uses_vad_user_speech_times_over_turn_closure_times():
+    async def ws_sender(_message):
+        pass
+
+    logs_buffer = InMemoryLogsBuffer(workflow_run_id=123)
+    observer = RealtimeFeedbackObserver(ws_sender=ws_sender, logs_buffer=logs_buffer)
+    user_aggregator = _FakeAggregator()
+    assistant_aggregator = _FakeAggregator()
+    register_turn_log_handlers(logs_buffer, user_aggregator, assistant_aggregator)
+
+    await observer.on_push_frame(
+        _frame_pushed(
+            VADUserStartedSpeakingFrame(start_secs=0.2, timestamp=1000.2),
+            FrameDirection.DOWNSTREAM,
+        )
+    )
+    await observer.on_push_frame(
+        _frame_pushed(
+            VADUserStoppedSpeakingFrame(stop_secs=0.5, timestamp=1002.5),
+            FrameDirection.DOWNSTREAM,
+        )
+    )
+    await observer.on_push_frame(
+        _frame_pushed(UserStoppedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+    )
+
+    await user_aggregator.handlers["on_user_turn_message_added"](
+        user_aggregator,
+        SimpleNamespace(content="Hello", timestamp="aggregator-user-start"),
+    )
+
+    user_event = logs_buffer.get_events()[0]
+    assert user_event["payload"]["timestamp"] == "1970-01-01T00:16:40.000+00:00"
+    assert user_event["payload"]["end_timestamp"] == "1970-01-01T00:16:42.000+00:00"
+
+
+@pytest.mark.asyncio
+async def test_completed_bot_speech_interval_is_not_reused_for_next_pre_playback_text():
+    logs_buffer = InMemoryLogsBuffer(workflow_run_id=123)
+
+    logs_buffer.mark_bot_started_speaking("2026-01-01T00:00:01.000+00:00")
+    await logs_buffer.append({"type": "rtf-bot-text", "payload": {"text": "First"}})
+    logs_buffer.mark_bot_stopped_speaking("2026-01-01T00:00:02.000+00:00")
+
+    await logs_buffer.append({"type": "rtf-bot-text", "payload": {"text": "Second"}})
+    second_event = logs_buffer.get_events()[-1]
+
+    assert second_event["payload"] == {"text": "Second"}

--- a/api/tests/test_realtime_feedback_observer.py
+++ b/api/tests/test_realtime_feedback_observer.py
@@ -265,3 +265,28 @@ async def test_completed_bot_speech_interval_is_not_reused_for_next_pre_playback
     second_event = logs_buffer.get_events()[-1]
 
     assert second_event["payload"] == {"text": "Second"}
+
+
+@pytest.mark.asyncio
+async def test_non_vad_user_turn_after_completed_vad_turn_gets_fresh_timestamps():
+    logs_buffer = InMemoryLogsBuffer(workflow_run_id=123)
+
+    logs_buffer.mark_user_started_speaking(
+        "2026-01-01T00:00:01.000+00:00", from_vad=True
+    )
+    logs_buffer.mark_user_stopped_speaking(
+        "2026-01-01T00:00:02.000+00:00", from_vad=True
+    )
+    await logs_buffer.append(
+        {"type": "rtf-user-transcription", "payload": {"text": "First", "final": True}}
+    )
+
+    logs_buffer.mark_user_started_speaking("2026-01-01T00:00:10.000+00:00")
+    logs_buffer.mark_user_stopped_speaking("2026-01-01T00:00:12.000+00:00")
+    await logs_buffer.append(
+        {"type": "rtf-user-transcription", "payload": {"text": "Second", "final": True}}
+    )
+
+    second_event = logs_buffer.get_events()[-1]
+    assert second_event["payload"]["timestamp"] == "2026-01-01T00:00:10.000+00:00"
+    assert second_event["payload"]["end_timestamp"] == "2026-01-01T00:00:12.000+00:00"

--- a/api/tests/test_realtime_feedback_observer.py
+++ b/api/tests/test_realtime_feedback_observer.py
@@ -1,7 +1,14 @@
 from types import SimpleNamespace
 
 import pytest
-from pipecat.frames.frames import TranscriptionFrame, TTSTextFrame
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
+    TranscriptionFrame,
+    TTSTextFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
+)
 from pipecat.observers.base_observer import FramePushed
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.transports.base_output import BaseOutputTransport
@@ -144,3 +151,55 @@ async def test_turn_log_handlers_persist_user_message_added_events():
         "timestamp": "2026-01-01T00:00:00+00:00",
     }
     assert events[0]["turn"] == 1
+
+
+@pytest.mark.asyncio
+async def test_observer_attaches_backend_speaking_intervals_to_logged_transcript_events():
+    async def ws_sender(_message):
+        pass
+
+    logs_buffer = InMemoryLogsBuffer(workflow_run_id=123)
+    observer = RealtimeFeedbackObserver(ws_sender=ws_sender, logs_buffer=logs_buffer)
+
+    user_aggregator = _FakeAggregator()
+    assistant_aggregator = _FakeAggregator()
+    register_turn_log_handlers(logs_buffer, user_aggregator, assistant_aggregator)
+
+    await observer.on_push_frame(
+        _frame_pushed(UserStartedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+    )
+    await observer.on_push_frame(
+        _frame_pushed(UserStoppedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+    )
+    await user_aggregator.handlers["on_user_turn_message_added"](
+        user_aggregator,
+        SimpleNamespace(
+            content="January fifth",
+            timestamp="aggregator-user-start",
+        ),
+    )
+
+    await observer.on_push_frame(
+        _frame_pushed(BotStartedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+    )
+    await assistant_aggregator.handlers["on_assistant_turn_stopped"](
+        assistant_aggregator,
+        SimpleNamespace(
+            content="Thank you",
+            timestamp="aggregator-bot-start",
+        ),
+    )
+    await observer.on_push_frame(
+        _frame_pushed(BotStoppedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+    )
+
+    user_event, bot_event = [
+        event
+        for event in logs_buffer.get_events()
+        if event["type"] in {"rtf-user-transcription", "rtf-bot-text"}
+    ]
+
+    assert user_event["payload"]["timestamp"] != "aggregator-user-start"
+    assert user_event["payload"]["end_timestamp"]
+    assert bot_event["payload"]["timestamp"] != "aggregator-bot-start"
+    assert bot_event["payload"]["end_timestamp"]

--- a/api/tests/test_realtime_feedback_observer.py
+++ b/api/tests/test_realtime_feedback_observer.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+import re
 
 import pytest
 from pipecat.frames.frames import (
@@ -200,6 +201,14 @@ async def test_observer_attaches_backend_speaking_intervals_to_logged_transcript
     ]
 
     assert user_event["payload"]["timestamp"] != "aggregator-user-start"
+    assert re.match(
+        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+00:00$",
+        user_event["payload"]["timestamp"],
+    )
     assert user_event["payload"]["end_timestamp"]
     assert bot_event["payload"]["timestamp"] != "aggregator-bot-start"
+    assert re.match(
+        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+00:00$",
+        bot_event["payload"]["timestamp"],
+    )
     assert bot_event["payload"]["end_timestamp"]

--- a/api/utils/transcript.py
+++ b/api/utils/transcript.py
@@ -3,11 +3,26 @@ from typing import List
 from pipecat.utils.enums import RealtimeFeedbackType
 
 
-def generate_transcript_text(events: List[dict]) -> str:
+def _format_timestamp_range(payload: dict, event: dict, include_end_timestamps: bool) -> str:
+    start_timestamp = payload.get("timestamp") or event.get("timestamp", "")
+    if not include_end_timestamps:
+        return start_timestamp
+
+    end_timestamp = payload.get("end_timestamp")
+    if end_timestamp:
+        return f"{start_timestamp} -> {end_timestamp}" if start_timestamp else end_timestamp
+    return start_timestamp
+
+
+def generate_transcript_text(
+    events: List[dict], *, include_end_timestamps: bool = False
+) -> str:
     """Generate transcript text from realtime feedback events.
 
     Filters for rtf-user-transcription (final) and rtf-bot-text events,
-    formats them as '[timestamp] user/assistant: text\\n'.
+    formats them as '[timestamp] user/assistant: text\\n'. When
+    include_end_timestamps is True, formats as
+    '[start_timestamp -> end_timestamp] user/assistant: text\\n'.
     """
     lines: List[str] = []
     for event in events:
@@ -18,11 +33,11 @@ def generate_transcript_text(events: List[dict]) -> str:
             event_type == RealtimeFeedbackType.USER_TRANSCRIPTION.value
             and payload.get("final") is True
         ):
-            timestamp = payload.get("timestamp") or event.get("timestamp", "")
+            timestamp = _format_timestamp_range(payload, event, include_end_timestamps)
             prefix = f"[{timestamp}] " if timestamp else ""
             lines.append(f"{prefix}user: {payload.get('text', '')}\n")
         elif event_type == RealtimeFeedbackType.BOT_TEXT.value:
-            timestamp = payload.get("timestamp") or event.get("timestamp", "")
+            timestamp = _format_timestamp_range(payload, event, include_end_timestamps)
             prefix = f"[{timestamp}] " if timestamp else ""
             lines.append(f"{prefix}assistant: {payload.get('text', '')}\n")
 

--- a/ui/src/app/workflow/[workflowId]/components/ConfigurationsDialog.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/ConfigurationsDialog.tsx
@@ -78,6 +78,7 @@ export const ConfigurationsDialog = ({
                 turn_start_min_words: turnStartMinWords,
                 provisional_vad_pause_secs: provisionalVadPauseSecs,
                 turn_stop_strategy: turnStopStrategy,
+                transcript_configuration: resolvedWorkflowConfigurations.transcript_configuration,
                 context_compaction_enabled: contextCompactionEnabled,
             }, name);
             onOpenChange(false);

--- a/ui/src/app/workflow/[workflowId]/settings/page.tsx
+++ b/ui/src/app/workflow/[workflowId]/settings/page.tsx
@@ -48,6 +48,7 @@ import {
     DEFAULT_PROVISIONAL_VAD_PAUSE_SECS,
     DEFAULT_TURN_START_MIN_WORDS,
     DEFAULT_VOICEMAIL_DETECTION_CONFIGURATION,
+    resolveWorkflowConfigurations,
     TURN_START_STRATEGY_OPTIONS,
     type TurnStartStrategy,
     type TurnStopStrategy,
@@ -293,6 +294,9 @@ function GeneralSection({
     const [contextCompactionEnabled, setContextCompactionEnabled] = useState(
         workflowConfigurations.context_compaction_enabled,
     );
+    const [includeTranscriptEndTimestamps, setIncludeTranscriptEndTimestamps] = useState(
+        workflowConfigurations.transcript_configuration?.include_end_timestamps ?? false,
+    );
     const [isSaving, setIsSaving] = useState(false);
     const [isUploadingAudio, setIsUploadingAudio] = useState(false);
     const [audioUploadError, setAudioUploadError] = useState<string | null>(null);
@@ -314,9 +318,11 @@ function GeneralSection({
             turnStartMinWords !== workflowConfigurations.turn_start_min_words ||
             provisionalVadPauseSecs !== workflowConfigurations.provisional_vad_pause_secs ||
             turnStopStrategy !== workflowConfigurations.turn_stop_strategy ||
-            contextCompactionEnabled !== workflowConfigurations.context_compaction_enabled
+            contextCompactionEnabled !== workflowConfigurations.context_compaction_enabled ||
+            includeTranscriptEndTimestamps !==
+            (workflowConfigurations.transcript_configuration?.include_end_timestamps ?? false)
         );
-    }, [name, workflowName, ambientNoiseConfig, maxCallDuration, maxUserIdleTimeout, smartTurnStopSecs, turnStartStrategy, turnStartMinWords, provisionalVadPauseSecs, turnStopStrategy, contextCompactionEnabled, workflowConfigurations]);
+    }, [name, workflowName, ambientNoiseConfig, maxCallDuration, maxUserIdleTimeout, smartTurnStopSecs, turnStartStrategy, turnStartMinWords, provisionalVadPauseSecs, turnStopStrategy, contextCompactionEnabled, includeTranscriptEndTimestamps, workflowConfigurations]);
 
     useUnsavedChanges("general", isDirty);
 
@@ -393,6 +399,10 @@ function GeneralSection({
                     provisional_vad_pause_secs: provisionalVadPauseSecs,
                     turn_stop_strategy: turnStopStrategy,
                     context_compaction_enabled: contextCompactionEnabled,
+                    transcript_configuration: {
+                        ...(workflowConfigurations.transcript_configuration ?? {}),
+                        include_end_timestamps: includeTranscriptEndTimestamps,
+                    },
                 },
                 name,
             );
@@ -682,6 +692,34 @@ function GeneralSection({
                             </p>
                         </div>
                     )}
+                </div>
+
+                <Separator />
+
+                {/* Transcript */}
+                <div className="space-y-4">
+                    <div>
+                        <h3 className="text-sm font-medium">Transcript</h3>
+                        <p className="text-xs text-muted-foreground mt-0.5">
+                            Include start and stop timestamps for each speaker in the uploaded transcript.
+                        </p>
+                    </div>
+                    <div className="flex items-center justify-between">
+                        <Label htmlFor="transcript-end-timestamps-enabled" className="text-sm">
+                            Enhanced Timestamped Transcript
+                        </Label>
+                        <Switch
+                            id="transcript-end-timestamps-enabled"
+                            checked={includeTranscriptEndTimestamps}
+                            onCheckedChange={setIncludeTranscriptEndTimestamps}
+                        />
+                    </div>
+                    <div className="rounded-md border bg-muted/20 p-3">
+                        <pre className="whitespace-pre-wrap text-xs leading-relaxed text-muted-foreground">
+                            {`[2026-07-06T10:00:00.000Z -> 2026-07-06T10:00:04.800Z] assistant: Can you confirm your date of birth?
+[2026-07-06T10:00:06.200Z -> 2026-07-06T10:00:08.700Z] user: January fifth, nineteen ninety.`}
+                        </pre>
+                    </div>
                 </div>
 
                 <Separator />
@@ -1458,6 +1496,9 @@ function WorkflowSettingsInner({
         initialWorkflowConfigurations,
         user,
     });
+    const resolvedWorkflowConfigurationsForRender = workflowConfigurations
+        ? resolveWorkflowConfigurations(workflowConfigurations)
+        : null;
 
     useEffect(() => {
         if (hasFetchedModelConfiguration.current) return;
@@ -1532,18 +1573,18 @@ function WorkflowSettingsInner({
             <div className="mx-auto flex max-w-5xl gap-8 px-6 py-8">
                 {/* Sections */}
                 <div className="min-w-0 flex-1 space-y-8">
-                    {workflowConfigurations && (
+                    {resolvedWorkflowConfigurationsForRender && (
                         <>
                             {/* General */}
                             <GeneralSection
-                                workflowConfigurations={workflowConfigurations}
+                                workflowConfigurations={resolvedWorkflowConfigurationsForRender}
                                 workflowName={workflowName || workflow.name}
                                 workflowId={workflowId}
                                 onSave={saveWorkflowConfigurations}
                             />
 
                             <WorkflowModelOverridesSection
-                                workflowConfigurations={workflowConfigurations}
+                                workflowConfigurations={resolvedWorkflowConfigurationsForRender}
                                 workflowName={workflowName}
                                 onSave={saveWorkflowConfigurations}
                                 modelConfigurationDefaults={modelConfigurationDefaults}
@@ -1563,7 +1604,7 @@ function WorkflowSettingsInner({
 
                             {/* Voicemail Detection */}
                             <VoicemailSection
-                                workflowConfigurations={workflowConfigurations}
+                                workflowConfigurations={resolvedWorkflowConfigurationsForRender}
                                 workflowName={workflowName}
                                 onSave={saveWorkflowConfigurations}
                             />

--- a/ui/src/components/workflow/conversation/types.ts
+++ b/ui/src/components/workflow/conversation/types.ts
@@ -38,6 +38,7 @@ export interface RealtimeFeedbackEvent {
         final?: boolean;
         user_id?: string;
         timestamp?: string;
+        end_timestamp?: string;
         function_name?: string;
         tool_call_id?: string;
         arguments?: unknown;

--- a/ui/src/types/workflow-configurations.ts
+++ b/ui/src/types/workflow-configurations.ts
@@ -60,6 +60,14 @@ export const DEFAULT_VOICEMAIL_DETECTION_CONFIGURATION: VoicemailDetectionConfig
     long_speech_timeout: 8.0,
 };
 
+export interface TranscriptConfiguration {
+    include_end_timestamps: boolean;
+}
+
+export const DEFAULT_TRANSCRIPT_CONFIGURATION: TranscriptConfiguration = {
+    include_end_timestamps: false,
+};
+
 export interface ModelOverrides {
     llm?: {
         provider?: string;
@@ -115,6 +123,7 @@ export type WorkflowConfigurations = WorkflowConfigurationBase & {
     turn_stop_strategy: TurnStopStrategy;  // Strategy for detecting end of user turn
     dictionary?: string;  // Comma-separated words for voice agent to listen for
     voicemail_detection?: VoicemailDetectionConfiguration;
+    transcript_configuration: TranscriptConfiguration;
     context_compaction_enabled: boolean;  // Summarize context on node transitions to remove stale tool calls
     model_overrides?: ModelOverrides;  // Per-workflow model configuration overrides
     model_configuration_v2_override?: OrganizationAiModelConfigurationV2;  // Full v2 model configuration override
@@ -134,6 +143,7 @@ const FALLBACK_WORKFLOW_CONFIGURATIONS: WorkflowConfigurations = {
     provisional_vad_pause_secs: DEFAULT_PROVISIONAL_VAD_PAUSE_SECS,
     turn_stop_strategy: 'transcription',  // Default to transcription-based detection
     dictionary: '',
+    transcript_configuration: DEFAULT_TRANSCRIPT_CONFIGURATION,
     context_compaction_enabled: false,
 };
 
@@ -186,5 +196,9 @@ export function resolveWorkflowConfigurations(
             configurations?.context_compaction_enabled
             ?? defaults?.context_compaction_enabled
             ?? FALLBACK_WORKFLOW_CONFIGURATIONS.context_compaction_enabled,
+        transcript_configuration: {
+            ...DEFAULT_TRANSCRIPT_CONFIGURATION,
+            ...(configurations?.transcript_configuration as Partial<TranscriptConfiguration> | undefined),
+        },
     };
 }

--- a/ui/src/types/workflow-configurations.ts
+++ b/ui/src/types/workflow-configurations.ts
@@ -198,6 +198,7 @@ export function resolveWorkflowConfigurations(
             ?? FALLBACK_WORKFLOW_CONFIGURATIONS.context_compaction_enabled,
         transcript_configuration: {
             ...DEFAULT_TRANSCRIPT_CONFIGURATION,
+            ...(defaults?.transcript_configuration as Partial<TranscriptConfiguration> | undefined),
             ...(configurations?.transcript_configuration as Partial<TranscriptConfiguration> | undefined),
         },
     };


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional end timestamps to call transcripts so each user/assistant message can show a “[start -> end]” interval when enabled. Adds backend interval tracking and a settings toggle; the default transcript format stays the same.

- **New Features**
  - Attach `timestamp`/`end_timestamp` to `rtf-user-transcription` (final) and `rtf-bot-text`; transcript generator outputs “[start -> end] …” when `include_end_timestamps` is true.
  - Read `transcript_configuration.include_end_timestamps` in `run_pipeline` and pass it through upload; add “Enhanced Timestamped Transcript” toggle in Workflow Settings and wire through `ConfigurationsDialog`; update types and config resolution to include `end_timestamp` and a defaulted `transcript_configuration`.

- **Bug Fixes**
  - Prefer VAD user speech times over turn-close times; record user/bot start/stop frames and propagate aggregator `end_timestamp` when present.
  - Prevent reuse of completed bot intervals for later text and ensure a non‑VAD user turn after a completed VAD turn gets fresh timestamps; normalize to millisecond ISO timestamps and add tests for formatting and interval attachment.

<sup>Written for commit 324a019b5f91380943a5bf7fcd5b463bcf3b4aab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds optional end timestamps to persisted call transcripts. The main changes are:

- Captures user and bot speaking intervals in the Pipecat realtime feedback path.
- Propagates `timestamp` and `end_timestamp` through transcript event builders and log buffering.
- Formats uploaded transcripts as `[start -> end]` only when `include_end_timestamps` is enabled.
- Adds workflow settings UI and configuration typing for the enhanced transcript toggle.
- Adds tests for default formatting, timestamp range formatting, VAD precedence, and interval attachment.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are scoped to transcript timestamp collection, formatting, tests, and settings wiring. No accepted runtime bugs or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Next.js dev server was started with npm run dev and served the /api/config/auth endpoint, and the server entered a compiling state for the workflow settings route.
- A direct curl -I request to the internal URL timed out after 60 seconds with 0 bytes received.
- The TypeScript type-check completed with exit code 0, indicating no type errors were found.

<a href="https://app.greptile.com/trex/runs/13518638/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/services/pipecat/in_memory_buffers.py | Adds speech interval tracking and timestamp attachment for persisted transcript events. |
| api/services/pipecat/realtime_feedback_observer.py | Records user and bot speaking frames and propagates aggregator-provided end timestamps into persisted transcript events. |
| api/services/pipecat/run_pipeline.py | Reads `transcript_configuration.include_end_timestamps` from pinned run configuration and forwards it to event handlers. |
| api/utils/transcript.py | Adds optional timestamp range formatting while preserving existing transcript output by default. |
| ui/src/app/workflow/[workflowId]/settings/page.tsx | Adds settings UI state and save payload wiring for the enhanced timestamped transcript toggle. |
| ui/src/types/workflow-configurations.ts | Adds transcript configuration defaults and resolution into workflow configuration typing. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant UI as Workflow Settings UI
participant Run as run_pipeline
participant Obs as RealtimeFeedbackObserver
participant Buf as InMemoryLogsBuffer
participant Upload as Artifact Upload

UI->>Run: Save transcript_configuration.include_end_timestamps
Run->>Obs: register_event_handlers(include_transcript_end_timestamps)
Obs->>Buf: mark user/bot speaking start and stop
Obs->>Buf: append final user/bot transcript events
Buf->>Buf: attach timestamp/end_timestamp intervals
Upload->>Buf: generate_transcript_text(include_end_timestamps)
Buf-->>Upload: "default [start] or enhanced [start -> end] transcript"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant UI as Workflow Settings UI
participant Run as run_pipeline
participant Obs as RealtimeFeedbackObserver
participant Buf as InMemoryLogsBuffer
participant Upload as Artifact Upload

UI->>Run: Save transcript_configuration.include_end_timestamps
Run->>Obs: register_event_handlers(include_transcript_end_timestamps)
Obs->>Buf: mark user/bot speaking start and stop
Obs->>Buf: append final user/bot transcript events
Buf->>Buf: attach timestamp/end_timestamp intervals
Upload->>Buf: generate_transcript_text(include_end_timestamps)
Buf-->>Upload: "default [start] or enhanced [start -> end] transcript"
```

</a>

<sub>Reviews (4): Last reviewed commit: ["fix: non vad user turn timestamp"](https://github.com/dograh-hq/dograh/commit/324a019b5f91380943a5bf7fcd5b463bcf3b4aab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42104747)</sub>

<!-- /greptile_comment -->