### PR TITLE
fix(web): honor X-Forwarded-Proto in uvicorn so request.url is https behind a reverse proxy

### DIFF
--- a/deploy/helm/dograh/templates/web-deployment.yaml
+++ b/deploy/helm/dograh/templates/web-deployment.yaml
@@ -52,6 +52,10 @@ spec:
           env:
             - name: WEB_PORT
               value: {{ .Values.web.port | quote }}
+            # Trust proxy headers from these peers so request.url reflects the
+            # original https scheme — see web.forwardedAllowIps in values.yaml.
+            - name: FORWARDED_ALLOW_IPS
+              value: {{ .Values.web.forwardedAllowIps | quote }}
             {{- include "dograh.dbEnv" . | nindent 12 }}
           # Distinct probes: readiness flips fast (drain), liveness is
           # slower (process aliveness).

--- a/deploy/helm/dograh/values.yaml
+++ b/deploy/helm/dograh/values.yaml
@@ -157,6 +157,16 @@ web:
   replicaCount: 2
   port: 8000
 
+  # Peers uvicorn trusts X-Forwarded-Proto / X-Forwarded-For from (exported
+  # as FORWARDED_ALLOW_IPS). The ingress proxy reaches the pod from a
+  # pod-network IP — not loopback — so uvicorn's 127.0.0.1 default ignores
+  # the headers, request.url reads back as http://, and telephony providers
+  # that sign their webhook URL (Vobiz, Twilio, Plivo) fail signature
+  # validation. "*" trusts every peer, which is fine while only the ingress
+  # can reach the pod; narrow to your proxy/pod CIDR (e.g. "10.42.0.0/16")
+  # if the pod is reachable from untrusted networks.
+  forwardedAllowIps: "*"
+
   # Long-lived signaling WebSockets keep per-connection state in process
   # memory (api/routes/webrtc_signaling.py). A naive pod restart drops every
   # in-flight call. The two settings below give the gateway time to stop

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -10,18 +10,14 @@ fi
 
 PORT="${WEB_PORT:-8000}"
 
-# --proxy-headers makes uvicorn honor X-Forwarded-Proto / X-Forwarded-For from
-# an upstream proxy (nginx, Traefik, ALB) so `request.url.scheme` reads back as
-# `https` inside the app — required for provider webhook signature checks that
-# hash the incoming URL.
-#
-# FORWARDED_ALLOW_IPS controls which peer IPs those headers are trusted from.
-# Default "*" trusts all peers, which is safe when the app is only reachable
-# via the proxy (the standard docker-compose and helm layouts). If uvicorn is
-# also directly reachable from an untrusted network, narrow this to the proxy
-# CIDR (e.g. FORWARDED_ALLOW_IPS="10.42.0.0/16") to prevent header spoofing.
-FORWARDED_ALLOW_IPS="${FORWARDED_ALLOW_IPS:-*}"
-
+# uvicorn enables proxy-header handling by default but only trusts
+# X-Forwarded-Proto / X-Forwarded-For from peers listed in the
+# FORWARDED_ALLOW_IPS env var (its built-in fallback when the
+# --forwarded-allow-ips flag is absent; defaults to 127.0.0.1). Behind a
+# reverse proxy that env var MUST be set, or request.url keeps the http
+# scheme and providers that sign their webhook URL (Vobiz, Twilio, Plivo)
+# fail signature validation. Each deployment declares it where its config
+# lives: docker-compose in the api service environment, helm via
+# web.forwardedAllowIps in values.yaml.
 cd "$BASE_DIR"
-exec uvicorn api.app:app --host 0.0.0.0 --port "$PORT" --workers 1 \
-  --proxy-headers --forwarded-allow-ips="$FORWARDED_ALLOW_IPS"
+exec uvicorn api.app:app --host 0.0.0.0 --port "$PORT" --workers 1

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -10,14 +10,9 @@ fi
 
 PORT="${WEB_PORT:-8000}"
 
-# uvicorn enables proxy-header handling by default but only trusts
-# X-Forwarded-Proto / X-Forwarded-For from peers listed in the
-# FORWARDED_ALLOW_IPS env var (its built-in fallback when the
-# --forwarded-allow-ips flag is absent; defaults to 127.0.0.1). Behind a
-# reverse proxy that env var MUST be set, or request.url keeps the http
-# scheme and providers that sign their webhook URL (Vobiz, Twilio, Plivo)
-# fail signature validation. Each deployment declares it where its config
-# lives: docker-compose in the api service environment, helm via
-# web.forwardedAllowIps in values.yaml.
+# uvicorn trusts X-Forwarded-Proto / X-Forwarded-For only from peers listed
+# in the FORWARDED_ALLOW_IPS env var (default 127.0.0.1). Behind a reverse
+# proxy it must be set (compose: api service env, helm: web.forwardedAllowIps)
+# or request.url stays http:// and URL-signed webhook validation fails.
 cd "$BASE_DIR"
 exec uvicorn api.app:app --host 0.0.0.0 --port "$PORT" --workers 1

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -10,6 +10,18 @@ fi
 
 PORT="${WEB_PORT:-8000}"
 
+# --proxy-headers makes uvicorn honor X-Forwarded-Proto / X-Forwarded-For from
+# an upstream proxy (nginx, Traefik, ALB) so `request.url.scheme` reads back as
+# `https` inside the app — required for provider webhook signature checks that
+# hash the incoming URL.
+#
+# FORWARDED_ALLOW_IPS controls which peer IPs those headers are trusted from.
+# Default "*" trusts all peers, which is safe when the app is only reachable
+# via the proxy (the standard docker-compose and helm layouts). If uvicorn is
+# also directly reachable from an untrusted network, narrow this to the proxy
+# CIDR (e.g. FORWARDED_ALLOW_IPS="10.42.0.0/16") to prevent header spoofing.
+FORWARDED_ALLOW_IPS="${FORWARDED_ALLOW_IPS:-*}"
+
 cd "$BASE_DIR"
 exec uvicorn api.app:app --host 0.0.0.0 --port "$PORT" --workers 1 \
-  --proxy-headers --forwarded-allow-ips="*"
+  --proxy-headers --forwarded-allow-ips="$FORWARDED_ALLOW_IPS"

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -11,4 +11,5 @@ fi
 PORT="${WEB_PORT:-8000}"
 
 cd "$BASE_DIR"
-exec uvicorn api.app:app --host 0.0.0.0 --port "$PORT" --workers 1
+exec uvicorn api.app:app --host 0.0.0.0 --port "$PORT" --workers 1 \
+  --proxy-headers --forwarded-allow-ips="*"


### PR DESCRIPTION
## Problem

When Dograh runs behind a TLS-terminating reverse proxy (Cloudflare → Traefik on Kubernetes, or nginx on the docker-compose install), the leg from the proxy to the app pod/container is plain HTTP. Uvicorn defaults to trusting `scope["scheme"]` from the socket, so `request.url.scheme` reads `http` inside the app even though the client dialed `https`.

That breaks any code path that hashes or echoes the incoming URL back to the caller. Concrete symptom seen in production: **Vobiz inbound webhook signatures fail with `signature validation failed for vobiz`** because Vobiz computes HMAC over the URL it dialed (`https://.../inbound/run`) while Dograh recomputes it as `http://...`. Log excerpt from the failing call:

```
WARNING | provider.py:251 | Vobiz webhook signature mismatch.
         Expected: daOpAZPm..., Got: 1+eW/RxE...
WARNING | telephony.py:760 | /inbound/run: signature validation failed for vobiz
INFO    | logging_config.py:41 | POST /api/v1/telephony/inbound/run 200
```

Twilio, Plivo, and any other provider that signs over the callback URL have the same failure mode when Dograh sits behind a proxy.

## Fix

uvicorn already enables proxy-header handling by default, and when the `--forwarded-allow-ips` CLI flag is absent it falls back to the **`FORWARDED_ALLOW_IPS` environment variable** (or `127.0.0.1` when that is also unset). The docker-compose install relies on exactly this: the api service sets `FORWARDED_ALLOW_IPS: "*"` in its environment and runs bare uvicorn. The helm chart set nothing, so the web pod trusted only loopback and ignored Traefik's `X-Forwarded-Proto`.

The fix is therefore pure configuration, declared where the chart's other deployment config lives (mirroring compose):

- `deploy/helm/dograh/values.yaml` — new `web.forwardedAllowIps` (default `"*"`; narrow to your proxy/pod CIDR, e.g. `"10.42.0.0/16"`, if the pod is reachable from untrusted networks)
- `deploy/helm/dograh/templates/web-deployment.yaml` — exports it as `FORWARDED_ALLOW_IPS` on the web container
- `scripts/run_web.sh` — stays deployment-agnostic: no CLI flags; a comment documents the env-var contract so the next reader knows why the variable matters

Verified end-to-end on a production k3s install (Traefik + Cloudflare edge → dograh-web pod): with `FORWARDED_ALLOW_IPS="*"` in the pod env, the very next Vobiz inbound webhook validated successfully and the call connected past the previous 11-second signature-failure hangup.

## Test plan

- [ ] Local: hit `https://<proxy-host>/api/v1/health` behind any reverse proxy, log `request.url` inside a handler, confirm scheme is `https`.
- [ ] Prod: place a real Vobiz/Twilio inbound call, confirm no `signature validation failed` warning and that the call proceeds past media-negotiation.
- [x] `helm lint` and `helm template` render `FORWARDED_ALLOW_IPS: "*"` on the web container.
- [ ] docker-compose / bare-VM installs are unaffected — they do not use `run_web.sh`, and compose already sets `FORWARDED_ALLOW_IPS` on the api service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Uvicorn proxy-header configuration for Helm web deployments. The main changes are:

- Adds `FORWARDED_ALLOW_IPS` to the Helm web container environment.
- Adds `web.forwardedAllowIps` to the Helm values file.
- Documents the env-var contract in `scripts/run_web.sh`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex reviewed the command transcript in trex-artifacts/pr515-helm-forwarded-allow-ips.log and confirmed that Helm is blocked on PATH while static Helm input checks and shell syntax checks passed.

<a href="https://app.greptile.com/trex/runs/14650407/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| deploy/helm/dograh/templates/web-deployment.yaml | Exports the Helm `web.forwardedAllowIps` value as `FORWARDED_ALLOW_IPS` for the web container. |
| deploy/helm/dograh/values.yaml | Adds the default `web.forwardedAllowIps` value and operator guidance for narrowing it. |
| scripts/run_web.sh | Documents that deployments should set `FORWARDED_ALLOW_IPS` when running behind a reverse proxy. |

<sub>Reviews (5): Last reviewed commit: ["simplify run\_web.sh comment"](https://github.com/dograh-hq/dograh/commit/3b092b7e3fe0a522d92dca8b4aa6c51c221f5d04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42889043)</sub>

<!-- /greptile_comment -->