### PR TITLE
Whatsapp platform

### DIFF
--- a/api/schemas/telephony_config.py
+++ b/api/schemas/telephony_config.py
@@ -40,6 +40,10 @@ from api.services.telephony.providers.vonage.config import (
     VonageConfigurationRequest,
     VonageConfigurationResponse,
 )
+from api.services.telephony.providers.whatsapp_platform.config import (
+    WhatsAppPlatformConfigurationRequest,
+    WhatsAppPlatformConfigurationResponse,
+)
 
 # Discriminated union for incoming save requests. Pydantic dispatches on the
 # ``provider`` Literal field of each request class. Replaces the manual
@@ -53,6 +57,7 @@ TelephonyConfigRequest = Annotated[
         TwilioConfigurationRequest,
         VobizConfigurationRequest,
         VonageConfigurationRequest,
+        WhatsAppPlatformConfigurationRequest,
     ],
     Field(discriminator="provider"),
 ]
@@ -73,7 +78,7 @@ class TelephonyConfigurationResponse(BaseModel):
     cloudonix: Optional[CloudonixConfigurationResponse] = None
     ari: Optional[ARIConfigurationResponse] = None
     telnyx: Optional[TelnyxConfigurationResponse] = None
-
+    whatsapp_platform: Optional[WhatsAppPlatformConfigurationResponse] = None
 
 # ---------------------------------------------------------------------------
 # Multi-config CRUD schemas
@@ -148,4 +153,6 @@ __all__ = [
     "VobizConfigurationResponse",
     "VonageConfigurationRequest",
     "VonageConfigurationResponse",
+    "WhatsAppPlatformConfigurationRequest",
+    "WhatsAppPlatformConfigurationResponse",
 ]

--- a/api/services/telephony/providers/__init__.py
+++ b/api/services/telephony/providers/__init__.py
@@ -14,4 +14,5 @@ from api.services.telephony.providers import (  # noqa: F401  -- import for side
     twilio,
     vobiz,
     vonage,
+    whatsapp_platform,
 )

--- a/api/services/telephony/providers/whatsapp_platform/__init__.py
+++ b/api/services/telephony/providers/whatsapp_platform/__init__.py
@@ -1,0 +1,80 @@
+"""WhatsApp Platform telephony provider package.
+
+This package lets Dograh receive inbound WhatsApp calls from the
+WhatsApp SaaS platform bridge (Node.js backend + @roamhq/wrtc).
+
+The bridge side already handles Meta WebRTC negotiation and PCM
+resampling. By the time audio reaches Dograh, it is a standard
+16kHz mono Linear PCM WebSocket stream — exactly what Dograh's
+pipecat pipeline expects.
+
+Inbound-only. Outbound calls are not supported because WhatsApp
+Business Policy requires explicit opt-in permission from the
+recipient before placing a call.
+"""
+
+from typing import Any, Dict
+
+from api.services.telephony.registry import (
+    ProviderSpec,
+    ProviderUIField,
+    ProviderUIMetadata,
+    register,
+)
+
+from .config import (
+    WhatsAppPlatformConfigurationRequest,
+    WhatsAppPlatformConfigurationResponse,
+)
+from .provider import WhatsAppPlatformProvider
+from .transport import create_transport
+
+
+def _config_loader(value: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "provider":            "whatsapp_platform",
+        "platform_api_url":    value.get("platform_api_url"),
+        "webhook_secret":      value.get("webhook_secret"),
+    }
+
+
+_UI_METADATA = ProviderUIMetadata(
+    display_name="WhatsApp Platform",
+    docs_url="https://docs.dograh.com/integrations/telephony/whatsapp-platform",
+    fields=[
+        ProviderUIField(
+            name="platform_api_url",
+            label="Platform API URL",
+            type="text",
+            placeholder="https://your-whatsapp-saas-backend.com",
+            required=True,
+            help_text=(
+                "Base URL of your WhatsApp SaaS backend. "
+                "Dograh will call /dograh-webhook/* on this host."
+            ),
+        ),
+        ProviderUIField(
+            name="webhook_secret",
+            label="Webhook Secret",
+            type="password",
+            placeholder="A strong shared secret (32+ chars)",
+            required=True,
+            help_text=(
+                "Shared secret used to authenticate Dograh → Platform webhooks. "
+                "Must match the key configured in the Platform admin panel."
+            ),
+        ),
+    ],
+)
+
+_PROVIDER_SPEC = ProviderSpec(
+    name="whatsapp_platform",
+    provider_class=WhatsAppPlatformProvider,
+    config_request_class=WhatsAppPlatformConfigurationRequest,
+    config_response_class=WhatsAppPlatformConfigurationResponse,
+    config_loader=_config_loader,
+    create_transport=create_transport,
+    ui_metadata=_UI_METADATA,
+)
+
+register(_PROVIDER_SPEC)

--- a/api/services/telephony/providers/whatsapp_platform/__init__.py
+++ b/api/services/telephony/providers/whatsapp_platform/__init__.py
@@ -48,7 +48,7 @@ _UI_METADATA = ProviderUIMetadata(
             type="text",
             placeholder="https://your-whatsapp-saas-backend.com",
             required=True,
-            help_text=(
+            description=(
                 "Base URL of your WhatsApp SaaS backend. "
                 "Dograh will call /dograh-webhook/* on this host."
             ),
@@ -59,7 +59,7 @@ _UI_METADATA = ProviderUIMetadata(
             type="password",
             placeholder="A strong shared secret (32+ chars)",
             required=True,
-            help_text=(
+            description=(
                 "Shared secret used to authenticate Dograh → Platform webhooks. "
                 "Must match the key configured in the Platform admin panel."
             ),
@@ -69,11 +69,12 @@ _UI_METADATA = ProviderUIMetadata(
 
 _PROVIDER_SPEC = ProviderSpec(
     name="whatsapp_platform",
-    provider_class=WhatsAppPlatformProvider,
-    config_request_class=WhatsAppPlatformConfigurationRequest,
-    config_response_class=WhatsAppPlatformConfigurationResponse,
+    provider_cls=WhatsAppPlatformProvider,
     config_loader=_config_loader,
-    create_transport=create_transport,
+    transport_factory=create_transport,
+    transport_sample_rate=16000,
+    config_request_cls=WhatsAppPlatformConfigurationRequest,
+    config_response_cls=WhatsAppPlatformConfigurationResponse,
     ui_metadata=_UI_METADATA,
 )
 

--- a/api/services/telephony/providers/whatsapp_platform/config.py
+++ b/api/services/telephony/providers/whatsapp_platform/config.py
@@ -1,0 +1,41 @@
+"""WhatsApp Platform telephony configuration schemas."""
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class WhatsAppPlatformConfigurationRequest(BaseModel):
+    """Request schema for WhatsApp Platform configuration.
+
+    Stored encrypted in Dograh's telephony_configurations table.
+    """
+
+    provider: Literal["whatsapp_platform"] = Field(default="whatsapp_platform")
+
+    platform_api_url: str = Field(
+        ...,
+        description=(
+            "Base URL of the WhatsApp SaaS backend. "
+            "Example: https://api.yourdomain.com"
+        ),
+    )
+    webhook_secret: str = Field(
+        ...,
+        description=(
+            "Shared secret sent as X-Dograh-Key header on every webhook call "
+            "from Dograh → Platform. Must be >= 32 characters."
+        ),
+        min_length=8,
+    )
+
+
+class WhatsAppPlatformConfigurationResponse(BaseModel):
+    """Response schema — webhook_secret is masked for security."""
+
+    id: int
+    provider: Literal["whatsapp_platform"] = "whatsapp_platform"
+    platform_api_url: str
+    webhook_secret: str = "••••••••••••••••"  # always masked
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None

--- a/api/services/telephony/providers/whatsapp_platform/provider.py
+++ b/api/services/telephony/providers/whatsapp_platform/provider.py
@@ -150,6 +150,35 @@ class WhatsAppPlatformProvider(TelephonyProvider):
             },
         )
 
+    # ── Agent Stream Entry Point ──────────────────────────────────────────────
+    async def handle_external_websocket(
+        self,
+        websocket: "WebSocket",
+        *,
+        organization_id: int,
+        workflow_id: int,
+        user_id: int,
+        workflow_run_id: int,
+        params: Dict[str, str],
+    ) -> None:
+        """Agent-stream entry point for WhatsApp bridge."""
+        from api.services.pipecat.run_pipeline import run_pipeline_telephony
+
+        logger.info(
+            f"[WhatsAppPlatform] Agent stream connected for run {workflow_run_id}, "
+            f"workflow {workflow_id}"
+        )
+
+        await run_pipeline_telephony(
+            websocket=websocket,
+            provider_name=self.PROVIDER_NAME,
+            workflow_id=workflow_id,
+            workflow_run_id=workflow_run_id,
+            user_id=user_id,
+            call_id=params.get("callId", ""),
+            transport_kwargs={"params": params},
+        )
+
     # ── Config sync ───────────────────────────────────────────────────────────
 
     async def configure_inbound(self, **kwargs: Any) -> ProviderSyncResult:
@@ -158,6 +187,46 @@ class WhatsAppPlatformProvider(TelephonyProvider):
 
     def validate_config(self) -> bool:
         return bool(self.platform_api_url and self.webhook_secret)
+
+    # ── Missing abstract methods ──────────────────────────────────────────────
+
+    def can_handle_webhook(self, request_path: str) -> bool:
+        return False
+
+    @staticmethod
+    def generate_error_response(error_type: str, message: str) -> tuple:
+        return {"error": message}, "application/json"
+
+    async def get_webhook_response(self, workflow_id: int, user_id: int, workflow_run_id: int) -> str:
+        return "{}"
+
+    async def handle_websocket(self, websocket: Any, workflow_id: int, user_id: int, workflow_run_id: int) -> None:
+        raise NotImplementedError("Use handle_external_websocket instead")
+
+    def parse_inbound_webhook(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        return data
+
+    def parse_status_callback(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        return data
+
+    async def start_inbound_stream(self, data: Dict[str, Any], workflow_id: int, user_id: int, workflow_run_id: int) -> tuple:
+        return {"error": "Not used"}, "application/json"
+
+    def supports_transfers(self) -> bool:
+        return True
+
+    async def transfer_call(self, destination: str, transfer_id: str, conference_name: str, timeout: int = 30, **kwargs: Any) -> Dict[str, Any]:
+        """Handled by WhatsAppTransferStrategy via save_transcript/etc"""
+        return {"status": "transferring"}
+
+    async def validate_account_id(self, account_id: str) -> bool:
+        return True
+
+    async def verify_inbound_signature(self, headers: Dict[str, str], raw_body: bytes) -> bool:
+        return True
+
+    async def verify_webhook_signature(self, url: str, params: Dict[str, Any], signature: str) -> bool:
+        return True
 
     # ── Internal helper ───────────────────────────────────────────────────────
 

--- a/api/services/telephony/providers/whatsapp_platform/provider.py
+++ b/api/services/telephony/providers/whatsapp_platform/provider.py
@@ -1,0 +1,187 @@
+"""
+WhatsApp Platform implementation of TelephonyProvider.
+
+Architecture
+────────────
+Inbound flow (customer calls → AI answers):
+  Customer WhatsApp call
+    → Meta webhook → Platform Node.js backend
+    → dograh-bridge.js (server-side WebRTC via @roamhq/wrtc)
+    → Dograh WebSocket audio stream (16kHz PCM)
+    → Dograh Pipecat pipeline (STT → LLM → TTS)
+    → dograh-bridge.js (PCM injected back to WebRTC track)
+    → Customer hears AI voice
+
+Transfer to human:
+  Pipecat pipeline calls WhatsAppTransferStrategy.execute_transfer()
+    → POST /dograh-webhook/transfer on Platform backend
+    → Platform re-broadcasts call:incoming to human agents
+
+Hangup by AI:
+  Pipecat pipeline calls WhatsAppHangupStrategy.execute_hangup()
+    → POST /dograh-webhook/hangup on Platform backend
+    → Platform calls Meta terminate API
+
+Outbound calls are NOT supported (WhatsApp Business Policy).
+"""
+
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+from loguru import logger
+
+from api.enums import TelephonyCallStatus, WorkflowRunMode
+from api.services.telephony.base import (
+    CallInitiationResult,
+    NormalizedInboundData,
+    ProviderSyncResult,
+    TelephonyProvider,
+)
+
+
+class WhatsAppPlatformProvider(TelephonyProvider):
+    """
+    WhatsApp Platform telephony provider.
+
+    The audio bridge (Node.js) handles all WebRTC complexity.
+    This provider's job is:
+      1. Provide a WebSocket endpoint for the bridge to connect to.
+      2. Implement transfer + hangup via HTTP callbacks to the platform.
+      3. Save post-call transcript via the call-ended webhook.
+    """
+
+    PROVIDER_NAME = "whatsapp_platform"
+    # The bridge connects directly to Dograh's audio-stream WebSocket.
+    # No separate inbound webhook URL is needed — the bridge is the caller.
+    WEBHOOK_ENDPOINT = None
+
+    def __init__(self, config: Dict[str, Any]):
+        self.platform_api_url = config.get("platform_api_url", "").rstrip("/")
+        self.webhook_secret   = config.get("webhook_secret", "")
+
+    # ── Outbound (not supported) ───────────────────────────────────────────────
+
+    async def initiate_call(
+        self,
+        to_number: str,
+        webhook_url: str,
+        workflow_run_id: Optional[int] = None,
+        from_number: Optional[str] = None,
+        **kwargs: Any,
+    ) -> CallInitiationResult:
+        """Not supported. WhatsApp Business Policy prohibits unsolicited calls."""
+        raise NotImplementedError(
+            "WhatsApp Platform does not support outbound calls. "
+            "Inbound calls only (customer initiates, AI answers)."
+        )
+
+    async def get_call_status(self, call_id: str) -> Dict[str, Any]:
+        """Call status is managed by the Platform backend, not polled by Dograh."""
+        return {"call_id": call_id, "status": "unknown", "provider": self.PROVIDER_NAME}
+
+    async def get_available_phone_numbers(self) -> List[str]:
+        """Phone numbers are managed by the Platform (WhatsApp numbers)."""
+        return []
+
+    async def get_call_cost(self, call_id: str) -> Dict[str, Any]:
+        """No per-minute cost — WhatsApp calls are free to receive."""
+        return {"call_id": call_id, "cost": 0.0, "currency": "USD"}
+
+    # ── Inbound normalisation ─────────────────────────────────────────────────
+
+    async def normalize_inbound_data(
+        self, raw_data: Dict[str, Any]
+    ) -> NormalizedInboundData:
+        """
+        Normalise inbound call data sent by the bridge when it starts a run.
+
+        The bridge passes these fields via the initial_context of the
+        trigger-workflow API call:
+          - wa_call_id:   Meta call ID
+          - caller_phone: Caller's WhatsApp number (+E.164)
+          - caller_name:  Display name (may be None)
+        """
+        return NormalizedInboundData(
+            provider=self.PROVIDER_NAME,
+            call_id=raw_data.get("wa_call_id", ""),
+            from_number=raw_data.get("caller_phone", ""),
+            to_number=raw_data.get("to_number", ""),
+            direction="inbound",
+            call_status="ringing",
+            raw_data=raw_data,
+        )
+
+    async def validate_inbound_request(
+        self, request_data: Dict[str, Any], headers: Dict[str, str]
+    ) -> bool:
+        """
+        Validate that an inbound request came from our bridge.
+        The bridge sends the webhook_secret in X-Dograh-Key header.
+        """
+        provided = headers.get("x-dograh-key", "")
+        return bool(provided and provided == self.webhook_secret)
+
+    # ── Post-call callbacks (called by Pipecat pipeline) ──────────────────────
+
+    async def save_recording(
+        self, call_id: str, recording_url: str, **kwargs: Any
+    ) -> bool:
+        """Notify the Platform to save the call recording URL."""
+        return await self._platform_post(
+            "/dograh-webhook/call-ended",
+            {
+                "wa_call_id": call_id,
+                "recording_url": recording_url,
+                **kwargs,
+            },
+        )
+
+    async def save_transcript(
+        self, call_id: str, transcript: str, outcome: Optional[str] = None, **kwargs: Any
+    ) -> bool:
+        """Push the full transcript + outcome to the Platform backend."""
+        return await self._platform_post(
+            "/dograh-webhook/call-ended",
+            {
+                "wa_call_id":  call_id,
+                "transcript":  transcript,
+                "outcome":     outcome,
+                **kwargs,
+            },
+        )
+
+    # ── Config sync ───────────────────────────────────────────────────────────
+
+    async def configure_inbound(self, **kwargs: Any) -> ProviderSyncResult:
+        """No upstream provider config to push — phone numbers live in the Platform."""
+        return ProviderSyncResult(ok=True, message="WhatsApp Platform configured (no upstream sync needed)")
+
+    def validate_config(self) -> bool:
+        return bool(self.platform_api_url and self.webhook_secret)
+
+    # ── Internal helper ───────────────────────────────────────────────────────
+
+    async def _platform_post(self, path: str, body: Dict[str, Any]) -> bool:
+        """POST to the WhatsApp Platform backend with the webhook secret header."""
+        url = self.platform_api_url + path
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url,
+                    json=body,
+                    headers={
+                        "X-Dograh-Key":  self.webhook_secret,
+                        "Content-Type":  "application/json",
+                    },
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if not resp.ok:
+                        text = await resp.text()
+                        logger.warning(
+                            f"[WhatsAppPlatform] POST {path} → HTTP {resp.status}: {text[:200]}"
+                        )
+                        return False
+                    return True
+        except Exception as exc:
+            logger.error(f"[WhatsAppPlatform] POST {path} failed: {exc}")
+            return False

--- a/api/services/telephony/providers/whatsapp_platform/serializers.py
+++ b/api/services/telephony/providers/whatsapp_platform/serializers.py
@@ -1,0 +1,55 @@
+"""WhatsApp Platform frame serializer.
+
+The bridge (Node.js dograh-bridge.js) sends and receives raw binary
+16kHz Linear PCM frames over the WebSocket — exactly the same wire
+format as Asterisk's native PCM stream.
+
+We re-use Pipecat's built-in RawAudioFrameSerializer which handles
+binary PCM frames with no framing headers.
+"""
+
+from pipecat.serializers.base_serializer import FrameSerializer
+from pipecat.frames.frames import AudioRawFrame, Frame
+from loguru import logger
+import struct
+
+
+class WhatsAppPlatformFrameSerializer(FrameSerializer):
+    """
+    Binary PCM serializer for the WhatsApp Platform bridge.
+
+    Wire format (same as the bridge sends/expects):
+      - Sample rate:    16,000 Hz
+      - Bit depth:      16-bit signed integer
+      - Byte order:     Little-endian
+      - Channels:       Mono (1)
+      - Framing:        None — each WebSocket message is a raw PCM chunk
+
+    Dograh reads: binary WebSocket message → Int16LE samples → AudioRawFrame
+    Dograh writes: AudioRawFrame samples → Int16LE bytes → binary WebSocket message
+    """
+
+    SAMPLE_RATE   = 16000
+    NUM_CHANNELS  = 1
+    BYTES_PER_SAMPLE = 2  # 16-bit
+
+    def serialize(self, frame: Frame) -> bytes | None:
+        """Convert an AudioRawFrame into raw PCM bytes to send to the bridge."""
+        if not isinstance(frame, AudioRawFrame):
+            return None
+        # frame.audio is already bytes of Int16LE PCM from TTS
+        return frame.audio
+
+    def deserialize(self, data: bytes) -> Frame | None:
+        """Convert raw PCM bytes from the bridge into an AudioRawFrame."""
+        if not data:
+            return None
+        try:
+            return AudioRawFrame(
+                audio=data,
+                sample_rate=self.SAMPLE_RATE,
+                num_channels=self.NUM_CHANNELS,
+            )
+        except Exception as exc:
+            logger.warning(f"[WhatsAppPlatform] Deserialize error: {exc}")
+            return None

--- a/api/services/telephony/providers/whatsapp_platform/serializers.py
+++ b/api/services/telephony/providers/whatsapp_platform/serializers.py
@@ -9,7 +9,7 @@ binary PCM frames with no framing headers.
 """
 
 from pipecat.serializers.base_serializer import FrameSerializer
-from pipecat.frames.frames import AudioRawFrame, Frame
+from pipecat.frames.frames import AudioRawFrame, InputAudioRawFrame, OutputAudioRawFrame, Frame
 from loguru import logger
 import struct
 
@@ -33,19 +33,19 @@ class WhatsAppPlatformFrameSerializer(FrameSerializer):
     NUM_CHANNELS  = 1
     BYTES_PER_SAMPLE = 2  # 16-bit
 
-    def serialize(self, frame: Frame) -> bytes | None:
+    async def serialize(self, frame: Frame) -> bytes | None:
         """Convert an AudioRawFrame into raw PCM bytes to send to the bridge."""
-        if not isinstance(frame, AudioRawFrame):
+        if not isinstance(frame, (AudioRawFrame, InputAudioRawFrame, OutputAudioRawFrame)):
             return None
         # frame.audio is already bytes of Int16LE PCM from TTS
         return frame.audio
 
-    def deserialize(self, data: bytes) -> Frame | None:
-        """Convert raw PCM bytes from the bridge into an AudioRawFrame."""
+    async def deserialize(self, data: bytes) -> Frame | None:
+        """Convert raw PCM bytes from the bridge into an InputAudioRawFrame."""
         if not data:
             return None
         try:
-            return AudioRawFrame(
+            return InputAudioRawFrame(
                 audio=data,
                 sample_rate=self.SAMPLE_RATE,
                 num_channels=self.NUM_CHANNELS,

--- a/api/services/telephony/providers/whatsapp_platform/strategies.py
+++ b/api/services/telephony/providers/whatsapp_platform/strategies.py
@@ -1,0 +1,114 @@
+"""WhatsApp Platform call operation strategies.
+
+Two strategies:
+
+1. WhatsAppTransferStrategy
+   Called by the Pipecat pipeline when the AI decides to transfer to a human.
+   POSTs to /dograh-webhook/transfer → Platform re-broadcasts to human agents.
+
+2. WhatsAppHangupStrategy
+   Called by the Pipecat pipeline when the AI ends the call.
+   POSTs to /dograh-webhook/hangup → Platform calls Meta terminate API.
+"""
+
+from typing import Any, Dict
+
+import aiohttp
+from loguru import logger
+from pipecat.serializers.call_strategies import HangupStrategy, TransferStrategy
+
+
+class WhatsAppTransferStrategy(TransferStrategy):
+    """
+    Transfer the call from the AI to a human agent.
+
+    Sends a POST to the Platform's /dograh-webhook/transfer endpoint.
+    The Platform will:
+      1. Stop the Dograh bridge audio
+      2. Re-broadcast the call as a normal incoming call to online agents
+      3. Mark the call row with ai_transferred = 1
+    """
+
+    async def execute_transfer(self, context: Dict[str, Any]) -> bool:
+        platform_api_url = context.get("platform_api_url", "")
+        webhook_secret   = context.get("webhook_secret",   "")
+        wa_call_id       = context.get("wa_call_id") or context.get("call_id", "")
+        run_id           = context.get("workflow_run_id")
+        reason           = context.get("reason", "ai_requested")
+
+        if not platform_api_url or not wa_call_id:
+            logger.warning("[WhatsApp Transfer] Missing platform_api_url or wa_call_id — cannot transfer")
+            return False
+
+        url = platform_api_url.rstrip("/") + "/dograh-webhook/transfer"
+        body = {
+            "wa_call_id": wa_call_id,
+            "run_id":     run_id,
+            "reason":     reason,
+        }
+
+        logger.info(f"[WhatsApp Transfer] Transferring {wa_call_id} to human agents")
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url,
+                    json=body,
+                    headers={
+                        "X-Dograh-Key":  webhook_secret,
+                        "Content-Type":  "application/json",
+                    },
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    ok = resp.ok
+                    if not ok:
+                        text = await resp.text()
+                        logger.error(f"[WhatsApp Transfer] HTTP {resp.status}: {text[:200]}")
+                    return ok
+        except Exception as exc:
+            logger.error(f"[WhatsApp Transfer] Request failed: {exc}")
+            return False
+
+
+class WhatsAppHangupStrategy(HangupStrategy):
+    """
+    End the call from the AI side.
+
+    Sends a POST to /dograh-webhook/hangup.
+    The Platform will call Meta's terminate API.
+    """
+
+    async def execute_hangup(self, context: Dict[str, Any]) -> bool:
+        platform_api_url = context.get("platform_api_url", "")
+        webhook_secret   = context.get("webhook_secret",   "")
+        wa_call_id       = context.get("wa_call_id") or context.get("call_id", "")
+        run_id           = context.get("workflow_run_id")
+
+        if not platform_api_url or not wa_call_id:
+            logger.warning("[WhatsApp Hangup] Missing platform_api_url or wa_call_id — cannot hang up")
+            return False
+
+        url = platform_api_url.rstrip("/") + "/dograh-webhook/hangup"
+        body = {"wa_call_id": wa_call_id, "run_id": run_id}
+
+        logger.info(f"[WhatsApp Hangup] Hanging up {wa_call_id}")
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url,
+                    json=body,
+                    headers={
+                        "X-Dograh-Key":  webhook_secret,
+                        "Content-Type":  "application/json",
+                    },
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    ok = resp.ok
+                    if not ok:
+                        text = await resp.text()
+                        logger.error(f"[WhatsApp Hangup] HTTP {resp.status}: {text[:200]}")
+                    return ok
+        except Exception as exc:
+            logger.error(f"[WhatsApp Hangup] Request failed: {exc}")
+            return False

--- a/api/services/telephony/providers/whatsapp_platform/transport.py
+++ b/api/services/telephony/providers/whatsapp_platform/transport.py
@@ -5,6 +5,7 @@ from the WhatsApp bridge. The bridge connects directly to Dograh's
 /api/v1/audio-stream/{run_id} WebSocket endpoint.
 """
 
+from typing import Any
 from fastapi import WebSocket
 
 from api.services.pipecat.audio_config import AudioConfig
@@ -27,7 +28,8 @@ async def create_transport(
     organization_id: int,
     *,
     ambient_noise_config: dict | None = None,
-    telephony_configuration_id: int,
+    telephony_configuration_id: int | None = None,
+    **kwargs: Any,
 ) -> FastAPIWebsocketTransport:
     """
     Build a Pipecat FastAPIWebsocketTransport for the WhatsApp bridge.
@@ -43,8 +45,9 @@ async def create_transport(
 
     # Load provider credentials (platform_api_url, webhook_secret)
     credentials = await load_credentials_for_transport(
-        telephony_configuration_id=telephony_configuration_id,
         organization_id=organization_id,
+        telephony_configuration_id=telephony_configuration_id,
+        expected_provider="whatsapp_platform",
     )
 
     platform_api_url = credentials.get("platform_api_url", "")
@@ -62,7 +65,7 @@ async def create_transport(
     }
 
     audio_out_mixer = await build_audio_out_mixer(
-        audio_config=audio_config,
+        audio_out_sample_rate=WhatsAppPlatformFrameSerializer.SAMPLE_RATE,
         ambient_noise_config=ambient_noise_config,
     )
 
@@ -70,8 +73,6 @@ async def create_transport(
         audio_in_enabled=True,
         audio_out_enabled=True,
         add_wav_header=False,          # raw PCM — no WAV header
-        vad_enabled=True,
-        vad_analyzer=audio_config.vad_analyzer,
         audio_out_sample_rate=WhatsAppPlatformFrameSerializer.SAMPLE_RATE,
         audio_in_sample_rate=WhatsAppPlatformFrameSerializer.SAMPLE_RATE,
         serializer=serializer,
@@ -80,7 +81,7 @@ async def create_transport(
         hangup_strategy=WhatsAppHangupStrategy(),
         transfer_context=strategy_context,
         hangup_context=strategy_context,
-        **realtime_param_overrides(audio_config),
+        **realtime_param_overrides(kwargs.get("is_realtime", False)),
     )
 
     return FastAPIWebsocketTransport(websocket=websocket, params=params)

--- a/api/services/telephony/providers/whatsapp_platform/transport.py
+++ b/api/services/telephony/providers/whatsapp_platform/transport.py
@@ -1,0 +1,86 @@
+"""WhatsApp Platform transport factory.
+
+Creates a FastAPIWebsocketTransport configured for raw 16kHz PCM audio
+from the WhatsApp bridge. The bridge connects directly to Dograh's
+/api/v1/audio-stream/{run_id} WebSocket endpoint.
+"""
+
+from fastapi import WebSocket
+
+from api.services.pipecat.audio_config import AudioConfig
+from api.services.pipecat.audio_mixer import build_audio_out_mixer
+from api.services.pipecat.transport_params import realtime_param_overrides
+from api.services.telephony.factory import load_credentials_for_transport
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
+
+from .serializers import WhatsAppPlatformFrameSerializer
+from .strategies import WhatsAppHangupStrategy, WhatsAppTransferStrategy
+
+
+async def create_transport(
+    websocket: WebSocket,
+    workflow_run_id: int,
+    audio_config: AudioConfig,
+    organization_id: int,
+    *,
+    ambient_noise_config: dict | None = None,
+    telephony_configuration_id: int,
+) -> FastAPIWebsocketTransport:
+    """
+    Build a Pipecat FastAPIWebsocketTransport for the WhatsApp bridge.
+
+    The bridge (Node.js dograh-bridge.js) will:
+      1. Open a WebSocket to /api/v1/audio-stream/{run_id}
+      2. Send 16kHz mono PCM (customer mic audio) as binary frames
+      3. Receive 16kHz mono PCM (TTS audio) as binary frames
+
+    Audio parameters are intentionally fixed at 16kHz mono to match
+    what the bridge resamples to — no negotiation needed.
+    """
+
+    # Load provider credentials (platform_api_url, webhook_secret)
+    credentials = await load_credentials_for_transport(
+        telephony_configuration_id=telephony_configuration_id,
+        organization_id=organization_id,
+    )
+
+    platform_api_url = credentials.get("platform_api_url", "")
+    webhook_secret   = credentials.get("webhook_secret", "")
+
+    # Build the serializer — raw binary PCM, no framing
+    serializer = WhatsAppPlatformFrameSerializer()
+
+    # Strategy context passed to transfer/hangup at runtime
+    strategy_context = {
+        "platform_api_url": platform_api_url,
+        "webhook_secret":   webhook_secret,
+        "workflow_run_id":  workflow_run_id,
+        # wa_call_id is injected at runtime from the run's initial_context
+    }
+
+    audio_out_mixer = await build_audio_out_mixer(
+        audio_config=audio_config,
+        ambient_noise_config=ambient_noise_config,
+    )
+
+    params = FastAPIWebsocketParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        add_wav_header=False,          # raw PCM — no WAV header
+        vad_enabled=True,
+        vad_analyzer=audio_config.vad_analyzer,
+        audio_out_sample_rate=WhatsAppPlatformFrameSerializer.SAMPLE_RATE,
+        audio_in_sample_rate=WhatsAppPlatformFrameSerializer.SAMPLE_RATE,
+        serializer=serializer,
+        audio_out_mixer=audio_out_mixer,
+        transfer_strategy=WhatsAppTransferStrategy(),
+        hangup_strategy=WhatsAppHangupStrategy(),
+        transfer_context=strategy_context,
+        hangup_context=strategy_context,
+        **realtime_param_overrides(audio_config),
+    )
+
+    return FastAPIWebsocketTransport(websocket=websocket, params=params)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,10 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: api/Dockerfile
+
+  ui:
+    build:
+      context: .
+      dockerfile: ui/Dockerfile

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: api/Dockerfile
+    volumes:
+      - ./api:/app/api
 
   ui:
     build:


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a new `whatsapp_platform` telephony provider to receive inbound WhatsApp calls via an external bridge streaming 16kHz PCM over WebSocket. Includes config, transport, serializer, and transfer/hangup callbacks to control calls through the Platform API.

- **New Features**
  - Provider `whatsapp_platform` with UI/config (`platform_api_url`, `webhook_secret`) and registry wiring.
  - 16kHz mono PCM WebSocket transport with a raw-frame serializer; no WAV header.
  - Transfer and hangup strategies POST to `/dograh-webhook/transfer` and `/dograh-webhook/hangup` using `X-Dograh-Key`.
  - Post-call callbacks POST to `/dograh-webhook/call-ended` for recordings and transcripts.
  - Inbound-only; outbound call initiation is not supported.

- **Migration**
  - Create a telephony configuration for `whatsapp_platform` and set `platform_api_url` and a strong `webhook_secret`.
  - Configure the bridge to connect to `/api/v1/audio-stream/{run_id}` and send `X-Dograh-Key` with the same secret.
  - Ensure the run’s initial context includes `wa_call_id`, `caller_phone`, and `to_number`.

<sup>Written for commit c983b86c6f655417840c6a9b4c0c0f7193ba5446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new WhatsApp Platform telephony provider. The main changes are:

- Provider registration and telephony config schema support for `whatsapp_platform`.
- A raw 16 kHz PCM WebSocket transport for inbound WhatsApp bridge audio.
- Transfer, hangup, recording, and transcript callbacks to the WhatsApp Platform backend.
- Local Docker Compose build overrides for the API and UI services.

<h3>Confidence Score: 3/5</h3>

These issues need to be fixed before merging.

The new provider has two blocking bugs: one exposes a stored webhook secret, and one can resolve the wrong telephony credentials or fail when the org default provider differs.

`api/services/telephony/providers/whatsapp_platform/__init__.py`; `api/services/telephony/providers/whatsapp_platform/provider.py`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Wrote a Python helper script to exercise provider metadata and masking behavior for the WhatsApp platform, using a sentinel webhook\_secret.
- The first execution was blocked by a missing loguru dependency, and api/requirements.txt was installed to enable progress.
- Later executions reached import-time Pipecat dependency issues and I started stubbing the missing optional module before the step limit was reached.
- Tried a Python service-boundary repro to verify config selection, but imports were blocked by missing or stubbed backend dependencies and the run hit the maximum tool-step limit.
- A pytest harness was generated to assert high-value provider behaviors, and the final run reported two tests passed with exit code 0.

<a href="https://app.greptile.com/trex/runs/13440653/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/schemas/telephony_config.py | Adds WhatsApp Platform request and response schemas to the telephony configuration union and aggregate response. |
| api/services/telephony/providers/whatsapp_platform/__init__.py | Registers provider metadata and UI fields, but the webhook secret field is not marked sensitive. |
| api/services/telephony/providers/whatsapp_platform/provider.py | Adds inbound-only provider behavior and platform callbacks, but agent-stream handling loses run-scoped configuration selection. |
| api/services/telephony/providers/whatsapp_platform/transport.py | Creates a FastAPI WebSocket transport using registry-loaded credentials, raw PCM serializer, mixer, and call strategies. |
| docker-compose.override.yml | Adds local Docker Compose build overrides for API and UI services. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Customer as WhatsApp Caller
participant Platform as WhatsApp Platform Backend
participant AgentStream as Dograh /agent-stream
participant Provider as WhatsAppPlatformProvider
participant Pipeline as Pipecat Pipeline
participant Callback as Platform Webhooks

Customer->>Platform: Starts WhatsApp call
Platform->>AgentStream: WebSocket with provider and call params
AgentStream->>Provider: handle_external_websocket(...)
Provider->>Pipeline: run_pipeline_telephony(call_id, transport_kwargs)
Platform-->>Pipeline: 16 kHz PCM audio frames
Pipeline-->>Platform: 16 kHz PCM TTS frames
Pipeline->>Callback: POST /dograh-webhook/transfer or /hangup or /call-ended
Callback-->>Customer: Transfer, terminate, or persist call outcome
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Customer as WhatsApp Caller
participant Platform as WhatsApp Platform Backend
participant AgentStream as Dograh /agent-stream
participant Provider as WhatsAppPlatformProvider
participant Pipeline as Pipecat Pipeline
participant Callback as Platform Webhooks

Customer->>Platform: Starts WhatsApp call
Platform->>AgentStream: WebSocket with provider and call params
AgentStream->>Provider: handle_external_websocket(...)
Provider->>Pipeline: run_pipeline_telephony(call_id, transport_kwargs)
Platform-->>Pipeline: 16 kHz PCM audio frames
Pipeline-->>Platform: 16 kHz PCM TTS frames
Pipeline->>Callback: POST /dograh-webhook/transfer or /hangup or /call-ended
Callback-->>Customer: Transfer, terminate, or persist call outcome
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Add WhatsApp Platform telephony provider..."](https://github.com/dograh-hq/dograh/commit/c983b86c6f655417840c6a9b4c0c0f7193ba5446) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42163333)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - api/services/telephony/providers/AGENTS.md ([source](https://app.greptile.com/dograh-hq/github/dograh-hq/dograh/-/custom-context?memory=f40b93ad-475b-4a76-9687-19ab74c6ec29))
- Context used - api/services/telephony/AGENTS.md ([source](https://app.greptile.com/dograh-hq/github/dograh-hq/dograh/-/custom-context?memory=5ba24b5a-a47b-4a9f-815f-2697e7295e4b))

<!-- /greptile_comment -->