### PR TITLE
fix(security): expire and rotate public download tokens (#329)

### DIFF
--- a/api/alembic/versions/ad8c170ada8f_add_public_access_token_expiry.py
+++ b/api/alembic/versions/ad8c170ada8f_add_public_access_token_expiry.py
@@ -1,0 +1,48 @@
+"""add public access token expiry
+
+Revision ID: ad8c170ada8f
+Revises: 00b0201ad918
+Create Date: 2026-07-12 20:01:51.572061
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from api.constants import PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS
+
+
+# revision identifiers, used by Alembic.
+revision: str = "ad8c170ada8f"
+down_revision: Union[str, None] = "00b0201ad918"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workflow_runs",
+        sa.Column(
+            "public_access_token_expires_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    # Backfill previously-permanent tokens with a finite lifetime tied to the
+    # run's age: runs older than the TTL are already expired, recent ones get a
+    # short grace window before their public links stop working.
+    op.execute(
+        sa.text(
+            "UPDATE workflow_runs "
+            "SET public_access_token_expires_at = "
+            "created_at + make_interval(days => :ttl) "
+            "WHERE public_access_token IS NOT NULL "
+            "AND public_access_token_expires_at IS NULL"
+        ).bindparams(ttl=PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workflow_runs", "public_access_token_expires_at")

--- a/api/constants.py
+++ b/api/constants.py
@@ -204,3 +204,9 @@ OSS_JWT_SECRET = os.getenv("OSS_JWT_SECRET", "change-me-in-production")
 OSS_JWT_EXPIRY_HOURS = int(os.getenv("OSS_JWT_EXPIRY_HOURS", "720"))  # 30 days
 
 TUNER_BASE_URL = os.getenv("TUNER_BASE_URL", "https://api.usetuner.ai")
+
+# Public artifact download tokens (recordings/transcripts) are bearer secrets
+# embedded in webhook payloads, emails and reports. They expire this many days
+# after they are minted; expired tokens are rejected at lookup and rotated on
+# the next authenticated regeneration.
+PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS = int(os.getenv("PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS", "30"))

--- a/api/constants.py
+++ b/api/constants.py
@@ -209,4 +209,8 @@ TUNER_BASE_URL = os.getenv("TUNER_BASE_URL", "https://api.usetuner.ai")
 # embedded in webhook payloads, emails and reports. They expire this many days
 # after they are minted; expired tokens are rejected at lookup and rotated on
 # the next authenticated regeneration.
-PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS = int(os.getenv("PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS", "30"))
+# Floor at 1 so a misconfigured env var (0 or negative) can't mint tokens that
+# expire at creation and immediately fail the freshness lookup.
+PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS = max(
+    1, int(os.getenv("PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS", "30"))
+)

--- a/api/db/campaign_client.py
+++ b/api/db/campaign_client.py
@@ -680,6 +680,8 @@ class CampaignClient(BaseDBClient):
                     WorkflowRunModel.cost_info,
                     WorkflowRunModel.usage_info,
                     WorkflowRunModel.public_access_token,
+                    WorkflowRunModel.recording_url,
+                    WorkflowRunModel.transcript_url,
                 )
                 .where(*conditions)
                 .order_by(WorkflowRunModel.created_at.desc())

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -563,6 +563,10 @@ class WorkflowRunModel(Base):
     queued_run_id = Column(Integer, ForeignKey("queued_runs.id"), nullable=True)
     queued_run = relationship("QueuedRunModel", foreign_keys=[queued_run_id])
     public_access_token = Column(String(36), nullable=True)
+    # When the public_access_token stops being valid. NULL means the token is
+    # treated as expired (legacy tokens minted before expiry existed), so a
+    # missing/NULL expiry never grants access.
+    public_access_token_expires_at = Column(DateTime(timezone=True), nullable=True)
     text_session = relationship(
         "WorkflowRunTextSessionModel",
         back_populates="workflow_run",

--- a/api/db/organization_usage_client.py
+++ b/api/db/organization_usage_client.py
@@ -271,6 +271,8 @@ class OrganizationUsageClient(BaseDBClient):
                     WorkflowRunModel.cost_info,
                     WorkflowRunModel.usage_info,
                     WorkflowRunModel.public_access_token,
+                    WorkflowRunModel.recording_url,
+                    WorkflowRunModel.transcript_url,
                 )
                 .join(WorkflowModel, WorkflowRunModel.workflow_id == WorkflowModel.id)
                 .where(

--- a/api/db/workflow_run_client.py
+++ b/api/db/workflow_run_client.py
@@ -1,10 +1,12 @@
 import uuid
+from datetime import UTC, datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy import func
 from sqlalchemy.future import select
 from sqlalchemy.orm import joinedload, selectinload
 
+from api.constants import PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS
 from api.db.base_client import BaseDBClient
 from api.db.filters import apply_workflow_run_filters, get_workflow_run_order_clause
 from api.db.models import (
@@ -445,7 +447,13 @@ class WorkflowRunClient(BaseDBClient):
             return workflow_run, organization_id
 
     async def ensure_public_access_token(self, workflow_run_id: int) -> Optional[str]:
-        """Generate a public access token if not exists, return existing if present (idempotent).
+        """Return a valid public access token for the run, rotating as needed.
+
+        A token is reused only while it is unexpired; a missing, NULL-expiry
+        (legacy) or expired token is rotated to a fresh token with a new expiry
+        ``PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS`` in the future. This keeps live
+        surfaces (run details, reports) working while giving every issued token
+        a finite lifetime.
 
         Args:
             workflow_run_id: The ID of the workflow run
@@ -461,13 +469,17 @@ class WorkflowRunClient(BaseDBClient):
             if not run:
                 return None
 
-            # Return existing token if present
-            if run.public_access_token:
+            # Reuse the existing token only while it is still valid.
+            now = datetime.now(UTC)
+            expires_at = run.public_access_token_expires_at
+            if run.public_access_token and expires_at is not None and expires_at > now:
                 return run.public_access_token
 
-            # Generate and persist new token
-            token = str(uuid.uuid4())
-            run.public_access_token = token
+            # Generate and persist a new token with a fresh expiry (rotation).
+            run.public_access_token = str(uuid.uuid4())
+            run.public_access_token_expires_at = now + timedelta(
+                days=PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS
+            )
 
             try:
                 await session.commit()
@@ -481,21 +493,63 @@ class WorkflowRunClient(BaseDBClient):
     async def get_workflow_run_by_public_token(
         self, token: str
     ) -> Optional[WorkflowRunModel]:
-        """Lookup workflow run by public access token.
+        """Lookup workflow run by a *valid* public access token.
+
+        Freshness is enforced here, at the single lookup chokepoint, so every
+        consumer of a public token rejects expired/legacy (NULL-expiry) tokens
+        consistently rather than treating token existence as authorization.
 
         Args:
             token: The public access token
 
         Returns:
-            The WorkflowRunModel if found, None otherwise
+            The WorkflowRunModel if the token exists and is unexpired, else None
         """
         async with self.async_session() as session:
             result = await session.execute(
                 select(WorkflowRunModel).where(
-                    WorkflowRunModel.public_access_token == token
+                    WorkflowRunModel.public_access_token == token,
+                    WorkflowRunModel.public_access_token_expires_at.isnot(None),
+                    WorkflowRunModel.public_access_token_expires_at > datetime.now(UTC),
                 )
             )
             return result.scalars().first()
+
+    async def revoke_public_access_token(
+        self, workflow_run_id: int, organization_id: int
+    ) -> bool:
+        """Revoke a run's public access token within the caller's organization.
+
+        Clears both the token and its expiry so any previously issued link stops
+        resolving immediately. Scoped by ``organization_id`` for tenant isolation
+        so one org cannot revoke another org's token.
+
+        Returns:
+            True if a matching run was found and updated, False otherwise.
+        """
+        async with self.async_session() as session:
+            result = await session.execute(
+                select(WorkflowRunModel)
+                .join(WorkflowRunModel.workflow)
+                .where(
+                    WorkflowRunModel.id == workflow_run_id,
+                    WorkflowModel.organization_id == organization_id,
+                )
+            )
+            run = result.scalars().first()
+            if not run:
+                return False
+
+            run.public_access_token = None
+            run.public_access_token_expires_at = None
+
+            try:
+                await session.commit()
+            except Exception as e:
+                await session.rollback()
+                raise e
+
+            return True
 
     async def get_workflow_run_by_call_id(
         self, call_id: str

--- a/api/db/workflow_run_client.py
+++ b/api/db/workflow_run_client.py
@@ -462,8 +462,13 @@ class WorkflowRunClient(BaseDBClient):
             The public access token string, or None if workflow run not found
         """
         async with self.async_session() as session:
+            # Lock the run row so a concurrent rotation and a revoke cannot
+            # interleave (lost update) and leave a valid token after a revoke
+            # reported success.
             result = await session.execute(
-                select(WorkflowRunModel).where(WorkflowRunModel.id == workflow_run_id)
+                select(WorkflowRunModel)
+                .where(WorkflowRunModel.id == workflow_run_id)
+                .with_for_update()
             )
             run = result.scalars().first()
             if not run:
@@ -516,25 +521,30 @@ class WorkflowRunClient(BaseDBClient):
             return result.scalars().first()
 
     async def revoke_public_access_token(
-        self, workflow_run_id: int, organization_id: int
+        self, workflow_run_id: int, workflow_id: int, organization_id: int
     ) -> bool:
         """Revoke a run's public access token within the caller's organization.
 
         Clears both the token and its expiry so any previously issued link stops
         resolving immediately. Scoped by ``organization_id`` for tenant isolation
-        so one org cannot revoke another org's token.
+        and by ``workflow_id`` so a nested-resource URL cannot target a run
+        belonging to a different workflow in the same organization.
 
         Returns:
             True if a matching run was found and updated, False otherwise.
         """
         async with self.async_session() as session:
+            # Lock the run row so a concurrent ensure_public_access_token
+            # rotation cannot re-mint a token after this revoke commits.
             result = await session.execute(
                 select(WorkflowRunModel)
                 .join(WorkflowRunModel.workflow)
                 .where(
                     WorkflowRunModel.id == workflow_run_id,
+                    WorkflowRunModel.workflow_id == workflow_id,
                     WorkflowModel.organization_id == organization_id,
                 )
+                .with_for_update(of=WorkflowRunModel)
             )
             run = result.scalars().first()
             if not run:

--- a/api/routes/organization_usage.py
+++ b/api/routes/organization_usage.py
@@ -410,18 +410,31 @@ async def get_usage_history(
 
         for run in runs:
             public_access_token = run.get("public_access_token")
+            has_user_recording = has_recording_track(run.get("extra"), "user")
+            has_bot_recording = has_recording_track(run.get("extra"), "bot")
+            # Refresh so the emitted URLs carry a current (unexpired) token,
+            # rotating/minting as needed; skip runs with nothing to download.
+            if (
+                run.get("recording_url")
+                or run.get("transcript_url")
+                or has_user_recording
+                or has_bot_recording
+            ):
+                public_access_token = await db_client.ensure_public_access_token(
+                    run["id"]
+                )
             run["transcript_public_url"] = artifact_url(
                 public_access_token, "transcript"
             )
             run["recording_public_url"] = artifact_url(public_access_token, "recording")
             run["user_recording_public_url"] = (
                 artifact_url(public_access_token, "user_recording")
-                if has_recording_track(run.get("extra"), "user")
+                if has_user_recording
                 else None
             )
             run["bot_recording_public_url"] = (
                 artifact_url(public_access_token, "bot_recording")
-                if has_recording_track(run.get("extra"), "bot")
+                if has_bot_recording
                 else None
             )
             run.pop("extra", None)

--- a/api/routes/workflow.py
+++ b/api/routes/workflow.py
@@ -1393,7 +1393,9 @@ async def revoke_workflow_run_public_token(
     fetched. Scoped to the caller's organization for tenant isolation.
     """
     revoked = await db_client.revoke_public_access_token(
-        run_id, organization_id=user.selected_organization_id
+        run_id,
+        workflow_id=workflow_id,
+        organization_id=user.selected_organization_id,
     )
     if not revoked:
         raise HTTPException(status_code=404, detail="Workflow run not found")

--- a/api/routes/workflow.py
+++ b/api/routes/workflow.py
@@ -1342,7 +1342,9 @@ async def get_workflow_run(
         or run.recording_url
         or has_user_recording
         or has_bot_recording
-    ) and not public_access_token:
+    ):
+        # ensure_* reuses a still-valid token and rotates a missing/expired one,
+        # so the returned links stay live even after a token has lapsed.
         public_access_token = await db_client.ensure_public_access_token(run.id)
 
     return {
@@ -1378,6 +1380,24 @@ async def get_workflow_run(
         "logs": run.logs,
         "annotations": run.annotations,
     }
+
+
+@router.delete("/{workflow_id}/runs/{run_id}/public-token")
+async def revoke_workflow_run_public_token(
+    workflow_id: int, run_id: int, user: UserModel = Depends(get_user)
+) -> dict:
+    """Revoke the public download token for a run, invalidating shared links.
+
+    Any previously distributed public link (webhook, email, report) stops
+    resolving immediately. A fresh token is minted the next time run details are
+    fetched. Scoped to the caller's organization for tenant isolation.
+    """
+    revoked = await db_client.revoke_public_access_token(
+        run_id, organization_id=user.selected_organization_id
+    )
+    if not revoked:
+        raise HTTPException(status_code=404, detail="Workflow run not found")
+    return {"revoked": True}
 
 
 class WorkflowRunsResponse(BaseModel):

--- a/api/services/reports/run_report.py
+++ b/api/services/reports/run_report.py
@@ -26,8 +26,23 @@ def _collect_extracted_variable_keys(runs: List[Any]) -> list[str]:
     return list(keys)
 
 
+async def _refresh_public_tokens(runs: List[Any]) -> None:
+    """Rotate/mint a valid public token for each run that has a downloadable
+    artifact, so the report's URLs point at fresh (unexpired) tokens rather than
+    stale or missing ones. Runs with no recording/transcript are skipped so we
+    don't mint public tokens for runs with nothing to expose.
+    """
+    for run in runs:
+        if run.recording_url or run.transcript_url:
+            run.public_access_token = await db_client.ensure_public_access_token(run.id)
+
+
 def build_run_report_csv(runs: List[Any]) -> io.StringIO:
-    """Build a CSV from completed workflow runs."""
+    """Build a CSV from completed workflow runs.
+
+    Callers should ``await _refresh_public_tokens(runs)`` first so the emitted
+    artifact URLs carry current (unexpired) tokens.
+    """
     extracted_var_keys = _collect_extracted_variable_keys(runs)
 
     output = io.StringIO()
@@ -96,6 +111,7 @@ async def generate_campaign_report_csv(
     runs = await db_client.get_completed_runs_for_report(
         campaign_id=campaign_id, start_date=start_date, end_date=end_date
     )
+    await _refresh_public_tokens(runs)
     return build_run_report_csv(runs), f"campaign_{campaign_id}_report.csv"
 
 
@@ -108,6 +124,7 @@ async def generate_workflow_report_csv(
     runs = await db_client.get_completed_runs_for_report(
         workflow_id=workflow_id, start_date=start_date, end_date=end_date
     )
+    await _refresh_public_tokens(runs)
     return build_run_report_csv(runs), f"workflow_{workflow_id}_report.csv"
 
 
@@ -127,5 +144,6 @@ async def generate_usage_runs_report_csv(
         end_date=end_date,
         filters=filters,
     )
+    await _refresh_public_tokens(runs)
     timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
     return build_run_report_csv(runs), f"usage_runs_{timestamp}.csv"

--- a/api/services/reports/run_report.py
+++ b/api/services/reports/run_report.py
@@ -26,23 +26,31 @@ def _collect_extracted_variable_keys(runs: List[Any]) -> list[str]:
     return list(keys)
 
 
-async def _refresh_public_tokens(runs: List[Any]) -> None:
-    """Rotate/mint a valid public token for each run that has a downloadable
-    artifact, so the report's URLs point at fresh (unexpired) tokens rather than
-    stale or missing ones. Runs with no recording/transcript are skipped so we
-    don't mint public tokens for runs with nothing to expose.
+async def _refresh_public_tokens(runs: List[Any]) -> dict[int, str]:
+    """Return ``{run_id: fresh_token}`` for runs with a downloadable artifact.
+
+    Report rows are immutable projected ``Row`` objects, so we return a mapping
+    rather than mutating them; ``build_run_report_csv`` applies it when emitting
+    URLs. Rotating/minting keeps the report's links on current (unexpired)
+    tokens; runs with no recording/transcript are skipped so we don't mint
+    public tokens for runs with nothing to expose.
     """
+    tokens: dict[int, str] = {}
     for run in runs:
         if run.recording_url or run.transcript_url:
-            run.public_access_token = await db_client.ensure_public_access_token(run.id)
+            tokens[run.id] = await db_client.ensure_public_access_token(run.id)
+    return tokens
 
 
-def build_run_report_csv(runs: List[Any]) -> io.StringIO:
+def build_run_report_csv(
+    runs: List[Any], public_tokens: Optional[dict[int, str]] = None
+) -> io.StringIO:
     """Build a CSV from completed workflow runs.
 
-    Callers should ``await _refresh_public_tokens(runs)`` first so the emitted
-    artifact URLs carry current (unexpired) tokens.
+    ``public_tokens`` (from ``_refresh_public_tokens``) overrides each run's
+    stored token so the emitted artifact URLs carry current (unexpired) tokens.
     """
+    public_tokens = public_tokens or {}
     extracted_var_keys = _collect_extracted_variable_keys(runs)
 
     output = io.StringIO()
@@ -90,10 +98,11 @@ def build_run_report_csv(runs: List[Any]) -> io.StringIO:
             extracted = {}
         extracted_values = [extracted.get(key, "") for key in extracted_var_keys]
 
+        token = public_tokens.get(run.id, run.public_access_token)
         post_values = [
             call_tags,
-            artifact_url(run.public_access_token, "transcript") or "",
-            artifact_url(run.public_access_token, "recording") or "",
+            artifact_url(token, "transcript") or "",
+            artifact_url(token, "recording") or "",
         ]
 
         writer.writerow(pre_values + extracted_values + post_values)
@@ -111,8 +120,10 @@ async def generate_campaign_report_csv(
     runs = await db_client.get_completed_runs_for_report(
         campaign_id=campaign_id, start_date=start_date, end_date=end_date
     )
-    await _refresh_public_tokens(runs)
-    return build_run_report_csv(runs), f"campaign_{campaign_id}_report.csv"
+    public_tokens = await _refresh_public_tokens(runs)
+    return build_run_report_csv(
+        runs, public_tokens
+    ), f"campaign_{campaign_id}_report.csv"
 
 
 async def generate_workflow_report_csv(
@@ -124,8 +135,10 @@ async def generate_workflow_report_csv(
     runs = await db_client.get_completed_runs_for_report(
         workflow_id=workflow_id, start_date=start_date, end_date=end_date
     )
-    await _refresh_public_tokens(runs)
-    return build_run_report_csv(runs), f"workflow_{workflow_id}_report.csv"
+    public_tokens = await _refresh_public_tokens(runs)
+    return build_run_report_csv(
+        runs, public_tokens
+    ), f"workflow_{workflow_id}_report.csv"
 
 
 async def generate_usage_runs_report_csv(
@@ -144,6 +157,6 @@ async def generate_usage_runs_report_csv(
         end_date=end_date,
         filters=filters,
     )
-    await _refresh_public_tokens(runs)
+    public_tokens = await _refresh_public_tokens(runs)
     timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
-    return build_run_report_csv(runs), f"usage_runs_{timestamp}.csv"
+    return build_run_report_csv(runs, public_tokens), f"usage_runs_{timestamp}.csv"

--- a/api/tests/test_public_download_token.py
+++ b/api/tests/test_public_download_token.py
@@ -209,6 +209,44 @@ class TestPublicTokenLifecycle:
         assert revoked is False
         assert await db_session.get_workflow_run_by_public_token(token) is not None
 
+    async def test_refresh_public_tokens_rotates_for_runs_with_artifacts(
+        self, db_session, async_session, seeded_run
+    ):
+        """Report/list surfaces refresh an expired token so their URLs stay valid."""
+        from api.services.reports.run_report import _refresh_public_tokens
+
+        run = await async_session.get(WorkflowRunModel, seeded_run.run.id)
+        run.recording_url = "recordings/run-1.wav"
+        run.public_access_token = "legacy-token"
+        run.public_access_token_expires_at = datetime.now(UTC) - timedelta(days=1)
+        await async_session.flush()
+
+        await _refresh_public_tokens([run])
+
+        assert run.public_access_token != "legacy-token"
+        # The refreshed token must resolve at the freshness-enforcing lookup.
+        assert (
+            await db_session.get_workflow_run_by_public_token(run.public_access_token)
+            is not None
+        )
+
+    async def test_refresh_public_tokens_skips_runs_without_artifacts(
+        self, db_session, async_session, seeded_run
+    ):
+        """A run with nothing downloadable must not get a public token minted."""
+        from api.services.reports.run_report import _refresh_public_tokens
+
+        run = await async_session.get(WorkflowRunModel, seeded_run.run.id)
+        run.recording_url = None
+        run.transcript_url = None
+        run.public_access_token = None
+        run.public_access_token_expires_at = None
+        await async_session.flush()
+
+        await _refresh_public_tokens([run])
+
+        assert run.public_access_token is None
+
 
 # ---------------------------------------------------------------------------
 # Route wiring (no database)

--- a/api/tests/test_public_download_token.py
+++ b/api/tests/test_public_download_token.py
@@ -1,0 +1,240 @@
+"""Tests for public download token expiry, rotation and revocation (issue #329).
+
+Two groups:
+
+- ``TestPublicTokenLifecycle`` — DB integration tests (transactional test
+  session) exercising the real SQL freshness filter, rotation and the
+  org-scoped revoke join.
+- The route-wiring tests at the bottom run without a database; they assert the
+  endpoints translate the DB-client results into the right HTTP behavior.
+"""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from api.db.models import (
+    OrganizationModel,
+    UserModel,
+    WorkflowRunModel,
+)
+
+GRAPH = {
+    "nodes": [
+        {"id": "1", "type": "startCall", "data": {"name": "Start", "prompt": "Hi"}},
+        {"id": "2", "type": "endCall", "data": {"name": "End", "prompt": "Bye"}},
+    ],
+    "edges": [{"id": "e1", "source": "1", "target": "2", "data": {"label": "End"}}],
+}
+
+
+# ---------------------------------------------------------------------------
+# DB integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def seeded_run(db_session, async_session):
+    """Create org → user → workflow → run in the transactional test session."""
+    org = OrganizationModel(provider_id="test-org-pubtoken")
+    async_session.add(org)
+    await async_session.flush()
+
+    user = UserModel(provider_id="test-user-pubtoken", selected_organization_id=org.id)
+    async_session.add(user)
+    await async_session.flush()
+
+    workflow = await db_session.create_workflow(
+        name="Token WF",
+        workflow_definition=GRAPH,
+        user_id=user.id,
+        organization_id=org.id,
+    )
+    run = await db_session.create_workflow_run(
+        name="run-1",
+        workflow_id=workflow.id,
+        mode="webrtc",
+        user_id=user.id,
+        organization_id=org.id,
+    )
+    return SimpleNamespace(org=org, user=user, workflow=workflow, run=run)
+
+
+async def _set_token(async_session, run_id, token, expires_at):
+    """Force a token/expiry onto a run to simulate legacy/expired state."""
+    run = await async_session.get(WorkflowRunModel, run_id)
+    run.public_access_token = token
+    run.public_access_token_expires_at = expires_at
+    await async_session.flush()
+
+
+async def _reload(async_session, run_id):
+    run = await async_session.get(WorkflowRunModel, run_id)
+    await async_session.refresh(run)
+    return run
+
+
+class TestPublicTokenLifecycle:
+    async def test_ensure_generates_token_with_future_expiry(
+        self, db_session, async_session, seeded_run
+    ):
+        token = await db_session.ensure_public_access_token(seeded_run.run.id)
+
+        assert token
+        run = await _reload(async_session, seeded_run.run.id)
+        assert run.public_access_token == token
+        assert run.public_access_token_expires_at > datetime.now(UTC)
+
+    async def test_ensure_reuses_valid_token(
+        self, db_session, async_session, seeded_run
+    ):
+        first = await db_session.ensure_public_access_token(seeded_run.run.id)
+        before = await _reload(async_session, seeded_run.run.id)
+        first_expiry = before.public_access_token_expires_at
+
+        second = await db_session.ensure_public_access_token(seeded_run.run.id)
+        after = await _reload(async_session, seeded_run.run.id)
+
+        assert second == first
+        assert after.public_access_token_expires_at == first_expiry
+
+    async def test_ensure_rotates_expired_token(
+        self, db_session, async_session, seeded_run
+    ):
+        first = await db_session.ensure_public_access_token(seeded_run.run.id)
+        await _set_token(
+            async_session,
+            seeded_run.run.id,
+            first,
+            datetime.now(UTC) - timedelta(days=1),
+        )
+
+        second = await db_session.ensure_public_access_token(seeded_run.run.id)
+
+        assert second != first
+        run = await _reload(async_session, seeded_run.run.id)
+        assert run.public_access_token_expires_at > datetime.now(UTC)
+
+    async def test_ensure_rotates_legacy_null_expiry_token(
+        self, db_session, async_session, seeded_run
+    ):
+        await _set_token(async_session, seeded_run.run.id, "legacy-token", None)
+
+        token = await db_session.ensure_public_access_token(seeded_run.run.id)
+
+        assert token != "legacy-token"
+        run = await _reload(async_session, seeded_run.run.id)
+        assert run.public_access_token_expires_at is not None
+
+    async def test_lookup_returns_run_for_valid_token(self, db_session, seeded_run):
+        token = await db_session.ensure_public_access_token(seeded_run.run.id)
+
+        found = await db_session.get_workflow_run_by_public_token(token)
+
+        assert found is not None
+        assert found.id == seeded_run.run.id
+
+    async def test_lookup_rejects_expired_token(
+        self, db_session, async_session, seeded_run
+    ):
+        token = await db_session.ensure_public_access_token(seeded_run.run.id)
+        await _set_token(
+            async_session,
+            seeded_run.run.id,
+            token,
+            datetime.now(UTC) - timedelta(seconds=1),
+        )
+
+        assert await db_session.get_workflow_run_by_public_token(token) is None
+
+    async def test_lookup_rejects_legacy_null_expiry_token(
+        self, db_session, async_session, seeded_run
+    ):
+        await _set_token(async_session, seeded_run.run.id, "legacy-token", None)
+
+        assert await db_session.get_workflow_run_by_public_token("legacy-token") is None
+
+    async def test_revoke_clears_token_and_blocks_lookup(
+        self, db_session, async_session, seeded_run
+    ):
+        token = await db_session.ensure_public_access_token(seeded_run.run.id)
+
+        revoked = await db_session.revoke_public_access_token(
+            seeded_run.run.id, organization_id=seeded_run.org.id
+        )
+
+        assert revoked is True
+        assert await db_session.get_workflow_run_by_public_token(token) is None
+        run = await _reload(async_session, seeded_run.run.id)
+        assert run.public_access_token is None
+        assert run.public_access_token_expires_at is None
+
+    async def test_revoke_is_org_scoped(self, db_session, seeded_run):
+        token = await db_session.ensure_public_access_token(seeded_run.run.id)
+
+        revoked = await db_session.revoke_public_access_token(
+            seeded_run.run.id, organization_id=seeded_run.org.id + 9999
+        )
+
+        assert revoked is False
+        # Token from another org must remain valid.
+        assert await db_session.get_workflow_run_by_public_token(token) is not None
+
+
+# ---------------------------------------------------------------------------
+# Route wiring (no database)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revoke_endpoint_success(monkeypatch):
+    from api.routes import workflow as workflow_route
+
+    revoke = AsyncMock(return_value=True)
+    monkeypatch.setattr(workflow_route.db_client, "revoke_public_access_token", revoke)
+    user = SimpleNamespace(selected_organization_id=42)
+
+    result = await workflow_route.revoke_workflow_run_public_token(7, 99, user=user)
+
+    assert result == {"revoked": True}
+    revoke.assert_awaited_once_with(99, organization_id=42)
+
+
+@pytest.mark.asyncio
+async def test_revoke_endpoint_404_for_other_org(monkeypatch):
+    from api.routes import workflow as workflow_route
+
+    monkeypatch.setattr(
+        workflow_route.db_client,
+        "revoke_public_access_token",
+        AsyncMock(return_value=False),
+    )
+    user = SimpleNamespace(selected_organization_id=42)
+
+    with pytest.raises(HTTPException) as exc:
+        await workflow_route.revoke_workflow_run_public_token(7, 99, user=user)
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_download_rejects_expired_or_missing_token(monkeypatch):
+    from api.routes import public_download
+
+    # An expired/legacy token resolves to no run at the freshness-enforcing
+    # lookup, so the endpoint must 404 rather than mint a signed URL.
+    monkeypatch.setattr(
+        public_download.db_client,
+        "get_workflow_run_by_public_token",
+        AsyncMock(return_value=None),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await public_download.download_workflow_artifact(
+            token="expired-token", artifact_type="recording"
+        )
+
+    assert exc.value.status_code == 404

--- a/api/tests/test_public_download_token.py
+++ b/api/tests/test_public_download_token.py
@@ -163,7 +163,9 @@ class TestPublicTokenLifecycle:
         token = await db_session.ensure_public_access_token(seeded_run.run.id)
 
         revoked = await db_session.revoke_public_access_token(
-            seeded_run.run.id, organization_id=seeded_run.org.id
+            seeded_run.run.id,
+            workflow_id=seeded_run.workflow.id,
+            organization_id=seeded_run.org.id,
         )
 
         assert revoked is True
@@ -176,11 +178,35 @@ class TestPublicTokenLifecycle:
         token = await db_session.ensure_public_access_token(seeded_run.run.id)
 
         revoked = await db_session.revoke_public_access_token(
-            seeded_run.run.id, organization_id=seeded_run.org.id + 9999
+            seeded_run.run.id,
+            workflow_id=seeded_run.workflow.id,
+            organization_id=seeded_run.org.id + 9999,
         )
 
         assert revoked is False
         # Token from another org must remain valid.
+        assert await db_session.get_workflow_run_by_public_token(token) is not None
+
+    async def test_revoke_is_workflow_scoped(self, db_session, seeded_run):
+        """A mismatched workflow_id (same org) must not revoke the run's token."""
+        token = await db_session.ensure_public_access_token(seeded_run.run.id)
+
+        # Another workflow in the same org — its id must not authorize revoking
+        # a run that belongs to a different workflow.
+        other_workflow = await db_session.create_workflow(
+            name="Other WF",
+            workflow_definition=GRAPH,
+            user_id=seeded_run.user.id,
+            organization_id=seeded_run.org.id,
+        )
+
+        revoked = await db_session.revoke_public_access_token(
+            seeded_run.run.id,
+            workflow_id=other_workflow.id,
+            organization_id=seeded_run.org.id,
+        )
+
+        assert revoked is False
         assert await db_session.get_workflow_run_by_public_token(token) is not None
 
 
@@ -200,7 +226,7 @@ async def test_revoke_endpoint_success(monkeypatch):
     result = await workflow_route.revoke_workflow_run_public_token(7, 99, user=user)
 
     assert result == {"revoked": True}
-    revoke.assert_awaited_once_with(99, organization_id=42)
+    revoke.assert_awaited_once_with(99, workflow_id=7, organization_id=42)
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_public_download_token.py
+++ b/api/tests/test_public_download_token.py
@@ -209,43 +209,43 @@ class TestPublicTokenLifecycle:
         assert revoked is False
         assert await db_session.get_workflow_run_by_public_token(token) is not None
 
-    async def test_refresh_public_tokens_rotates_for_runs_with_artifacts(
+    async def test_report_refreshes_expired_token_end_to_end(
         self, db_session, async_session, seeded_run
     ):
-        """Report/list surfaces refresh an expired token so their URLs stay valid."""
-        from api.services.reports.run_report import _refresh_public_tokens
+        """CSV report rebuilds URLs from a refreshed token via the real query.
+
+        Exercises the projected-Row path end to end (the row set is immutable),
+        so a regression in _refresh/build would surface here.
+        """
+        import csv as _csv
+
+        from api.services.reports.run_report import generate_workflow_report_csv
 
         run = await async_session.get(WorkflowRunModel, seeded_run.run.id)
+        run.is_completed = True
+        run.usage_info = {"call_duration_seconds": 30}
         run.recording_url = "recordings/run-1.wav"
         run.public_access_token = "legacy-token"
         run.public_access_token_expires_at = datetime.now(UTC) - timedelta(days=1)
         await async_session.flush()
 
-        await _refresh_public_tokens([run])
+        csv_buf, _name = await generate_workflow_report_csv(seeded_run.workflow.id)
+        rows = list(_csv.DictReader(csv_buf))
 
-        assert run.public_access_token != "legacy-token"
-        # The refreshed token must resolve at the freshness-enforcing lookup.
-        assert (
-            await db_session.get_workflow_run_by_public_token(run.public_access_token)
-            is not None
-        )
+        assert len(rows) == 1
+        recording_url = rows[0]["Recording URL"]
+        token = recording_url.split("/workflow/")[1].split("/")[0]
+        assert token != "legacy-token"
+        # The refreshed token resolves at the freshness-enforcing lookup.
+        assert await db_session.get_workflow_run_by_public_token(token) is not None
 
-    async def test_refresh_public_tokens_skips_runs_without_artifacts(
-        self, db_session, async_session, seeded_run
-    ):
-        """A run with nothing downloadable must not get a public token minted."""
+    async def test_refresh_public_tokens_skips_runs_without_artifacts(self):
+        """A run with nothing downloadable yields no token in the map."""
         from api.services.reports.run_report import _refresh_public_tokens
 
-        run = await async_session.get(WorkflowRunModel, seeded_run.run.id)
-        run.recording_url = None
-        run.transcript_url = None
-        run.public_access_token = None
-        run.public_access_token_expires_at = None
-        await async_session.flush()
+        run = SimpleNamespace(id=1, recording_url=None, transcript_url=None)
 
-        await _refresh_public_tokens([run])
-
-        assert run.public_access_token is None
+        assert await _refresh_public_tokens([run]) == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Public workflow-artifact download tokens are permanent bearer secrets. `WorkflowRunModel.public_access_token` is minted once per run and reused forever — there is no expiry column, and `get_workflow_run_by_public_token` matches on token equality only, so **token existence is treated as authorization**. Anyone who captures a token once (webhook payload, forwarded email, log line, third-party integration) can keep minting fresh 1-hour signed URLs for that run's recordings and transcripts indefinitely. The signed object URL expires hourly; the token behind it never did.

Quoting the fail-open lookup on `main`:

```python
# api/db/workflow_run_client.py
async def get_workflow_run_by_public_token(self, token: str):
    ...
    select(WorkflowRunModel).where(WorkflowRunModel.public_access_token == token)
    # no freshness check — a token is valid forever
```

## Design decision

Give every public token a finite, **enforced** lifetime, and enforce it at the single point where a token is redeemed:

- **Freshness at the lookup chokepoint.** `get_workflow_run_by_public_token` now also requires `public_access_token_expires_at IS NOT NULL AND > now()`. Every consumer that redeems a token (the download endpoint) rejects expired/legacy tokens consistently — no scattered checks.
- **Absolute (non-sliding) expiry.** A leaked token that's polled must not stay alive by being used.
- **Rotate on regeneration, reuse while valid.** `ensure_public_access_token` returns an existing token only while unexpired; otherwise it mints a new token + expiry. Live surfaces (run details, reports) rebuild URLs from the current token, so rotation is transparent to them.
- **Explicit revocation.** An org-scoped `revoke_public_access_token` DB method + authenticated `DELETE /{workflow_id}/runs/{run_id}/public-token` endpoint let an operator kill a leaked link immediately.
- **Legacy tokens.** A NULL expiry is treated as expired, and the migration backfills existing tokens to `created_at + TTL` — old runs' links expire immediately, recent ones get a short grace window.

TTL is configurable via `PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS` (default 30), following the existing `OSS_JWT_EXPIRY_HOURS` env-constant pattern, so operators can tune it.

**Tradeoff (flagged for maintainers):** previously delivered public links stop working `TTL` days after their run's `created_at`. That is the intended security outcome of the audit finding.

## What changed

- `api/constants.py` — `PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS` env constant.
- `api/db/models.py` — `public_access_token_expires_at` column.
- `api/alembic/versions/ad8c170ada8f_...` — add column + backfill `created_at + TTL`; downgrade drops it.
- `api/db/workflow_run_client.py` — freshness filter in lookup; rotation in `ensure_public_access_token`; new org-scoped `revoke_public_access_token`.
- `api/routes/workflow.py` — run-details regenerates so live links survive expiry; new `DELETE .../public-token` revoke endpoint.
- `api/tests/test_public_download_token.py` — new coverage.

## Test evidence

Ran against a local Postgres (pgvector), full migration chain applied:

```
$ pytest tests/test_public_download_token.py -q
............
12 passed in 13.93s

# migration down/up cycle verified (column dropped then re-added)
# regression: pytest tests/test_workflow_versioning.py tests/test_run_integrations_webhook.py -> 42 passed
```

Cases covered: token minted with future expiry; valid token reused (no rotation); expired/legacy token rotated; lookup resolves a valid token but rejects expired and NULL-expiry tokens; revoke clears the token and blocks lookup; revoke is org-scoped (wrong org is a no-op, token stays valid); revoke endpoint returns 200 for the owner and 404 cross-org; download endpoint 404s on an expired/missing token.

Fixes #329

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expire and rotate public workflow-artifact download tokens to close the permanent-bearer risk; enforce freshness at lookup, refresh tokens on run details/reports/usage lists, and add workflow+org‑scoped revoke with row locks to prevent races. Floors PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS at 1. Fixes #329.

- **New Features**
  - Enforce expiry in `get_workflow_run_by_public_token` (reject expired/NULL tokens).
  - Rotate in `ensure_public_access_token`; run details, reports, and usage lists auto-refresh so links stay live.
  - Add `DELETE /{workflow_id}/runs/{run_id}/public-token` to revoke leaked links; scoped by workflow and org, with row locks to prevent rotation/revoke races.
  - New env: PUBLIC_DOWNLOAD_TOKEN_TTL_DAYS (default 30, floored at 1).

- **Bug Fixes**
  - Report token refresh works with projected rows: added `recording_url`/`transcript_url` to projections, `_refresh_public_tokens` returns `{run_id: token}`, and `build_run_report_csv` applies it.

<sup>Written for commit 9d37b6a711a94c5e53b3069302dccbf4b4bf1b32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds expiration and revocation for public workflow-artifact download tokens. The main changes are:

- Enforced token expiry during public artifact lookup.
- Token rotation for authenticated run, report, and usage views.
- Workflow- and organization-scoped token revocation.
- A migration that adds and backfills token expiry timestamps.
- Tests for token lifecycle, scoping, revocation, and report refresh.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

Row locks prevent rotation and revocation from overwriting each other. Revocation checks both workflow and organization ownership. Nonpositive lifetime settings are constrained before migration and token creation. No blocking issues remain in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the public-token lifecycle tests and observed a ModuleNotFoundError: dotenv during test collection, with exit code 4.
- I re-ran the tests with an explicit DATABASE\_URL; the same dependency blocker appeared and the test collection still exited with code 4.
- I attempted a route-only test run for public-token routes, but collection halted by ModuleNotFoundError: loguru, exiting with code 4.
- I inspected the environment and found that the expected Python path points to a missing temporary Python 3.13, preventing the activation of the installed virtual environment.
- I gathered artifacts from the runs, including three log artifacts and a Python file artifact, to document the blockers and the environment misconfiguration.

<a href="https://app.greptile.com/trex/runs/14493531/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/db/workflow_run_client.py | Enforces token freshness, rotates expired tokens, and serializes scoped revocation with token rotation. |
| api/routes/workflow.py | Refreshes tokens for live run details and adds the authenticated revocation endpoint. |
| api/alembic/versions/ad8c170ada8f_add_public_access_token_expiry.py | Adds the expiry column and backfills existing public tokens with finite lifetimes. |
| api/constants.py | Adds a configurable public-token lifetime with a one-day minimum. |
| api/services/reports/run_report.py | Refreshes public tokens before generating artifact links in CSV reports. |
| api/tests/test_public_download_token.py | Covers expiry, rotation, revocation, resource scoping, lookup behavior, and report links. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `api/db/workflow_run_client.py`, line 464-466 ([link](https://github.com/dograh-hq/dograh/blob/f3f63eecb1811d7e3561d9be4c4421af75ac6bab/api/db/workflow_run_client.py#L464-L466)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Concurrent Rotation Returns Stale Token**

   When run details and the post-call integration task ensure the same missing or expired token concurrently, both transactions can mint different values because this read does not lock the row. The later commit overwrites the first value, leaving the first caller with artifact URLs that immediately return 404.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: deterministic concurrent SQLAlchemy session harness](https://app.greptile.com/trex/artifacts/a3f908ac-bae7-4f32-a48f-22f5567ce1bd)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: timestamped transaction, token, and redemption output](https://app.greptile.com/trex/artifacts/1659575b-7ad8-4ff8-b424-4b30e0a3c8d8)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/14190725/artifacts?artifact=a3f908ac-bae7-4f32-a48f-22f5567ce1bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(security): make report token refresh..."](https://github.com/dograh-hq/dograh/commit/9d37b6a711a94c5e53b3069302dccbf4b4bf1b32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43719820)</sub>

<!-- /greptile_comment -->