### PR TITLE
fix(auth): allow invited org members to start workflow runs

### DIFF
--- a/api/db/organization_client.py
+++ b/api/db/organization_client.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 
+from sqlalchemy import exists
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.future import select
 
@@ -90,6 +91,21 @@ class OrganizationClient(BaseDBClient):
                 await session.refresh(organization)
                 return organization, was_created
             return organization, False
+
+    async def is_user_member_of_organization(
+        self, user_id: int, organization_id: int
+    ) -> bool:
+        """Return True if the user belongs to the given organization."""
+        async with self.async_session() as session:
+            result = await session.execute(
+                select(
+                    exists().where(
+                        (organization_users_association.c.user_id == user_id)
+                        & (organization_users_association.c.organization_id == organization_id)
+                    )
+                )
+            )
+            return bool(result.scalar())
 
     async def add_user_to_organization(
         self, user_id: int, organization_id: int

--- a/api/services/quota_service.py
+++ b/api/services/quota_service.py
@@ -357,10 +357,24 @@ async def authorize_workflow_run_start(
 
         actor_id = getattr(actor_user, "id", None)
         if actor_id is not None and workflow.organization_id is not None:
-            is_member = await db_client.is_user_member_of_organization(
-                user_id=actor_id,
-                organization_id=workflow.organization_id,
-            )
+            try:
+                is_member = await db_client.is_user_member_of_organization(
+                    user_id=actor_id,
+                    organization_id=workflow.organization_id,
+                )
+            except Exception as e:
+                logger.error(
+                    "Workflow start authorization denied: failed to validate actor {} membership for workflow {} org {}: {}",
+                    actor_id,
+                    workflow_id,
+                    workflow.organization_id,
+                    e,
+                )
+                return QuotaCheckResult(
+                    has_quota=False,
+                    error_code="workflow_not_found",
+                    error_message="Workflow not found",
+                )
             if not is_member:
                 logger.warning(
                     "Workflow start authorization denied: actor {} is not a member of workflow {} org {}",

--- a/api/services/quota_service.py
+++ b/api/services/quota_service.py
@@ -356,7 +356,7 @@ async def authorize_workflow_run_start(
             )
 
         actor_id = getattr(actor_user, "id", None)
-        if actor_id is not None:
+        if actor_id is not None and workflow.organization_id is not None:
             is_member = await db_client.is_user_member_of_organization(
                 user_id=actor_id,
                 organization_id=workflow.organization_id,

--- a/api/services/quota_service.py
+++ b/api/services/quota_service.py
@@ -355,19 +355,24 @@ async def authorize_workflow_run_start(
                 error_message="Workflow not found",
             )
 
-        actor_org_id = getattr(actor_user, "selected_organization_id", None)
-        if actor_org_id is not None and actor_org_id != workflow.organization_id:
-            logger.warning(
-                "Workflow start authorization denied: actor org {} does not match workflow {} org {}",
-                actor_org_id,
-                workflow_id,
-                workflow.organization_id,
+        actor_id = getattr(actor_user, "id", None)
+        if actor_id is not None:
+            is_member = await db_client.is_user_member_of_organization(
+                user_id=actor_id,
+                organization_id=workflow.organization_id,
             )
-            return QuotaCheckResult(
-                has_quota=False,
-                error_code="workflow_not_found",
-                error_message="Workflow not found",
-            )
+            if not is_member:
+                logger.warning(
+                    "Workflow start authorization denied: actor {} is not a member of workflow {} org {}",
+                    actor_id,
+                    workflow_id,
+                    workflow.organization_id,
+                )
+                return QuotaCheckResult(
+                    has_quota=False,
+                    error_code="workflow_not_found",
+                    error_message="Workflow not found",
+                )
 
         workflow_owner = await db_client.get_user_by_id(workflow.user_id)
         if not workflow_owner:

--- a/api/tests/test_quota_service.py
+++ b/api/tests/test_quota_service.py
@@ -7,6 +7,7 @@ import pytest
 from api.services import quota_service
 from api.services.configuration.registry import ServiceProviders
 from api.services.managed_model_services import MPS_CORRELATION_ID_CONTEXT_KEY
+from api.services.quota_service import QuotaCheckResult
 
 
 def _dograh_config(
@@ -399,14 +400,51 @@ async def test_authorize_workflow_run_oss_uses_key_paths_not_workflow_org(
 
 
 @pytest.mark.asyncio
-async def test_authorize_workflow_run_rejects_actor_from_another_org(monkeypatch):
+async def test_authorize_workflow_run_rejects_actor_not_a_member(monkeypatch):
     monkeypatch.setattr(quota_service, "DEPLOYMENT_MODE", "saas")
     _patch_workflow_context(monkeypatch)
+    monkeypatch.setattr(
+        quota_service.db_client,
+        "is_user_member_of_organization",
+        AsyncMock(return_value=False),
+    )
 
     result = await quota_service.authorize_workflow_run_start(
         workflow_id=7,
-        actor_user=SimpleNamespace(selected_organization_id=999),
+        actor_user=SimpleNamespace(id=456, selected_organization_id=999),
     )
 
     assert result.has_quota is False
     assert result.error_code == "workflow_not_found"
+
+
+@pytest.mark.asyncio
+async def test_authorize_workflow_run_allows_invited_member(monkeypatch):
+    """User invited to an org can start workflows belonging to that org."""
+    monkeypatch.setattr(quota_service, "DEPLOYMENT_MODE", "saas")
+    _patch_workflow_context(monkeypatch)
+    monkeypatch.setattr(
+        quota_service.db_client,
+        "is_user_member_of_organization",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        quota_service,
+        "get_effective_ai_model_configuration_for_workflow",
+        AsyncMock(return_value=_byok_config()),
+    )
+    hosted_authorize = AsyncMock(return_value=QuotaCheckResult(has_quota=True))
+    monkeypatch.setattr(
+        quota_service,
+        "_authorize_hosted_workflow_run_start",
+        hosted_authorize,
+    )
+
+    # actor_user.selected_organization_id=999 differs from workflow.organization_id=42,
+    # but is_user_member_of_organization returns True so the run should be allowed.
+    result = await quota_service.authorize_workflow_run_start(
+        workflow_id=7,
+        actor_user=SimpleNamespace(id=456, selected_organization_id=999),
+    )
+
+    assert result.has_quota is True

--- a/api/tests/test_quota_service.py
+++ b/api/tests/test_quota_service.py
@@ -419,6 +419,26 @@ async def test_authorize_workflow_run_rejects_actor_not_a_member(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_authorize_workflow_run_membership_lookup_error_fails_closed(monkeypatch):
+    monkeypatch.setattr(quota_service, "DEPLOYMENT_MODE", "saas")
+    _patch_workflow_context(monkeypatch)
+    monkeypatch.setattr(
+        quota_service.db_client,
+        "is_user_member_of_organization",
+        AsyncMock(side_effect=RuntimeError("database unavailable")),
+    )
+
+    result = await quota_service.authorize_workflow_run_start(
+        workflow_id=7,
+        actor_user=SimpleNamespace(id=456, selected_organization_id=42),
+    )
+
+    assert result.has_quota is False
+    assert result.error_code == "workflow_not_found"
+    quota_service.db_client.get_user_by_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_authorize_workflow_run_allows_invited_member(monkeypatch):
     """User invited to an org can start workflows belonging to that org."""
     monkeypatch.setattr(quota_service, "DEPLOYMENT_MODE", "saas")

--- a/api/tests/test_quota_service.py
+++ b/api/tests/test_quota_service.py
@@ -448,3 +448,40 @@ async def test_authorize_workflow_run_allows_invited_member(monkeypatch):
     )
 
     assert result.has_quota is True
+
+
+@pytest.mark.asyncio
+async def test_authorize_workflow_run_allows_personal_workflow_with_actor(monkeypatch):
+    """Personal/legacy workflows (organization_id=None) bypass membership check."""
+    personal_workflow = SimpleNamespace(
+        id=7,
+        user_id=123,
+        organization_id=None,
+        workflow_configurations={"model_overrides": {}},
+    )
+    monkeypatch.setattr(quota_service, "DEPLOYMENT_MODE", "saas")
+    _patch_workflow_context(monkeypatch, workflow=personal_workflow)
+    is_member_mock = AsyncMock()
+    monkeypatch.setattr(
+        quota_service.db_client,
+        "is_user_member_of_organization",
+        is_member_mock,
+    )
+    monkeypatch.setattr(
+        quota_service,
+        "get_effective_ai_model_configuration_for_workflow",
+        AsyncMock(return_value=_byok_config()),
+    )
+    monkeypatch.setattr(
+        quota_service,
+        "_authorize_hosted_workflow_run_start",
+        AsyncMock(return_value=QuotaCheckResult(has_quota=True)),
+    )
+
+    result = await quota_service.authorize_workflow_run_start(
+        workflow_id=7,
+        actor_user=SimpleNamespace(id=456),
+    )
+
+    assert result.has_quota is True
+    is_member_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary

Users invited to an organization cannot start workflow runs belonging to that org. The `authorize_workflow_run_start` function compares `actor_user.selected_organization_id` against `workflow.organization_id` with a strict equality check. When user Y accepts an invite to Org A, their `selected_organization_id` is updated to Org A's id, but the gate still fires `workflow_not_found` in some scenarios.

The root issue is that identity comparison is the wrong policy. `api/AGENTS.md` states: "Whenever you read or write an organization-scoped field, you must filter or validate by `organization_id`." The correct invariant is membership, not identity.

## Root cause

`api/services/quota_service.py` lines 358-370 (before this fix):

```python
actor_org_id = getattr(actor_user, "selected_organization_id", None)
if actor_org_id is not None and actor_org_id != workflow.organization_id:
    return QuotaCheckResult(has_quota=False, error_code="workflow_not_found", ...)
```

This denies any actor whose `selected_organization_id` does not exactly match `workflow.organization_id`, which fails for invited users under certain token-resolution timing or when the request carries a stale selected-org value.

## Fix

- Added `is_user_member_of_organization(user_id, organization_id)` to `OrganizationClient` - a single `EXISTS` query against the `organization_users` association table. No lazy-load risk, no relationship traversal.
- Replaced the identity check with a membership lookup: deny only when `actor_user.id` is not in `organization_users` for `workflow.organization_id`. Error code stays `workflow_not_found` to avoid leaking existence information.

## Test coverage

- Renamed `test_authorize_workflow_run_rejects_actor_from_another_org` to `test_authorize_workflow_run_rejects_actor_not_a_member` and updated the mock to reflect the actual policy (membership lookup returns False).
- Added `test_authorize_workflow_run_allows_invited_member`: seeds `is_user_member_of_organization` returning True for a user whose `selected_organization_id` differs from `workflow.organization_id`, asserts `has_quota=True`.

```
api/tests/test_quota_service.py::test_authorize_workflow_run_rejects_actor_not_a_member PASSED
api/tests/test_quota_service.py::test_authorize_workflow_run_allows_invited_member PASSED
```

Note: `test_authorize_workflow_run_oss_exhausted_key_blocks_run` fails on `main` before this change (asserts `founders@dograh.com` in an error message that was updated to reference `app.dograh.com`). That failure is pre-existing and unrelated to this PR.

Closes #491

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow invited org members to start workflow runs by checking org membership instead of the selected org ID. Also bypass membership check for personal workflows and fail closed on membership lookup errors; fixes #491 and stops false "workflow_not_found" for valid users.

- **Bug Fixes**
  - Added OrganizationClient.is_user_member_of_organization (single EXISTS on the association table).
  - Updated authorize_workflow_run_start: validate membership for org-scoped workflows; bypass when organization_id is None; fail closed on lookup errors with "workflow_not_found".
  - Tests: renamed non-member rejection test; added passing tests for invited members, personal workflows, and fail-closed behavior.

<sup>Written for commit d363840bded1e48625218fcc13af1a7db97a633e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates workflow run authorization to use organization membership instead of the selected organization value. The main changes are:

- Adds `is_user_member_of_organization` for direct membership checks against the organization-user table.
- Uses membership validation before starting organization-scoped workflow runs.
- Keeps personal workflows with `organization_id=None` outside the membership check.
- Adds tests for invited members, non-members, personal workflows, and membership lookup failures.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow, fails closed on membership lookup errors, and follows the API organization-scoping guidance.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the contract by reviewing the proof that tests ran in the repository with dummy DATABASE\_URL and REDIS\_URL environment variables, and that Pytest exited with code 0 with a log listing the collected test names and a pass summary.

<a href="https://app.greptile.com/trex/runs/13682108/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/db/organization_client.py | Adds a direct async membership existence check on the organization-user association table. |
| api/services/quota_service.py | Replaces selected-organization identity authorization with organization membership validation before workflow run quota authorization. |
| api/tests/test_quota_service.py | Updates quota authorization tests for non-members, invited members, personal workflows, and membership lookup failures. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Caller
participant Quota as authorize_workflow_run_start
participant DB as db_client
participant MPS as MPS quota service

Caller->>Quota: workflow_id, optional actor_user
Quota->>DB: get_workflow_by_id(workflow_id)
DB-->>Quota: workflow
alt actor_user and workflow.organization_id exist
    Quota->>DB: is_user_member_of_organization(actor_id, organization_id)
    DB-->>Quota: membership result
    alt not a member or lookup fails
        Quota-->>Caller: workflow_not_found
    end
end
Quota->>DB: get_user_by_id(workflow.user_id)
DB-->>Quota: workflow owner
Quota->>Quota: resolve effective model configuration
alt hosted deployment
    Quota->>MPS: authorize_workflow_run_start(organization_id, config)
    MPS-->>Quota: quota result
else OSS deployment
    Quota->>MPS: validate service key / create correlation
    MPS-->>Quota: quota result
end
Quota-->>Caller: QuotaCheckResult
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Caller
participant Quota as authorize_workflow_run_start
participant DB as db_client
participant MPS as MPS quota service

Caller->>Quota: workflow_id, optional actor_user
Quota->>DB: get_workflow_by_id(workflow_id)
DB-->>Quota: workflow
alt actor_user and workflow.organization_id exist
    Quota->>DB: is_user_member_of_organization(actor_id, organization_id)
    DB-->>Quota: membership result
    alt not a member or lookup fails
        Quota-->>Caller: workflow_not_found
    end
end
Quota->>DB: get_user_by_id(workflow.user_id)
DB-->>Quota: workflow owner
Quota->>Quota: resolve effective model configuration
alt hosted deployment
    Quota->>MPS: authorize_workflow_run_start(organization_id, config)
    MPS-->>Quota: quota result
else OSS deployment
    Quota->>MPS: validate service key / create correlation
    MPS-->>Quota: quota result
end
Quota-->>Caller: QuotaCheckResult
```

</a>

<sub>Reviews (3): Last reviewed commit: ["fix(auth): fail closed on workflow membe..."](https://github.com/dograh-hq/dograh/commit/d363840bded1e48625218fcc13af1a7db97a633e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42499842)</sub>

<!-- /greptile_comment -->