### PR TITLE
fix(telephony): fix webhook signature validation behind TLS-terminating proxy

### DIFF
--- a/api/routes/telephony.py
+++ b/api/routes/telephony.py
@@ -39,6 +39,7 @@ from api.services.telephony.transfer_event_protocol import (
 )
 from api.utils.common import get_backend_endpoints
 from api.utils.telephony_helper import (
+    effective_public_url,
     generic_hangup_response,
     normalize_webhook_data,
     numbers_match,
@@ -754,7 +755,7 @@ async def handle_inbound_run(request: Request):
             telephony_configuration_id, config.organization_id
         )
         signature_valid = await provider_instance.verify_inbound_signature(
-            str(request.url), webhook_data, headers, raw_body
+            effective_public_url(request), webhook_data, headers, raw_body
         )
         if not signature_valid:
             logger.warning(

--- a/api/tests/telephony/test_inbound_run_url_reconstruction.py
+++ b/api/tests/telephony/test_inbound_run_url_reconstruction.py
@@ -1,0 +1,115 @@
+"""Tests for effective_public_url — the URL used for webhook signature verification.
+
+Behind a TLS-terminating proxy, request.url carries the internal http://
+scheme. Twilio and Vobiz sign the public https:// URL, so the HMAC never
+matches unless we reconstruct the canonical origin first.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from starlette.requests import Request
+from starlette.testclient import TestClient
+
+from api.utils.telephony_helper import effective_public_url
+
+
+def _make_request(
+    url: str,
+    headers: dict[str, str] | None = None,
+) -> Request:
+    """Build a minimal Starlette Request with the given URL and headers."""
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": parsed.path or "/",
+        "query_string": (parsed.query or "").encode(),
+        "headers": [
+            (k.lower().encode(), v.encode()) for k, v in (headers or {}).items()
+        ],
+        "server": (parsed.hostname, parsed.port or (443 if parsed.scheme == "https" else 80)),
+        "scheme": parsed.scheme,
+    }
+    return Request(scope)
+
+
+class TestEffectivePublicUrl:
+    def test_public_base_url_overrides_request_scheme(self):
+        """PUBLIC_BASE_URL env takes priority; internal http:// becomes https://."""
+        request = _make_request("http://internal:8000/telephony/inbound/run")
+        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", "https://prod.dograh.example"):
+            result = effective_public_url(request)
+        assert result == "https://prod.dograh.example/telephony/inbound/run"
+
+    def test_public_base_url_preserves_query_string(self):
+        request = _make_request("http://internal:8000/telephony/inbound/run?foo=bar&baz=1")
+        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", "https://prod.dograh.example"):
+            result = effective_public_url(request)
+        assert result == "https://prod.dograh.example/telephony/inbound/run?foo=bar&baz=1"
+
+    def test_public_base_url_strips_trailing_slash(self):
+        request = _make_request("http://internal:8000/telephony/inbound/run")
+        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", "https://prod.dograh.example/"):
+            result = effective_public_url(request)
+        assert result == "https://prod.dograh.example/telephony/inbound/run"
+
+    def test_forwarded_proto_upgrades_scheme_when_no_base_url(self):
+        """X-Forwarded-Proto: https upgrades scheme when PUBLIC_BASE_URL not set."""
+        request = _make_request(
+            "http://internal:8000/telephony/inbound/run",
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "myvoice.example.com",
+            },
+        )
+        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", None):
+            result = effective_public_url(request)
+        assert result == "https://myvoice.example.com/telephony/inbound/run"
+
+    def test_forwarded_proto_preserves_query_string(self):
+        request = _make_request(
+            "http://internal:8000/telephony/inbound/run?CallSid=CA123",
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "myvoice.example.com",
+            },
+        )
+        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", None):
+            result = effective_public_url(request)
+        assert result == "https://myvoice.example.com/telephony/inbound/run?CallSid=CA123"
+
+    def test_host_header_used_when_no_x_forwarded_host(self):
+        """Falls back to Host header if X-Forwarded-Host is absent."""
+        request = _make_request(
+            "http://internal:8000/telephony/inbound/run",
+            headers={
+                "x-forwarded-proto": "https",
+                "host": "myvoice.example.com",
+            },
+        )
+        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", None):
+            result = effective_public_url(request)
+        assert result == "https://myvoice.example.com/telephony/inbound/run"
+
+    def test_falls_back_to_request_url_without_proxy_headers(self):
+        """Local dev with no proxy: returns str(request.url) unchanged."""
+        request = _make_request("http://localhost:8000/telephony/inbound/run")
+        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", None):
+            result = effective_public_url(request)
+        assert result == "http://localhost:8000/telephony/inbound/run"
+
+    def test_public_base_url_takes_precedence_over_forwarded_headers(self):
+        """PUBLIC_BASE_URL wins even when X-Forwarded-Proto is present."""
+        request = _make_request(
+            "http://internal:8000/telephony/inbound/run",
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "other.example.com",
+            },
+        )
+        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", "https://canonical.example.com"):
+            result = effective_public_url(request)
+        assert result == "https://canonical.example.com/telephony/inbound/run"

--- a/api/tests/telephony/test_inbound_run_url_reconstruction.py
+++ b/api/tests/telephony/test_inbound_run_url_reconstruction.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 
 import pytest
 from starlette.requests import Request
-from starlette.testclient import TestClient
 
 from api.utils.telephony_helper import effective_public_url
 
@@ -37,27 +36,27 @@ def _make_request(
 
 
 class TestEffectivePublicUrl:
-    def test_public_base_url_overrides_request_scheme(self):
-        """PUBLIC_BASE_URL env takes priority; internal http:// becomes https://."""
+    def test_backend_endpoint_overrides_request_scheme(self):
+        """BACKEND_API_ENDPOINT takes priority; internal http:// becomes https://."""
         request = _make_request("http://internal:8000/telephony/inbound/run")
-        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", "https://prod.dograh.example"):
+        with patch("api.utils.telephony_helper.BACKEND_API_ENDPOINT", "https://prod.dograh.example"):
             result = effective_public_url(request)
         assert result == "https://prod.dograh.example/telephony/inbound/run"
 
-    def test_public_base_url_preserves_query_string(self):
+    def test_backend_endpoint_preserves_query_string(self):
         request = _make_request("http://internal:8000/telephony/inbound/run?foo=bar&baz=1")
-        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", "https://prod.dograh.example"):
+        with patch("api.utils.telephony_helper.BACKEND_API_ENDPOINT", "https://prod.dograh.example"):
             result = effective_public_url(request)
         assert result == "https://prod.dograh.example/telephony/inbound/run?foo=bar&baz=1"
 
-    def test_public_base_url_strips_trailing_slash(self):
+    def test_backend_endpoint_strips_trailing_slash(self):
         request = _make_request("http://internal:8000/telephony/inbound/run")
-        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", "https://prod.dograh.example/"):
+        with patch("api.utils.telephony_helper.BACKEND_API_ENDPOINT", "https://prod.dograh.example/"):
             result = effective_public_url(request)
         assert result == "https://prod.dograh.example/telephony/inbound/run"
 
-    def test_forwarded_proto_upgrades_scheme_when_no_base_url(self):
-        """X-Forwarded-Proto: https upgrades scheme when PUBLIC_BASE_URL not set."""
+    def test_forwarded_proto_upgrades_scheme_when_no_backend_endpoint(self):
+        """X-Forwarded-Proto: https upgrades scheme when BACKEND_API_ENDPOINT not set."""
         request = _make_request(
             "http://internal:8000/telephony/inbound/run",
             headers={
@@ -65,7 +64,7 @@ class TestEffectivePublicUrl:
                 "x-forwarded-host": "myvoice.example.com",
             },
         )
-        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", None):
+        with patch("api.utils.telephony_helper.BACKEND_API_ENDPOINT", None):
             result = effective_public_url(request)
         assert result == "https://myvoice.example.com/telephony/inbound/run"
 
@@ -77,7 +76,7 @@ class TestEffectivePublicUrl:
                 "x-forwarded-host": "myvoice.example.com",
             },
         )
-        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", None):
+        with patch("api.utils.telephony_helper.BACKEND_API_ENDPOINT", None):
             result = effective_public_url(request)
         assert result == "https://myvoice.example.com/telephony/inbound/run?CallSid=CA123"
 
@@ -90,19 +89,33 @@ class TestEffectivePublicUrl:
                 "host": "myvoice.example.com",
             },
         )
-        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", None):
+        with patch("api.utils.telephony_helper.BACKEND_API_ENDPOINT", None):
             result = effective_public_url(request)
         assert result == "https://myvoice.example.com/telephony/inbound/run"
 
     def test_falls_back_to_request_url_without_proxy_headers(self):
         """Local dev with no proxy: returns str(request.url) unchanged."""
         request = _make_request("http://localhost:8000/telephony/inbound/run")
-        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", None):
+        with patch("api.utils.telephony_helper.BACKEND_API_ENDPOINT", None):
             result = effective_public_url(request)
         assert result == "http://localhost:8000/telephony/inbound/run"
 
-    def test_public_base_url_takes_precedence_over_forwarded_headers(self):
-        """PUBLIC_BASE_URL wins even when X-Forwarded-Proto is present."""
+    def test_localhost_backend_endpoint_falls_through_to_proxy_headers(self):
+        """BACKEND_API_ENDPOINT=http://localhost:8000 (local dev default) is not used
+        for signature reconstruction; proxy headers take over when present."""
+        request = _make_request(
+            "http://internal:8000/telephony/inbound/run",
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "myvoice.example.com",
+            },
+        )
+        with patch("api.utils.telephony_helper.BACKEND_API_ENDPOINT", "http://localhost:8000"):
+            result = effective_public_url(request)
+        assert result == "https://myvoice.example.com/telephony/inbound/run"
+
+    def test_backend_endpoint_takes_precedence_over_forwarded_headers(self):
+        """BACKEND_API_ENDPOINT wins even when X-Forwarded-Proto is present."""
         request = _make_request(
             "http://internal:8000/telephony/inbound/run",
             headers={
@@ -110,6 +123,6 @@ class TestEffectivePublicUrl:
                 "x-forwarded-host": "other.example.com",
             },
         )
-        with patch("api.utils.telephony_helper.PUBLIC_BASE_URL", "https://canonical.example.com"):
+        with patch("api.utils.telephony_helper.BACKEND_API_ENDPOINT", "https://canonical.example.com"):
             result = effective_public_url(request)
         assert result == "https://canonical.example.com/telephony/inbound/run"

--- a/api/utils/telephony_helper.py
+++ b/api/utils/telephony_helper.py
@@ -9,7 +9,7 @@ from fastapi import Request
 from loguru import logger
 from starlette.responses import HTMLResponse
 
-from api.constants import COUNTRY_CODES
+from api.constants import COUNTRY_CODES, PUBLIC_BASE_URL
 
 
 def numbers_match(
@@ -187,3 +187,36 @@ def get_countries_for_code(dialing_code: str) -> list[str]:
         return []
 
     return [country for country, code in COUNTRY_CODES.items() if code == dialing_code]
+
+
+def effective_public_url(request: Request) -> str:
+    """Return the URL to use for webhook signature verification.
+
+    Behind a TLS-terminating proxy (nginx), request.url carries the internal
+    http:// scheme. Twilio and Vobiz sign the public https:// URL so the HMAC
+    never matches without this reconstruction. Priority order:
+
+    1. PUBLIC_BASE_URL env — deterministic operator-supplied canonical origin.
+    2. X-Forwarded-Proto + X-Forwarded-Host headers — set by the proxy.
+    3. str(request.url) — fallback for local dev without a proxy.
+
+    ponytail: X-Forwarded-Proto trust is only safe when the deployment nginx
+    sets it; PUBLIC_BASE_URL is the deterministic override.
+    """
+    if PUBLIC_BASE_URL:
+        base = PUBLIC_BASE_URL.rstrip("/")
+        path = request.url.path
+        qs = str(request.url.query)
+        return f"{base}{path}?{qs}" if qs else f"{base}{path}"
+
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    forwarded_host = (
+        request.headers.get("x-forwarded-host") or request.headers.get("host")
+    )
+    if forwarded_proto and forwarded_host:
+        path = request.url.path
+        qs = str(request.url.query)
+        base = f"{forwarded_proto}://{forwarded_host}"
+        return f"{base}{path}?{qs}" if qs else f"{base}{path}"
+
+    return str(request.url)

--- a/api/utils/telephony_helper.py
+++ b/api/utils/telephony_helper.py
@@ -9,7 +9,7 @@ from fastapi import Request
 from loguru import logger
 from starlette.responses import HTMLResponse
 
-from api.constants import COUNTRY_CODES, PUBLIC_BASE_URL
+from api.constants import BACKEND_API_ENDPOINT, COUNTRY_CODES
 
 
 def numbers_match(
@@ -196,15 +196,17 @@ def effective_public_url(request: Request) -> str:
     http:// scheme. Twilio and Vobiz sign the public https:// URL so the HMAC
     never matches without this reconstruction. Priority order:
 
-    1. PUBLIC_BASE_URL env — deterministic operator-supplied canonical origin.
+    1. BACKEND_API_ENDPOINT env — the public origin the backend is reachable at.
+       Derives from PUBLIC_BASE_URL when not set explicitly; covers split
+       deployments where the backend host differs from the UI/CDN origin.
     2. X-Forwarded-Proto + X-Forwarded-Host headers — set by the proxy.
     3. str(request.url) — fallback for local dev without a proxy.
 
-    ponytail: X-Forwarded-Proto trust is only safe when the deployment nginx
-    sets it; PUBLIC_BASE_URL is the deterministic override.
+    Note: X-Forwarded-Proto trust is only safe when the deployment nginx sets
+    it; BACKEND_API_ENDPOINT is the deterministic override.
     """
-    if PUBLIC_BASE_URL:
-        base = PUBLIC_BASE_URL.rstrip("/")
+    if BACKEND_API_ENDPOINT and not BACKEND_API_ENDPOINT.startswith("http://localhost"):
+        base = BACKEND_API_ENDPOINT.rstrip("/")
         path = request.url.path
         qs = str(request.url.query)
         return f"{base}{path}?{qs}" if qs else f"{base}{path}"


### PR DESCRIPTION
## Summary

Twilio and Vobiz sign the public `https://` webhook URL at configuration time. On self-hosted deployments behind nginx (TLS termination), Starlette's `request.url` returns the internal `http://` scheme after nginx strips TLS. The HMAC computed from that URL never matches, causing all inbound webhooks to fail signature validation.

Three independent reporters confirmed the bug on v1.32.x, with logs matching:

```
WARNING | provider.py:251 | Vobiz webhook signature mismatch. Expected: qXL/hBry... Got: TvkPvNy5...
WARNING | telephony.py:730 | /inbound/run: signature validation failed for twilio
```

`PUBLIC_BASE_URL` already existed in `api/constants.py` (added in #460 for the sslip.io helper) but was not used for signature URL reconstruction.

## Root cause

`api/routes/telephony.py` line 756-758 (before this fix):

```python
signature_valid = await provider_instance.verify_inbound_signature(
    str(request.url), webhook_data, headers, raw_body
)
```

`str(request.url)` returns the ASGI-layer URL, which is `http://` behind any TLS-terminating proxy. Neither provider's `verify_webhook_signature` can reconstruct the correct URL — they receive it as-is. The fix belongs at the route layer, not in the providers.

## Fix

Added `effective_public_url(request: Request) -> str` to `api/utils/telephony_helper.py` with three-level resolution:

1. `PUBLIC_BASE_URL` env var — deterministic, operator-supplied. Set this and signature verification works regardless of proxy configuration.
2. `X-Forwarded-Proto` + `X-Forwarded-Host` headers — set by nginx when configured. Safe for deployments where the proxy is trusted.
3. `str(request.url)` — unchanged fallback for local dev without a proxy.

Updated `handle_inbound_run()` in `api/routes/telephony.py` to pass `effective_public_url(request)` instead of `str(request.url)`.

## Test coverage

New file `api/tests/telephony/test_inbound_run_url_reconstruction.py` — 8 cases:

- `PUBLIC_BASE_URL` set: internal `http://` becomes `https://` canonical origin
- `PUBLIC_BASE_URL` with trailing slash: stripped correctly
- `PUBLIC_BASE_URL` with query string: preserved
- `X-Forwarded-Proto: https` + `X-Forwarded-Host`: scheme and host upgraded
- `X-Forwarded-Proto` + query string: preserved
- `Host` header fallback when `X-Forwarded-Host` absent
- No proxy headers: falls back to `str(request.url)`
- `PUBLIC_BASE_URL` takes precedence over forwarded headers

```
8 passed in 0.06s
```

## Operator upgrade path

Self-hosted deployers fix signature validation by adding one env var:

```bash
PUBLIC_BASE_URL=https://your-dograh-domain.example
```

No nginx config change required when using `PUBLIC_BASE_URL`. For deployers who prefer proxy-header-based resolution, ensure nginx sets `X-Forwarded-Proto` and `X-Forwarded-Host` (or `Host`).

Closes #374

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inbound webhook signature validation behind TLS-terminating proxies by reconstructing the public backend HTTPS URL before verifying Twilio and Vobiz signatures. Prevents false mismatches on self-hosted nginx and split-domain setups.

- **Bug Fixes**
  - Added `effective_public_url(request)` to resolve the signing URL in priority: `BACKEND_API_ENDPOINT` (if set and not localhost) → `X-Forwarded-Proto`/`X-Forwarded-Host` (or `Host`) → `request.url`.
  - Switched inbound handler to use the effective public URL for signature checks.
  - Preserves path and query string; trims trailing slash on `BACKEND_API_ENDPOINT`. Includes a localhost fall-through case.

- **Migration**
  - Recommended: set `BACKEND_API_ENDPOINT=https://api.your-domain.example` for deterministic validation (it cascades from `PUBLIC_BASE_URL` if unset).
  - If not using `BACKEND_API_ENDPOINT`, ensure the proxy sets `X-Forwarded-Proto` and `X-Forwarded-Host` (or `Host`).

<sup>Written for commit 50d0bea4ef77ce3712208da56bb878c6dd1e3054. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes inbound telephony webhook signature validation behind TLS-terminating proxies. The main changes are:

- Reconstructs the public webhook URL before provider signature checks.
- Prefers `BACKEND_API_ENDPOINT`/`PUBLIC_BASE_URL`, then forwarded proxy headers, then `request.url`.
- Preserves webhook path and query string during URL reconstruction.
- Adds focused tests for configured origins, forwarded headers, query strings, and fallback behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to the URL passed into existing provider signature validation. The helper preserves the existing local fallback path. Tests cover the main proxy and configured-origin cases.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the telephony URL reconstruction tests; the log shows 9 items collected, 9 passed, 3 warnings, and EXIT\_CODE: 0.
- Attempted route-level validation using the generated mock harness; the process failed due to ModuleNotFoundError: No module named 'pipecat.utils.run\_context' with EXIT\_CODE: 1.
- A generated narrow mock harness was prepared and used for the attempted route-level validation.

<a href="https://app.greptile.com/trex/runs/13603632/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/routes/telephony.py | Inbound telephony signature verification now passes the reconstructed public webhook URL into provider validation. |
| api/utils/telephony_helper.py | Adds `effective_public_url` to prefer configured public backend origin, then proxy headers, then the ASGI request URL while preserving path and query. |
| api/tests/telephony/test_inbound_run_url_reconstruction.py | Adds focused unit coverage for configured origins, proxy-header reconstruction, query preservation, and fallback behavior. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Provider as Twilio/Vobiz
participant Proxy as TLS-terminating proxy
participant Route as handle_inbound_run
participant Helper as effective_public_url
participant Verifier as Provider signature verifier

Provider->>Proxy: POST public https webhook URL
Proxy->>Route: Forward request over internal http
Route->>Helper: Build verification URL from request
alt BACKEND_API_ENDPOINT/PUBLIC_BASE_URL configured
    Helper-->>Route: configured origin + path/query
else Forwarded headers present
    Helper-->>Route: forwarded scheme/host + path/query
else Local fallback
    Helper-->>Route: str(request.url)
end
Route->>Verifier: verify_inbound_signature(effective URL, data, headers, body)
Verifier-->>Route: signature_valid
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Provider as Twilio/Vobiz
participant Proxy as TLS-terminating proxy
participant Route as handle_inbound_run
participant Helper as effective_public_url
participant Verifier as Provider signature verifier

Provider->>Proxy: POST public https webhook URL
Proxy->>Route: Forward request over internal http
Route->>Helper: Build verification URL from request
alt BACKEND_API_ENDPOINT/PUBLIC_BASE_URL configured
    Helper-->>Route: configured origin + path/query
else Forwarded headers present
    Helper-->>Route: forwarded scheme/host + path/query
else Local fallback
    Helper-->>Route: str(request.url)
end
Route->>Verifier: verify_inbound_signature(effective URL, data, headers, body)
Verifier-->>Route: signature_valid
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(telephony): use BACKEND\_API\_ENDPOINT..."](https://github.com/dograh-hq/dograh/commit/50d0bea4ef77ce3712208da56bb878c6dd1e3054) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42502053)</sub>

<!-- /greptile_comment -->