### PR TITLE
fix(vobiz): handle proxied signatures and number binding

### DIFF
--- a/api/services/telephony/providers/vobiz/provider.py
+++ b/api/services/telephony/providers/vobiz/provider.py
@@ -14,6 +14,7 @@ import aiohttp
 from fastapi import HTTPException
 from loguru import logger
 
+from api.constants import BACKEND_API_ENDPOINT
 from api.enums import TelephonyCallStatus, WorkflowRunMode
 from api.services.telephony.base import (
     CallInitiationResult,
@@ -21,7 +22,7 @@ from api.services.telephony.base import (
     ProviderSyncResult,
     TelephonyProvider,
 )
-from api.utils.common import get_backend_endpoints
+from api.utils.common import get_backend_endpoints, is_local_or_private_url
 from api.utils.telephony_address import normalize_telephony_address
 
 if TYPE_CHECKING:
@@ -461,6 +462,56 @@ class VobizProvider(TelephonyProvider):
         stored_auth_id = config_data.get("auth_id")
         return stored_auth_id == webhook_account_id
 
+    @staticmethod
+    def _signature_verification_url(url: str, headers: Dict[str, str]) -> str:
+        """Reconstruct the public URL Vobiz used to sign a callback.
+
+        A TLS-terminating proxy can expose the request to the API with an
+        internal ``http://`` origin even though Vobiz called and signed the
+        configured public ``https://`` URL.
+        """
+        parsed_url = urlparse(url)
+
+        if BACKEND_API_ENDPOINT and not is_local_or_private_url(BACKEND_API_ENDPOINT):
+            backend_url = BACKEND_API_ENDPOINT.rstrip("/")
+            if "://" not in backend_url:
+                backend_url = f"http://{backend_url}"
+
+            parsed_backend = urlparse(backend_url)
+            return urlunparse(
+                (
+                    parsed_backend.scheme,
+                    parsed_backend.netloc,
+                    parsed_url.path,
+                    "",
+                    parsed_url.query,
+                    "",
+                )
+            )
+
+        forwarded_proto = headers.get("x-forwarded-proto", "")
+        forwarded_host = headers.get("x-forwarded-host", "")
+        if forwarded_proto:
+            forwarded_proto = forwarded_proto.split(",", 1)[0].strip()
+        if forwarded_host:
+            forwarded_host = forwarded_host.split(",", 1)[0].strip()
+        else:
+            forwarded_host = headers.get("host", "")
+
+        if forwarded_proto and forwarded_host:
+            return urlunparse(
+                (
+                    forwarded_proto,
+                    forwarded_host,
+                    parsed_url.path,
+                    "",
+                    parsed_url.query,
+                    "",
+                )
+            )
+
+        return url
+
     async def verify_inbound_signature(
         self,
         url: str,
@@ -491,8 +542,9 @@ class VobizProvider(TelephonyProvider):
             logger.warning("Inbound Vobiz webhook missing X-Vobiz-Signature-V3/V2")
             return False
 
+        verification_url = self._signature_verification_url(url, normalized_headers)
         return await self.verify_webhook_signature(
-            url,
+            verification_url,
             webhook_data,
             signature,
             nonce,

--- a/api/tests/telephony/vobiz/test_routes.py
+++ b/api/tests/telephony/vobiz/test_routes.py
@@ -219,6 +219,71 @@ async def test_vobiz_verify_inbound_signature_accepts_v2():
 
 
 @pytest.mark.asyncio
+async def test_vobiz_inbound_signature_uses_configured_public_backend_url():
+    provider = _provider()
+    public_url = "https://voice.example.test/api/v1/telephony/inbound/run"
+    headers = _signed_headers(provider, url=public_url)
+
+    with patch(
+        "api.services.telephony.providers.vobiz.provider.BACKEND_API_ENDPOINT",
+        "https://voice.example.test",
+    ):
+        is_valid = await provider.verify_inbound_signature(
+            "http://api:8000/api/v1/telephony/inbound/run",
+            {},
+            headers,
+        )
+
+    assert is_valid
+
+
+@pytest.mark.asyncio
+async def test_vobiz_inbound_signature_uses_forwarded_url_for_local_backend():
+    provider = _provider()
+    public_url = "https://voice.example.test/api/v1/telephony/inbound/run"
+    headers = {
+        **_signed_headers(provider, url=public_url),
+        "X-Forwarded-Proto": "https",
+        "X-Forwarded-Host": "voice.example.test",
+    }
+
+    with patch(
+        "api.services.telephony.providers.vobiz.provider.BACKEND_API_ENDPOINT",
+        "http://localhost:8000",
+    ):
+        is_valid = await provider.verify_inbound_signature(
+            "http://api:8000/api/v1/telephony/inbound/run",
+            {},
+            headers,
+        )
+
+    assert is_valid
+
+
+@pytest.mark.asyncio
+async def test_vobiz_inbound_signature_uses_forwarded_url_for_private_backend():
+    provider = _provider()
+    public_url = "https://voice.example.test/api/v1/telephony/inbound/run"
+    headers = {
+        **_signed_headers(provider, url=public_url),
+        "X-Forwarded-Proto": "https",
+        "X-Forwarded-Host": "voice.example.test",
+    }
+
+    with patch(
+        "api.services.telephony.providers.vobiz.provider.BACKEND_API_ENDPOINT",
+        "http://10.0.0.5:8000",
+    ):
+        is_valid = await provider.verify_inbound_signature(
+            "http://api:8000/api/v1/telephony/inbound/run",
+            {},
+            headers,
+        )
+
+    assert is_valid
+
+
+@pytest.mark.asyncio
 async def test_vobiz_verify_inbound_signature_rejects_missing_signature():
     provider = _provider()
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix inbound signature verification behind proxies by reconstructing the public callback URL, and harden Vobiz number binding flows.

- **Bug Fixes**
  - Rebuild the verification URL using a public `BACKEND_API_ENDPOINT` (when not local/private) or `X-Forwarded-Proto`/`X-Forwarded-Host` (fallback to `Host`) so signatures match behind TLS-terminating proxies; tests cover public/local/private backends.

- **New Features**
  - Safer number lifecycle: attach first, then set `answer_url`; clear/delete now detach via `configure_inbound(None)` and delete responses include `provider_sync`; detaching removes only the binding (keeps shared `answer_url`).
  - Validate PSTN numbers and percent-encode them in provider requests with clearer errors and logs.

<sup>Written for commit 5df459d3af07783f8a58078c2514a01386f5630b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves Vobiz callback verification and phone-number binding. The main changes are:

- Reconstruct signed callback URLs from the public backend endpoint or proxy headers.
- Attach numbers before updating the shared answer URL.
- Detach numbers when clearing or deleting them.
- Validate and encode PSTN numbers in provider requests.
- Add tests for public, local, and private backend URL handling.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex tested the pre-change flow by sending three valid proxied requests to the internal API URL and observed they were rejected with HTTP\_STATUS=403 MESSAGE=Forbidden - invalid Vobiz signature.
- T-Rex reconfigured the flow so the requests were reconstructed to the public endpoint https://voice.example.test/api/v1/telephony/inbound/run and confirmed the valid requests now returned HTTP\_STATUS=200 MESSAGE=OK - signature accepted, while the invalid control remained 403.
- The after-run completed with exit code 0 and exercised the repository code directly rather than copying the verification implementation.

<a href="https://app.greptile.com/trex/runs/14522841/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/services/telephony/providers/vobiz/provider.py | Adds proxy-aware callback URL reconstruction for Vobiz signature verification. |
| api/tests/telephony/vobiz/test_routes.py | Adds signature tests for configured public endpoints and forwarded URLs with local or private backends. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `api/services/telephony/providers/vobiz/provider.py`, line 651-661 ([link](https://github.com/dograh-hq/dograh/blob/f3ca5a787f926189059c54c9723e3adca4b9817a/api/services/telephony/providers/vobiz/provider.py#L651-L661)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Successful Bind Survives Update Failure**

   When the number binding succeeds but the Application update fails or times out, this branch returns an error without removing the new binding. The local phone-number write has already completed, so inbound calls can remain bound to an Application with a missing or stale `answer_url` and fail to reach the configured workflow.

   **Context Used:** api/services/telephony/providers/AGENTS.md ([source](https://app.greptile.com/dograh-hq/github/dograh-hq/dograh/-/custom-context?memory=f40b93ad-475b-4a76-9687-19ab74c6ec29))
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(vobiz): verify signatures with publi..."](https://github.com/dograh-hq/dograh/commit/5df459d3af07783f8a58078c2514a01386f5630b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44053065)</sub>

<!-- /greptile_comment -->