### PR TITLE
fix(llm): sanitize Gemini history to prevent tool-call turn-order violations

### DIFF
--- a/api/services/pipecat/gemini_history_sanitizer.py
+++ b/api/services/pipecat/gemini_history_sanitizer.py
@@ -1,0 +1,63 @@
+"""Sanitize Gemini message history to prevent turn-order violations.
+
+Vertex AI and Gemini reject completions where an assistant turn containing
+tool_calls is immediately followed by a user text turn instead of a tool
+response turn. This happens when a call is interrupted mid-tool execution.
+The sanitizer injects synthetic tool response messages so the sequence is
+always: assistant(tool_calls) -> tool(response) -> user(text).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _has_tool_calls(msg: Any) -> bool:
+    if not isinstance(msg, dict):
+        return False
+    return bool(msg.get("role") == "assistant" and msg.get("tool_calls"))
+
+
+def _is_tool_response(msg: Any) -> bool:
+    if not isinstance(msg, dict):
+        return False
+    return msg.get("role") == "tool"
+
+
+def sanitize_gemini_history(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return messages with synthetic tool responses injected where needed.
+
+    If an assistant turn with tool_calls is followed by a non-tool user turn,
+    inserts a synthetic tool response per pending call before the user turn.
+    Operates on the universal LLMContext dict format (role/content/tool_calls).
+    """
+    if not messages:
+        return messages
+
+    result: list[dict[str, Any]] = []
+    for i, msg in enumerate(messages):
+        result.append(msg)
+
+        if not _has_tool_calls(msg):
+            continue
+
+        next_msg = messages[i + 1] if i + 1 < len(messages) else None
+        if next_msg is None or _is_tool_response(next_msg):
+            continue
+
+        # Next turn is not a tool response — inject one synthetic response per call.
+        for tc in msg["tool_calls"]:
+            tc_id = tc.get("id", "")
+            name = tc.get("function", {}).get("name", "tool_call")
+            result.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc_id,
+                    "name": name,
+                    "content": "interrupted_by_user",
+                }
+            )
+
+    return result

--- a/api/services/pipecat/gemini_history_sanitizer.py
+++ b/api/services/pipecat/gemini_history_sanitizer.py
@@ -3,8 +3,8 @@
 Vertex AI and Gemini reject completions where an assistant turn containing
 tool_calls is immediately followed by a user text turn instead of a tool
 response turn. This happens when a call is interrupted mid-tool execution.
-The sanitizer injects synthetic tool response messages so the sequence is
-always: assistant(tool_calls) -> tool(response) -> user(text).
+The sanitizer injects synthetic tool response messages so every pending
+tool_call_id has a response before the next user text turn.
 """
 
 from __future__ import annotations
@@ -25,39 +25,59 @@ def _is_tool_response(msg: Any) -> bool:
 
 
 def sanitize_gemini_history(
-    messages: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
+    messages: list[Any],
+) -> list[Any]:
     """Return messages with synthetic tool responses injected where needed.
 
-    If an assistant turn with tool_calls is followed by a non-tool user turn,
-    inserts a synthetic tool response per pending call before the user turn.
+    For each assistant turn with tool_calls, walks the immediately following
+    tool response turns to collect which call IDs are already answered. Any
+    unanswered call IDs are injected as synthetic tool responses
+    (content: "interrupted_by_user") before the next non-tool turn.
+
+    Handles:
+    - Zero responses appended: inject all (fully interrupted)
+    - Some responses appended: inject only the missing ones (partially interrupted)
+    - All responses present: pass through unchanged
+
     Operates on the universal LLMContext dict format (role/content/tool_calls).
+    Non-dict messages (LLMSpecificMessage) pass through unchanged.
     """
     if not messages:
         return messages
 
-    result: list[dict[str, Any]] = []
-    for i, msg in enumerate(messages):
+    result: list[Any] = []
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
         result.append(msg)
+        i += 1
 
         if not _has_tool_calls(msg):
             continue
 
-        next_msg = messages[i + 1] if i + 1 < len(messages) else None
-        if next_msg is None or _is_tool_response(next_msg):
-            continue
+        # Collect IDs and names for all pending calls in this assistant turn.
+        pending: dict[str, str] = {
+            tc.get("id", ""): tc.get("function", {}).get("name", "tool_call")
+            for tc in msg["tool_calls"]
+        }
 
-        # Next turn is not a tool response — inject one synthetic response per call.
-        for tc in msg["tool_calls"]:
-            tc_id = tc.get("id", "")
-            name = tc.get("function", {}).get("name", "tool_call")
-            result.append(
-                {
-                    "role": "tool",
-                    "tool_call_id": tc_id,
-                    "name": name,
-                    "content": "interrupted_by_user",
-                }
-            )
+        # Consume consecutive tool response turns, tracking which IDs are answered.
+        answered: set[str] = set()
+        while i < len(messages) and _is_tool_response(messages[i]):
+            answered.add(messages[i].get("tool_call_id", ""))
+            result.append(messages[i])
+            i += 1
+
+        # Inject synthetics for any call IDs that have no response yet.
+        for call_id, name in pending.items():
+            if call_id not in answered:
+                result.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": call_id,
+                        "name": name,
+                        "content": "interrupted_by_user",
+                    }
+                )
 
     return result

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -11,6 +11,7 @@ from api.services.configuration.options import (
     DEEPGRAM_FLUX_MULTILINGUAL_LANGUAGE_OPTIONS,
 )
 from api.services.configuration.registry import ServiceProviders
+from api.services.pipecat.gemini_history_sanitizer import sanitize_gemini_history
 from api.services.pipecat.gemini_json_schema_adapter import (
     DograhGeminiJSONSchemaAdapter,
 )
@@ -120,9 +121,17 @@ def stt_uses_external_turns(user_config) -> bool:
 class DograhGoogleLLMService(GoogleLLMService):
     adapter_class = DograhGeminiJSONSchemaAdapter
 
+    async def _stream_content(self, context):
+        context.set_messages(sanitize_gemini_history(context.get_messages()))
+        return await super()._stream_content(context)
+
 
 class DograhGoogleVertexLLMService(GoogleVertexLLMService):
     adapter_class = DograhGeminiJSONSchemaAdapter
+
+    async def _stream_content(self, context):
+        context.set_messages(sanitize_gemini_history(context.get_messages()))
+        return await super()._stream_content(context)
 
 
 def _validate_runtime_service_url(url: str, field_name: str) -> None:

--- a/api/tests/test_gemini_history_sanitizer.py
+++ b/api/tests/test_gemini_history_sanitizer.py
@@ -98,6 +98,31 @@ def test_empty_messages():
     assert sanitize_gemini_history([]) == []
 
 
+def test_injects_missing_response_when_only_partial_tool_responses_appended():
+    """assistant(c1,c2) -> tool(c1) -> user: inject synthetic for c2 only."""
+    msgs = [
+        _user("go"),
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "c1", "function": {"name": "tool_a", "arguments": "{}"}},
+                {"id": "c2", "function": {"name": "tool_b", "arguments": "{}"}},
+            ],
+        },
+        _tool_response("tool_a", "c1"),
+        _user("interrupted"),
+    ]
+    result = sanitize_gemini_history(msgs)
+    # expect: user, assistant, tool(c1), tool(c2 synthetic), user
+    assert len(result) == 5
+    tool_ids = {m["tool_call_id"] for m in result if m.get("role") == "tool"}
+    assert tool_ids == {"c1", "c2"}
+    synthetic = next(m for m in result if m.get("tool_call_id") == "c2")
+    assert synthetic["content"] == "interrupted_by_user"
+    assert result[-1] == _user("interrupted")
+
+
 def test_does_not_mutate_input():
     msgs = [
         _assistant_tool_call("end_call", "c1"),

--- a/api/tests/test_gemini_history_sanitizer.py
+++ b/api/tests/test_gemini_history_sanitizer.py
@@ -1,0 +1,108 @@
+"""Tests for sanitize_gemini_history.
+
+Operates on the universal LLMContext dict format (role/content/tool_calls).
+No pipecat import required — the sanitizer is a pure dict transform.
+"""
+
+import pytest
+
+from api.services.pipecat.gemini_history_sanitizer import sanitize_gemini_history
+
+
+def _user(text: str) -> dict:
+    return {"role": "user", "content": text}
+
+
+def _assistant_text(text: str) -> dict:
+    return {"role": "assistant", "content": text}
+
+
+def _assistant_tool_call(name: str, call_id: str = "call_1") -> dict:
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{"id": call_id, "function": {"name": name, "arguments": "{}"}}],
+    }
+
+
+def _tool_response(name: str, call_id: str = "call_1") -> dict:
+    return {"role": "tool", "tool_call_id": call_id, "name": name, "content": "done"}
+
+
+def test_passthrough_when_no_tool_calls():
+    msgs = [_user("hello"), _assistant_text("hi")]
+    assert sanitize_gemini_history(msgs) == msgs
+
+
+def test_passthrough_when_tool_response_follows():
+    msgs = [
+        _user("run it"),
+        _assistant_tool_call("end_call"),
+        _tool_response("end_call"),
+        _user("thanks"),
+    ]
+    result = sanitize_gemini_history(msgs)
+    assert result == msgs
+
+
+def test_injects_synthetic_response_before_user_text():
+    msgs = [
+        _user("run it"),
+        _assistant_tool_call("end_call", "call_1"),
+        _user("interrupted"),
+    ]
+    result = sanitize_gemini_history(msgs)
+    assert len(result) == 4
+    assert result[2]["role"] == "tool"
+    assert result[2]["tool_call_id"] == "call_1"
+    assert result[2]["name"] == "end_call"
+    assert result[2]["content"] == "interrupted_by_user"
+    assert result[3] == _user("interrupted")
+
+
+def test_injects_multiple_responses_for_parallel_tool_calls():
+    msgs = [
+        _user("go"),
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "c1", "function": {"name": "tool_a", "arguments": "{}"}},
+                {"id": "c2", "function": {"name": "tool_b", "arguments": "{}"}},
+            ],
+        },
+        _user("interrupted"),
+    ]
+    result = sanitize_gemini_history(msgs)
+    assert len(result) == 5
+    assert result[2]["tool_call_id"] == "c1"
+    assert result[2]["name"] == "tool_a"
+    assert result[3]["tool_call_id"] == "c2"
+    assert result[3]["name"] == "tool_b"
+    assert result[4] == _user("interrupted")
+
+
+def test_handles_llm_specific_message_objects_passthrough():
+    """Non-dict messages (LLMSpecificMessage) pass through without error."""
+
+    class FakeSpecific:
+        pass
+
+    specific = FakeSpecific()
+    msgs = [_user("hi"), specific, _user("bye")]
+    result = sanitize_gemini_history(msgs)
+    assert result == msgs
+
+
+def test_empty_messages():
+    assert sanitize_gemini_history([]) == []
+
+
+def test_does_not_mutate_input():
+    msgs = [
+        _assistant_tool_call("end_call", "c1"),
+        _user("interrupted"),
+    ]
+    original_len = len(msgs)
+    sanitize_gemini_history(msgs)
+    assert len(msgs) == original_len


### PR DESCRIPTION
## Summary

Vertex AI and Gemini reject completions with `BadRequestError: function call turn comes immediately after a user turn or after a function response turn` when a call is interrupted mid-tool execution, leaving an assistant `tool_calls` turn immediately followed by a user text turn.

**Root cause**: pipecat's `GoogleLLMService._stream_content` passes the raw message history to the Gemini API. When a tool call is interrupted, no `tool` response is ever appended, so the sequence `assistant(tool_calls) -> user(text)` violates Gemini's strict turn ordering.

**Fix**: Override `_stream_content` in `DograhGoogleLLMService` and `DograhGoogleVertexLLMService` to run a sanitizer before delegating to the parent. The sanitizer (`api/services/pipecat/gemini_history_sanitizer.py`) operates on the universal `LLMContext` dict format and injects a synthetic `tool` response (`"interrupted_by_user"`) for each pending call when the next turn is not a tool response.

The fix stays entirely in Dograh's own tree — no pipecat submodule changes required.

## Repro

Configure a workflow with Vertex AI / Gemini + a node that fires tool calls (e.g. `end_call`). Trigger the tool, then interrupt mid-call. Pipeline crashes:

```
litellm.BadRequestError: function call turn comes immediately after a user turn or after a function response turn
```

## Changes

- `api/services/pipecat/gemini_history_sanitizer.py` — pure dict transform, no pipecat import, fully unit-testable
- `api/services/pipecat/service_factory.py` — `_stream_content` override on both Dograh Google services
- `api/tests/test_gemini_history_sanitizer.py` — 7 tests: passthrough, injection, parallel calls, LLMSpecificMessage passthrough, empty input, no mutation

## Test plan

- [ ] `python -m pytest api/tests/test_gemini_history_sanitizer.py -v` — all 7 pass
- [ ] Reproduce with Gemini/Vertex workflow + `end_call` tool + mid-call interruption — confirm no `BadRequestError`

**Note**: A durable upstream fix would patch `pipecat`'s Google service directly. Happy to follow up with a PR against `dograh-hq/pipecat` once this lands.

Closes #506

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes Gemini/Vertex message history to prevent turn-order errors when tool calls are interrupted, including partially answered parallel calls. Inserts synthetic tool responses for any unanswered `tool_calls` before streaming to avoid `litellm.BadRequestError`. Closes #506

- **Bug Fixes**
  - Added `sanitize_gemini_history` to inject `"interrupted_by_user"` tool responses only for missing call IDs by consuming consecutive tool turns (covers fully/partially interrupted and parallel calls).
  - Overrode `_stream_content` in `DograhGoogleLLMService` and `DograhGoogleVertexLLMService` to sanitize `LLMContext` messages before delegating, with no `pipecat` changes.
  - Added tests, including a partial-response regression case; preserves non-dict passthrough and input immutability.

<sup>Written for commit 5e2b910041b5b787dd5583e9b7afb160e65c26c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Gemini history sanitization before Google and Vertex LLM streaming. The main changes are:

- Adds a pure `sanitize_gemini_history` transform for `LLMContext` message dictionaries.
- Injects synthetic `tool` responses for unanswered Gemini tool calls after interruptions.
- Applies the sanitizer in Dograh's Google and Vertex LLM service overrides.
- Adds tests for passthrough, full injection, partial parallel tool responses, non-dict messages, empty input, and input list immutability.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to Gemini and Vertex context preparation, and the previous partial-response edge case is covered by tests.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex completed the requested verification and reported that local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/services/pipecat/gemini_history_sanitizer.py | Adds a pure message-history sanitizer that fills missing Gemini tool responses, including partial parallel tool-call responses. |
| api/services/pipecat/service_factory.py | Wraps Dograh Google and Vertex LLM streaming to sanitize context messages before delegating to pipecat. |
| api/tests/test_gemini_history_sanitizer.py | Covers passthrough, full and partial synthetic injection, parallel calls, non-dict messages, empty inputs, and input list immutability. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Caller as Pipeline/LLM caller
participant Service as Dograh Google/Vertex LLM Service
participant Sanitizer as sanitize_gemini_history
participant Pipecat as pipecat Google service
participant Gemini as Gemini/Vertex API

Caller->>Service: _stream_content(context)
Service->>Service: context.get_messages()
Service->>Sanitizer: sanitize_gemini_history(messages)
Sanitizer-->>Service: messages with synthetic tool responses for pending calls
Service->>Service: context.set_messages(sanitized)
Service->>Pipecat: super()._stream_content(context)
Pipecat->>Gemini: stream sanitized history
Gemini-->>Pipecat: completion stream
Pipecat-->>Service: stream result
Service-->>Caller: stream result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Caller as Pipeline/LLM caller
participant Service as Dograh Google/Vertex LLM Service
participant Sanitizer as sanitize_gemini_history
participant Pipecat as pipecat Google service
participant Gemini as Gemini/Vertex API

Caller->>Service: _stream_content(context)
Service->>Service: context.get_messages()
Service->>Sanitizer: sanitize_gemini_history(messages)
Sanitizer-->>Service: messages with synthetic tool responses for pending calls
Service->>Service: context.set_messages(sanitized)
Service->>Pipecat: super()._stream_content(context)
Pipecat->>Gemini: stream sanitized history
Gemini-->>Pipecat: completion stream
Pipecat-->>Service: stream result
Service-->>Caller: stream result
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(llm): handle partial tool responses ..."](https://github.com/dograh-hq/dograh/commit/5e2b910041b5b787dd5583e9b7afb160e65c26c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42529401)</sub>

<!-- /greptile_comment -->