### PR TITLE
chore: bump pipecat submodule to 1.5.0

### DIFF
--- a/api/tests/test_custom_tools.py
+++ b/api/tests/test_custom_tools.py
@@ -22,6 +22,7 @@ from pipecat.frames.frames import (
     LLMContextFrame,
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
+    LLMServiceMetadataFrame,
     UserTurnInferenceCompletedFrame,
 )
 from pipecat.pipeline.pipeline import Pipeline
@@ -1214,6 +1215,7 @@ class TestCustomToolManagerIntegration:
             pipeline,
             frames_to_send=frames_to_send,
             expected_down_frames=[
+                LLMServiceMetadataFrame,
                 LLMFullResponseStartFrame,
                 FunctionCallsFromLLMInfoFrame,
                 UserTurnInferenceCompletedFrame,

--- a/api/tests/test_unregistered_function_call.py
+++ b/api/tests/test_unregistered_function_call.py
@@ -9,6 +9,7 @@ from pipecat.frames.frames import (
     LLMContextFrame,
     LLMFullResponseEndFrame,
     LLMFullResponseStartFrame,
+    LLMServiceMetadataFrame,
     UserTurnInferenceCompletedFrame,
 )
 from pipecat.pipeline.pipeline import Pipeline
@@ -44,6 +45,7 @@ class TestUnregisteredFunctionCall:
             pipeline,
             frames_to_send=[LLMContextFrame(context)],
             expected_down_frames=[
+                LLMServiceMetadataFrame,
                 LLMFullResponseStartFrame,
                 FunctionCallsFromLLMInfoFrame,
                 UserTurnInferenceCompletedFrame,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrades `pipecat` submodule to 1.5.0. Updates tests to expect `LLMServiceMetadataFrame` before `LLMFullResponseStartFrame` in tool-call flows.

- **Dependencies**
  - Bumped `pipecat` to 1.5.0.

<sup>Written for commit 88cb715e48237fac00331675b04f6ea569f22e94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Pipecat submodule for the 1.5.0 contracts. The main changes are:

- Advances the Pipecat submodule revision.
- Updates two LLM tests to expect service metadata before response frames.
- Adopts revised Dograh STT and TTS lifecycle behavior.

<h3>Confidence Score: 5/5</h3>

The update is mergeable after confirming that interrupted TTS turns do not retain stale timestamp state.

The new LLM metadata expectations match the updated service lifecycle.

The TTS stop path in pipecat no longer emits the previous timestamp reset, which can affect stateful timestamp consumers.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the direct PyTest command to exercise the direct harness and captured the interpreter error with exit code 127.
- Tried the harness under fallback Python 3.11 and identified a missing wait\_for2 import.
- Reran a second harness attempt and confirmed that dependencies built for Python 3.13 cannot execute under Python 3.11.
- Generated and reviewed the narrow pipeline harness (pipecat\_metadata\_harness.py) to assert the Pipecat 1.5 metadata-frame order and unregistered-function contract.
- Compared the evidence artifacts to verify the contract validation coverage and ensure the findings are reflected in the artifact set.

<a href="https://app.greptile.com/trex/runs/14235512/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/tests/test_custom_tools.py | Updates the custom-tool integration test for the new LLM service metadata frame. |
| api/tests/test_unregistered_function_call.py | Updates the unregistered-function test for the new metadata frame ordering. |
| pipecat | Advances Pipecat to the 1.5.0-compatible revision, including changed Dograh service lifecycle and timestamp behavior. |

<sub>Reviews (1): Last reviewed commit: ["Bump Pipecat to 1.5.0"](https://github.com/dograh-hq/dograh/commit/88cb715e48237fac00331675b04f6ea569f22e94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43811462)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->