### PR TITLE
fix: forward billing-v2 protocol on textchat KB retrieval and node su…

### DIFF
--- a/api/services/workflow/qa/node_summary.py
+++ b/api/services/workflow/qa/node_summary.py
@@ -7,6 +7,7 @@ from pipecat.processors.aggregators.llm_context import LLMContext
 
 from api.db import db_client
 from api.db.models import WorkflowRunModel
+from api.services.managed_model_services import get_mps_correlation_id
 from api.services.pipecat.service_factory import create_llm_service_from_provider
 from api.services.workflow.dto import NodeType, QANodeData
 from api.services.workflow.qa.llm_config import resolve_llm_config
@@ -75,7 +76,15 @@ async def ensure_node_summaries(
         logger.warning("No API key for node summary generation, skipping")
         return existing_summaries
 
-    llm = create_llm_service_from_provider(provider, model, api_key, **service_kwargs)
+    # Reuse the run's MPS correlation id (minted at run start, persisted on
+    # initial_context) so managed-model-services calls carry billing-v2
+    # markers — orgs on billing v2 reject managed calls that lack them.
+    mps_correlation_id = get_mps_correlation_id(
+        getattr(workflow_run, "initial_context", None)
+    )
+    llm = create_llm_service_from_provider(
+        provider, model, api_key, correlation_id=mps_correlation_id, **service_kwargs
+    )
 
     updated_summaries = dict(existing_summaries)
 

--- a/api/services/workflow/text_chat_runner.py
+++ b/api/services/workflow/text_chat_runner.py
@@ -532,6 +532,9 @@ async def execute_text_chat_pending_turn(
     embeddings_api_key = None
     embeddings_model = None
     embeddings_base_url = None
+    embeddings_provider = None
+    embeddings_endpoint = None
+    embeddings_api_version = None
     if user_config.embeddings:
         from api.services.configuration.ai_model_configuration import (
             apply_managed_embeddings_base_url,
@@ -544,6 +547,8 @@ async def execute_text_chat_pending_turn(
             provider=embeddings_provider,
             base_url=getattr(user_config.embeddings, "base_url", None),
         )
+        embeddings_endpoint = getattr(user_config.embeddings, "endpoint", None)
+        embeddings_api_version = getattr(user_config.embeddings, "api_version", None)
 
     has_recordings = await db_client.has_active_recordings(workflow.organization_id)
     context_compaction_enabled = (workflow.workflow_configurations or {}).get(
@@ -560,6 +565,9 @@ async def execute_text_chat_pending_turn(
         embeddings_api_key=embeddings_api_key,
         embeddings_model=embeddings_model,
         embeddings_base_url=embeddings_base_url,
+        embeddings_provider=embeddings_provider,
+        embeddings_endpoint=embeddings_endpoint,
+        embeddings_api_version=embeddings_api_version,
         has_recordings=has_recordings,
         context_compaction_enabled=context_compaction_enabled,
     )


### PR DESCRIPTION
…mmaries

Two call sites dropped the MPS billing-v2 protocol, so orgs on model config v2 got 400 "Service Key uses billing v2" from MPS:

- text_chat_runner built PipecatEngine without embeddings_provider (extracted but never passed), so knowledge-base retrieval fell through to the plain OpenAI-compatible client instead of DograhEmbeddingService and sent no correlation_id/mps_billing_version metadata. Also pass endpoint/api_version for Azure BYOK parity with run_pipeline.
- node_summary built its QA LLM without the run's correlation id, unlike its sibling call in qa/analysis.py.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped MPS billing-v2 metadata in text chat KB retrieval and node summaries to prevent 400 “Service Key uses billing v2” errors for orgs on model config v2.

- **Bug Fixes**
  - text chat: forward `embeddings_provider`, `embeddings_endpoint`, and `embeddings_api_version` to the Pipecat engine so KB retrieval uses DograhEmbeddingService and includes billing-v2 metadata; adds Azure BYOK parity with `run_pipeline`.
  - node summaries: reuse the run’s correlation id via `get_mps_correlation_id` when creating the QA LLM so managed calls carry billing-v2 markers.

<sup>Written for commit 92bd22493d2ca00a09fb81bc42c34165443b023f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR forwards billing-v2 context through text-chat KB retrieval and QA node summaries. The main changes are:

- Passes text-chat embeddings provider, endpoint, and API version into `PipecatEngine`.
- Keeps text-chat KB retrieval aligned with the existing `run_pipeline` embeddings setup.
- Reuses the workflow run's stored MPS correlation id when creating node-summary LLM services.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrow config-plumbing fixes that use existing engine and service-factory parameters. The text-chat embeddings path now matches the existing pipeline path. No blocking correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex generated a mocked runtime harness file billing\_v2\_forwarding\_harness.py that includes the local pipecat.utils.run\_context shim.
- The harness log shows a blocker where fallback Python 3.11 plus Python 3.13 site-packages fail with ModuleNotFoundError: No module named 'pydantic\_core.\_pydantic\_core'.
- The pytest run log records an earlier attempt where an interpreter in a py313 virtual environment exited with code 127 due to the target interpreter being missing.
- The logs collectively confirm environmental blockers prevent progress in the provided setup, based on the final command execution blocker and missing interpreter.
- Artifacts were created and are available for inspection: the harness, and two logs documenting blockers and prior attempts.

<a href="https://app.greptile.com/trex/runs/13425649/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/services/workflow/qa/node_summary.py | Passes the workflow run's MPS correlation id into node-summary LLM creation so Dograh managed LLM calls include billing-v2 metadata. |
| api/services/workflow/text_chat_runner.py | Forwards embeddings provider, Azure endpoint, and API version from text-chat model config into `PipecatEngine` for KB retrieval parity with pipeline runs. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant TextChat as text_chat_runner
participant Engine as PipecatEngine
participant KB as retrieve_from_knowledge_base
participant MPS as Managed Model Services
participant Summary as node_summary
participant LLM as DograhLLMService

TextChat->>Engine: pass embeddings provider/base_url/endpoint/api_version
Engine->>KB: retrieve(query, embeddings config, correlation_id)
KB->>MPS: embeddings request with billing-v2 metadata
Summary->>Summary: read mps_correlation_id from run.initial_context
Summary->>LLM: create_llm_service_from_provider(correlation_id)
LLM->>MPS: node summary inference with billing-v2 metadata
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant TextChat as text_chat_runner
participant Engine as PipecatEngine
participant KB as retrieve_from_knowledge_base
participant MPS as Managed Model Services
participant Summary as node_summary
participant LLM as DograhLLMService

TextChat->>Engine: pass embeddings provider/base_url/endpoint/api_version
Engine->>KB: retrieve(query, embeddings config, correlation_id)
KB->>MPS: embeddings request with billing-v2 metadata
Summary->>Summary: read mps_correlation_id from run.initial_context
Summary->>LLM: create_llm_service_from_provider(correlation_id)
LLM->>MPS: node summary inference with billing-v2 metadata
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: forward billing-v2 protocol on text..."](https://github.com/dograh-hq/dograh/commit/92bd22493d2ca00a09fb81bc42c34165443b023f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42133742)</sub>

<!-- /greptile_comment -->