### PR TITLE
Add MiniMax M3 model option

### DIFF
--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -534,6 +534,7 @@ class HuggingFaceLLMConfiguration(BaseLLMConfiguration):
 MINIMAX_MODELS = [
     "MiniMax-M2.7",
     "MiniMax-M2.7-highspeed",
+    "MiniMax-M3",
 ]
 
 


### PR DESCRIPTION
Reason: MiniMax provider 已原生接入(LLM+TTS),但建议型号目录 MINIMAX_MODELS 仅列 M2.7/M2.7-highspeed 缺 M3;

## Summary
- Add `MiniMax-M3` to the MiniMax LLM model suggestions.

## Checks
- `python3 -m compileall /root/octopatch-4/work/repos/dograh-hq_dograh/api/services/configuration/registry.py`
- `python3 -m pytest /root/octopatch-4/work/repos/dograh-hq_dograh/api/tests/test_minimax_service_factory.py` (not run: pytest is not installed in this environment)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MiniMax M3 to the MiniMax LLM model suggestions so users can select it now that the provider supports M3.

<sup>Written for commit e9901323c64ea0f1f64472c56534247bca125f67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new MiniMax model option to the configuration registry. The main change is:

- `MiniMax-M3` is added to the MiniMax LLM model suggestion list.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change only adds one model name to an examples list and does not alter validation, defaults, persistence, or runtime behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The minimax model validation run was executed and its full command transcript was captured in the log.
- A supplemental minimax model inspection script was created and its runtime output was appended to the main log.
- The validation scope was confirmed to exclude broad suites, Docker, and unrelated provider validations.

<a href="https://app.greptile.com/trex/runs/13672224/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/services/configuration/registry.py | Adds `MiniMax-M3` to the MiniMax LLM configuration example model list. |

<sub>Reviews (1): Last reviewed commit: ["Add MiniMax M3 model option"](https://github.com/dograh-hq/dograh/commit/e9901323c64ea0f1f64472c56534247bca125f67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42669549)</sub>

<!-- /greptile_comment -->