### PR TITLE
docs: add video-embedded getting-started pages for API Trigger, Webhook, Telephony, Tools & KB

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -22,6 +22,10 @@
                 "pages": [
                   "getting-started/index",
                   "getting-started/first-agent",
+                  "getting-started/trigger-calls-from-your-backend",
+                  "getting-started/send-call-data-with-webhooks",
+                  "getting-started/connect-telephony",
+                  "getting-started/add-tools-and-knowledge-base",
                   "getting-started/prerequisites",
                   "getting-started/troubleshooting"
                 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -21,15 +21,20 @@
                 "group": "Introduction",
                 "pages": [
                   "getting-started/index",
-                  "getting-started/first-agent",
-                  "getting-started/trigger-calls-from-your-backend",
-                  "getting-started/send-call-data-with-webhooks",
-                  "getting-started/connect-telephony",
-                  "getting-started/add-tools-and-knowledge-base",
                   "getting-started/prerequisites",
                   "getting-started/troubleshooting"
                 ]
               }
+            ]
+          },
+          {
+            "group": "Build your First Agent",
+            "pages": [
+                  "getting-started/first-agent",
+                  "getting-started/trigger-calls-from-your-backend",
+                  "getting-started/send-call-data-with-webhooks",
+                  "getting-started/connect-telephony",
+                  "getting-started/add-tools-and-knowledge-base"
             ]
           },
           {

--- a/docs/getting-started/add-tools-and-knowledge-base.mdx
+++ b/docs/getting-started/add-tools-and-knowledge-base.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Give Your Agent Real Data"
+title: "Use External Tools, Knowledge"
 description: "Make your agent do something during the call, not just talk. Connect it to live data and your company documents."
 ---
 

--- a/docs/getting-started/add-tools-and-knowledge-base.mdx
+++ b/docs/getting-started/add-tools-and-knowledge-base.mdx
@@ -1,0 +1,95 @@
+---
+title: "Give Your Agent Real Data"
+description: "Make your agent do something during the call, not just talk. Connect it to live data and your company documents."
+---
+
+You've made the agent reachable through real phone calls. Now let's make it useful during the call.
+
+Your agent can hold a conversation. But can it check an order, or answer a policy question correctly? That's what this page is about.
+
+There are two ways to connect real information to your agent. A **tool** is for anything live, data that changes, or an action that needs to happen, like checking an order or looking up availability. A **Knowledge Base** is for anything written down, like your return policy or an FAQ, that doesn't change from call to call.
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/gJCBmsHW8_A"
+  title="How to Add API Tools and a Knowledge Base to Your Voice Agent"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
+Here's the setup used in the video: an order support agent named Maya, for a store called QuickMart. A customer can ask what's in their cart, and Maya calls an API to check it. A customer can also ask a policy question, and Maya answers from a document you uploaded.
+
+## Step 1: Create the tool
+
+Open the node where most of the conversation happens, in this case Maya's main support node. Scroll down and click **Create a Tool**, then choose **External HTTP API**. Name it `get_cart_details`.
+
+<Note>
+The description matters more than anything else here. It's what the agent reads to decide when to call the tool. Write it plainly: *"Use this tool when the caller asks about cart details. It returns the cart's products, quantities, total, and discounted total."*
+</Note>
+
+For the endpoint, this demo uses [dummyjson.com](https://dummyjson.com), a public sample API. Copy this exact URL and test it yourself, no backend required:
+
+```
+GET https://dummyjson.com/carts/1
+```
+
+No auth, no parameters. It's a GET request because you're fetching information, not changing anything. In your own setup, this would point at your CRM or order system instead.
+
+Save the tool.
+
+## Step 2: Attach the tool to the node
+
+Creating the tool isn't enough by itself. Go back to Maya's node and select `get_cart_details` under Tools, then save.
+
+<Warning>
+A tool only becomes available once it's attached to the node that needs it. If you skip this, the tool exists but the agent will never call it.
+</Warning>
+
+## Step 3: Upload a Knowledge Base document
+
+Click **Upload Document**, or go straight to **Knowledge Base Files**. Pick the document you want the agent to read from, a return policy, a shipping FAQ, whatever your customers actually ask about.
+
+Dograh asks how it should retrieve from this document:
+
+- **Full Document** works best for small files, where the agent can see the whole thing at once.
+- **Chunked Search** is for large documents, where the agent should only pull the relevant section.
+
+A short policy document is a Full Document case. Upload it, then wait for the status to say **Completed**.
+
+## Step 4: Attach the document to the node
+
+Same rule as the tool. Go back to Maya's node, scroll to **Knowledge Base Documents**, and attach the file.
+
+<Warning>
+Uploading isn't enough on its own. The document has to be attached to the node where the agent should use it.
+</Warning>
+
+## Step 5: Tell the agent when to use each
+
+In the node's prompt, spell out which mechanism handles which question. Don't leave it to guesswork:
+
+```
+If the caller asks about cart contents, order items, quantities, total, or discounts,
+use the get_cart_details tool before answering.
+
+For questions about returns, refunds, or cancellations,
+use the attached Knowledge Base document.
+```
+
+Save the node.
+
+## Step 6: Test it
+
+Start a Web Call and try both:
+
+- *"Hi Maya, what's inside my cart?"* Watch the transcript. Maya decides the tool is relevant, calls the API, and answers from the response instead of guessing.
+- *"What's the return policy?"* Maya retrieves the answer from the document and responds from that context.
+
+That's the difference that matters: for cart details, Maya uses the tool because the data changes call to call. For the return policy, she uses the Knowledge Base because that answer lives in a document and doesn't change. Tools connect your agent to systems. Knowledge Base connects it to documents. Together, your agent starts to feel connected to your actual business, not just reciting a script.
+
+## Next Steps
+
+You've now got the full loop: calls trigger automatically, data flows in and out, your number is connected, and the agent can act on live data and your own documents.
+
+- **Full tool reference**: parameter types, authentication, and best practices in [HTTP API Tools](/voice-agent/tools/http-api).
+- **Full Knowledge Base reference**: chunking behavior and embedding setup in [Knowledge Base](/voice-agent/knowledge-base).

--- a/docs/getting-started/add-tools-and-knowledge-base.mdx
+++ b/docs/getting-started/add-tools-and-knowledge-base.mdx
@@ -51,8 +51,8 @@ Click **Upload Document**, or go straight to **Knowledge Base Files**. Pick the 
 
 Dograh asks how it should retrieve from this document:
 
-- **Full Document** works best for small files, where the agent can see the whole thing at once.
-- **Chunked Search** is for large documents, where the agent should only pull the relevant section.
+- **Full Document** works best for small files, where the agent can see the whole thing at once. It does not require an embeddings model.
+- **Chunked Search** is for large documents, where the agent should only pull the relevant section. Configure an embeddings model before selecting this mode; otherwise document processing or retrieval will fail.
 
 A short policy document is a Full Document case. Upload it, then wait for the status to say **Completed**.
 

--- a/docs/getting-started/connect-telephony.mdx
+++ b/docs/getting-started/connect-telephony.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Connect Your Phone Number"
+title: "Connect with Telephony"
 description: "Hook up Twilio so Dograh can make and receive real calls, not just browser test calls."
 ---
 
@@ -39,7 +39,7 @@ Before testing from a Twilio trial account, verify the destination number you pl
 
 ## Step 6: Test it
 
-Once verified, trigger a call the same way you did in [Trigger Calls Automatically](/getting-started/trigger-calls-from-your-backend), from Postman or your backend. Dograh places the outbound call through Twilio. The phone rings, the agent answers, and the connection is live.
+Once verified, trigger a call the same way you did in [Trigger Calls using API](/getting-started/trigger-calls-from-your-backend), from Postman or your backend. Dograh places the outbound call through Twilio. The phone rings, the agent answers, and the connection is live.
 
 <Note>
 On a trial account, Twilio plays a default message before connecting to your agent. Press any key to skip it and go straight to the agent.
@@ -49,5 +49,5 @@ Inbound calls work the same way in reverse, routed through Twilio's webhook into
 
 ## Next Steps
 
-- **Make your agent do more on the call**: [Give Your Agent Real Data](/getting-started/add-tools-and-knowledge-base) covers tools and a Knowledge Base.
+- **Make your agent do more on the call**: [Use External Tools, Knowledge](/getting-started/add-tools-and-knowledge-base) covers tools and a Knowledge Base.
 - **Other providers**: Vonage, Plivo, Cloudonix, and SIP-based setups are covered in [Telephony Integration](/integrations/telephony/overview).

--- a/docs/getting-started/connect-telephony.mdx
+++ b/docs/getting-started/connect-telephony.mdx
@@ -35,7 +35,7 @@ Once the configuration exists, go to manage phone numbers and add the number you
 
 ## Step 5: Verify your number
 
-Before testing from a Twilio trial account, verify the destination number you plan to call, such as your personal phone number. This is separate from the Twilio number you purchased for use as the caller ID. In Twilio, go to **Phone Numbers → Manage → Verified Caller IDs** and add the destination number.
+Before testing from a Twilio trial account, verify the destination number you plan to call, such as your personal phone number. This is separate from the Twilio number you purchased for use as the caller ID. In Twilio, go to the [Verified Caller IDs page](https://www.twilio.com/console/phone-numbers/verified) and add the destination number.
 
 ## Step 6: Test it
 

--- a/docs/getting-started/connect-telephony.mdx
+++ b/docs/getting-started/connect-telephony.mdx
@@ -35,7 +35,7 @@ Once the configuration exists, go to manage phone numbers and add the number you
 
 ## Step 5: Verify your number
 
-Before testing, verify your phone number. Twilio trial accounts only allow calls to verified numbers. In Twilio, go to **Phone Numbers → Manage → Verified Caller IDs**, and add your number there.
+Before testing from a Twilio trial account, verify the destination number you plan to call, such as your personal phone number. This is separate from the Twilio number you purchased for use as the caller ID. In Twilio, go to **Phone Numbers → Manage → Verified Caller IDs** and add the destination number.
 
 ## Step 6: Test it
 

--- a/docs/getting-started/connect-telephony.mdx
+++ b/docs/getting-started/connect-telephony.mdx
@@ -29,6 +29,10 @@ Go back to Twilio, copy your **Auth Token**, and paste it in. Keep that token pr
 
 If you want this configuration to be the default for test calls and campaigns, enable that here. For a basic setup, leave answering machine detection off, then click **Create**.
 
+<Warning>
+Enable **Set as default for outbound calls** on your telephony configuration. If no default is set, API Trigger will return a `400: Telephony provider not configured for this organization` error even after a successful setup.
+</Warning>
+
 ## Step 4: Add your phone number
 
 Once the configuration exists, go to manage phone numbers and add the number you bought. Copy it from Twilio and paste it in as-is, country **US**. The label is optional, leave it blank if you want. Select your inbound workflow, in this demo, a debt collection agent. Keep it active, and enable default caller ID if you want test calls to always show that number.

--- a/docs/getting-started/connect-telephony.mdx
+++ b/docs/getting-started/connect-telephony.mdx
@@ -1,0 +1,53 @@
+---
+title: "Connect Your Phone Number"
+description: "Hook up Twilio so Dograh can make and receive real calls, not just browser test calls."
+---
+
+You've covered API Trigger and Webhooks. Both of those work on real calls, which means you need a real phone number connected first. This page walks through Twilio specifically, since it's the fastest way to get a number and test with free trial credits.
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/w8EhcqDjZKI"
+  title="How to Set Up Telephony for Dograh AI Voice Agents"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
+## Step 1: Create a Twilio account and buy a number
+
+Sign up at Twilio. You'll land on their dashboard with free trial credits you can use for testing. Go to **Phone Numbers** and click **Buy a number**, pick any number you like.
+
+## Step 2: Copy your Account SID
+
+Back on the Twilio dashboard, copy your **Account SID**.
+
+## Step 3: Add the configuration in Dograh
+
+Open **Telephony** in Dograh, click **Add Configuration**, and select **Twilio** as the provider. Name it something you'll recognize later, your workflow name works well. Paste the Account SID.
+
+Go back to Twilio, copy your **Auth Token**, and paste it in. Keep that token private.
+
+If you want this configuration to be the default for test calls and campaigns, enable that here. For a basic setup, leave answering machine detection off, then click **Create**.
+
+## Step 4: Add your phone number
+
+Once the configuration exists, go to manage phone numbers and add the number you bought. Copy it from Twilio and paste it in as-is, country **US**. The label is optional, leave it blank if you want. Select your inbound workflow, in this demo, a debt collection agent. Keep it active, and enable default caller ID if you want test calls to always show that number.
+
+## Step 5: Verify your number
+
+Before testing, verify your phone number. Twilio trial accounts only allow calls to verified numbers. In Twilio, go to **Phone Numbers → Manage → Verified Caller IDs**, and add your number there.
+
+## Step 6: Test it
+
+Once verified, trigger a call the same way you did in [Trigger Calls Automatically](/getting-started/trigger-calls-from-your-backend), from Postman or your backend. Dograh places the outbound call through Twilio. The phone rings, the agent answers, and the connection is live.
+
+<Note>
+On a trial account, Twilio plays a default message before connecting to your agent. Press any key to skip it and go straight to the agent.
+</Note>
+
+Inbound calls work the same way in reverse, routed through Twilio's webhook into your Dograh workflow.
+
+## Next Steps
+
+- **Make your agent do more on the call**: [Give Your Agent Real Data](/getting-started/add-tools-and-knowledge-base) covers tools and a Knowledge Base.
+- **Other providers**: Vonage, Plivo, Cloudonix, and SIP-based setups are covered in [Telephony Integration](/integrations/telephony/overview).

--- a/docs/getting-started/first-agent.mdx
+++ b/docs/getting-started/first-agent.mdx
@@ -5,6 +5,14 @@ description: "Build and talk to a working voice agent in five minutes using Web 
 
 This is the fastest path to a working voice agent. You'll create an agent, get a generated conversation flow, and talk to it in your browser — no phone number, no telephony provider, no configuration.
 
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/sGcOFhH8gxI"
+  title="How to Build Your First Voice Agent in Dograh"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
 <Note>
 Using the hosted platform, go to [app.dograh.com](https://app.dograh.com). Self-hosting locally? Use `http://localhost:3010` instead, and follow [Getting Started](/getting-started) first to get the platform running.
 </Note>

--- a/docs/getting-started/send-call-data-with-webhooks.mdx
+++ b/docs/getting-started/send-call-data-with-webhooks.mdx
@@ -1,11 +1,9 @@
 ---
-title: "Send Call Data Back Automatically"
+title: "Sync Data using Webhook"
 description: "Get everything Dograh learned during the call back into your system the moment it ends."
 ---
 
 The last page covered sending data into a call with API Trigger and `initial_context`. Now the opposite side: how Dograh sends what it learned back out to your system once the call ends.
-
-Say a caller tells your agent, *"I'll pay the full amount tomorrow."* If the node handling that moment has variable extraction turned on, Dograh pulls structured fields out of that one sentence: the amount they'll pay, payment method, sentiment, a confidence score, and next steps. From *"I'll pay full amount tomorrow"*, that becomes: amount to pay is the full balance, payment method not specified, sentiment cooperative, next step is a follow-up call the day they promised to pay.
 
 That extracted data lives in `gathered_context`. So the full picture is: `initial_context` is what your backend sends into the call, `gathered_context` is what Dograh extracts from it. A **Webhook** node is how you get `gathered_context` back out.
 
@@ -58,5 +56,5 @@ That's the complete loop: your backend sends `initial_context` into Dograh, Dogr
 
 ## Next Steps
 
-- **Connect a real phone number**: [Connect Your Phone Number](/getting-started/connect-telephony) covers hooking up Twilio so these calls go out for real.
+- **Connect a real phone number**: [Connect with Telephony](/getting-started/connect-telephony) covers hooking up Twilio so these calls go out for real.
 - **Full variable list and authentication options**: see the [Webhook reference](/voice-agent/webhook) and the [Webhook Payloads developer reference](/developer/webhooks).

--- a/docs/getting-started/send-call-data-with-webhooks.mdx
+++ b/docs/getting-started/send-call-data-with-webhooks.mdx
@@ -43,7 +43,7 @@ This is the important part, it decides exactly what JSON Dograh sends. Include b
 ```
 
 <Warning>
-Variable names in your payload have to match your context fields exactly, or that field just won't show up.
+Variable names in your payload have to match your context fields exactly. If a variable cannot be resolved, its field remains in the payload with an empty string value.
 </Warning>
 
 ## Step 4: Save and publish

--- a/docs/getting-started/send-call-data-with-webhooks.mdx
+++ b/docs/getting-started/send-call-data-with-webhooks.mdx
@@ -1,0 +1,62 @@
+---
+title: "Send Call Data Back Automatically"
+description: "Get everything Dograh learned during the call back into your system the moment it ends."
+---
+
+The last page covered sending data into a call with API Trigger and `initial_context`. Now the opposite side: how Dograh sends what it learned back out to your system once the call ends.
+
+Say a caller tells your agent, *"I'll pay the full amount tomorrow."* If the node handling that moment has variable extraction turned on, Dograh pulls structured fields out of that one sentence: the amount they'll pay, payment method, sentiment, a confidence score, and next steps. From *"I'll pay full amount tomorrow"*, that becomes: amount to pay is the full balance, payment method not specified, sentiment cooperative, next step is a follow-up call the day they promised to pay.
+
+That extracted data lives in `gathered_context`. So the full picture is: `initial_context` is what your backend sends into the call, `gathered_context` is what Dograh extracts from it. A **Webhook** node is how you get `gathered_context` back out.
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/w4XvzPWoFv4"
+  title="Dograh Webhook Node Explained, Get Call Data Into Your Backend"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
+## Step 1: Add the node
+
+Click **Add node**, scroll down, and you'll find the **Webhook** node. Add it and open it up.
+
+## Step 2: Set the endpoint
+
+First thing you'll see is the endpoint URL. Paste your backend's webhook URL here. Still testing? Use a free URL from [webhook.site](https://webhook.site), copy your unique URL there and paste it into Dograh.
+
+Set the method to **POST**. If your backend needs auth, add a bearer token or API key right here too.
+
+## Step 3: Build the payload template
+
+This is the important part, it decides exactly what JSON Dograh sends. Include both kinds of context: `initial_context` fields like debtor name, client name, and debt amount, and `gathered_context` fields like amount to pay, payment method, and sentiment.
+
+```json
+{
+  "debtor_name": "{{initial_context.debtor_name}}",
+  "client_name": "{{initial_context.client_name}}",
+  "debt_amount": "{{initial_context.debt_amount}}",
+  "amount_user_will_pay": "{{gathered_context.amount_user_will_pay}}",
+  "payment_method": "{{gathered_context.payment_method}}",
+  "sentiment": "{{gathered_context.sentiment}}"
+}
+```
+
+<Warning>
+Variable names in your payload have to match your context fields exactly, or that field just won't show up.
+</Warning>
+
+## Step 4: Save and publish
+
+Save the webhook node, then publish the agent.
+
+## Step 5: Test it
+
+Run a test call. When it ends, go back to your webhook receiver. You'll see one request with both `initial_context`, the data you sent into the call, and `gathered_context`, what Dograh extracted from the conversation, sitting in the same JSON payload.
+
+That's the complete loop: your backend sends `initial_context` into Dograh, Dograh runs the call and extracts `gathered_context`, and the webhook node sends the final structured data back to your backend. For production, swap the webhook.site URL for your real backend URL.
+
+## Next Steps
+
+- **Connect a real phone number**: [Connect Your Phone Number](/getting-started/connect-telephony) covers hooking up Twilio so these calls go out for real.
+- **Full variable list and authentication options**: see the [Webhook reference](/voice-agent/webhook) and the [Webhook Payloads developer reference](/developer/webhooks).

--- a/docs/getting-started/trigger-calls-from-your-backend.mdx
+++ b/docs/getting-started/trigger-calls-from-your-backend.mdx
@@ -25,9 +25,12 @@ That's the part that matters: instead of the agent asking basic setup questions 
 Every node has a docs link in the top right corner. If you get stuck or want to go deeper on any node type, open the docs straight from there.
 </Tip>
 
-## Step 2: Get an API key
+## Step 2: Check the prerequisites
 
-Before you trigger anything, go to the developer portal and generate an API key. You'll need it in the request header.
+Before you trigger anything:
+
+1. [Connect a telephony provider](/getting-started/connect-telephony) for outbound calls.
+2. Go to the developer portal and generate an API key. You'll need it in the request header.
 
 ## Step 3: Find your trigger URL
 

--- a/docs/getting-started/trigger-calls-from-your-backend.mdx
+++ b/docs/getting-started/trigger-calls-from-your-backend.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Trigger Calls Automatically"
+title: "Trigger Calls using API"
 description: "Kick off a call the moment a lead lands in your CRM or spreadsheet, no manual dialing."
 ---
 
@@ -67,6 +67,6 @@ Send the request, and the call goes out immediately. Because the agent already h
 
 ## Next Steps
 
-- **Get that data back automatically**: the next step is [Send Call Data Back Automatically](/getting-started/send-call-data-with-webhooks), which takes whatever the agent learns on the call and sends it back to your system the moment it ends.
-- **No phone number connected yet?** See [Connect Your Phone Number](/getting-started/connect-telephony) first, outbound calls need a telephony provider attached.
+- **Get that data back automatically**: the next step is [Sync Data using Webhook](/getting-started/send-call-data-with-webhooks), which takes whatever the agent learns on the call and sends it back to your system the moment it ends.
+- **No phone number connected yet?** See [Connect with Telephony](/getting-started/connect-telephony) first, outbound calls need a telephony provider attached.
 - **Full endpoint reference**: error codes, response shape, and choosing a specific telephony configuration are in [API Trigger](/voice-agent/api-trigger).

--- a/docs/getting-started/trigger-calls-from-your-backend.mdx
+++ b/docs/getting-started/trigger-calls-from-your-backend.mdx
@@ -29,7 +29,7 @@ Every node has a docs link in the top right corner. If you get stuck or want to 
 
 Before you trigger anything:
 
-1. [Connect a telephony provider](/getting-started/connect-telephony) for outbound calls.
+1. [Connect with Telephony](/getting-started/connect-telephony) for outbound calls.
 2. Go to the developer portal and generate an API key. You'll need it in the request header.
 
 ## Step 3: Find your trigger URL

--- a/docs/getting-started/trigger-calls-from-your-backend.mdx
+++ b/docs/getting-started/trigger-calls-from-your-backend.mdx
@@ -1,0 +1,69 @@
+---
+title: "Trigger Calls Automatically"
+description: "Kick off a call the moment a lead lands in your CRM or spreadsheet, no manual dialing."
+---
+
+If your team is manually dialing leads one by one, or your CRM needs to kick off a call the moment a lead comes in, this is how you automate that with Dograh.
+
+Say you've got leads or accounts sitting in a CRM or a Google Sheet. Each row has details like customer name, company name, amount due. The **API Trigger** node lets you take that row of data and turn it into a personalized call, automatically.
+
+<iframe
+  className="w-full aspect-video rounded-xl"
+  src="https://www.youtube.com/embed/P9zWbO78oSg"
+  title="How to Trigger Voice AI Calls from Your CRM (API Trigger)"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
+## Step 1: Add the node
+
+Click **Add node** and add an **API Trigger** node, the topmost option in the list. This node starts the call and passes your data into the agent as `initial_context`.
+
+That's the part that matters: instead of the agent asking basic setup questions on the call, like "what's your name" or "how much do you owe", it already knows. In this demo, the opening node greets the caller with `{{debtor_name}}`, and the next node references `{{client_name}}` and `{{debt_amount}}`. None of that is hardcoded into the agent. It all comes from the API call.
+
+<Tip>
+Every node has a docs link in the top right corner. If you get stuck or want to go deeper on any node type, open the docs straight from there.
+</Tip>
+
+## Step 2: Get an API key
+
+Before you trigger anything, go to the developer portal and generate an API key. You'll need it in the request header.
+
+## Step 3: Find your trigger URL
+
+Open the API Trigger node. You'll see two URLs:
+
+- **Test URL** runs your latest draft.
+- **Production URL** runs your published agent.
+
+If you change the agent and want the production URL to reflect it, publish first, otherwise production keeps running the older version. While you're still testing, use the test URL.
+
+## Step 4: Send the request
+
+Trigger the call from Postman, or wherever your backend lives. In the body, send `phone_number` and `initial_context`:
+
+```bash
+curl -X POST https://api.dograh.com/api/v1/public/agent/test/{uuid} \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: dg_your_api_key" \
+  -d '{
+    "phone_number": "+14155550100",
+    "initial_context": {
+      "debtor_name": "Rushil",
+      "client_name": "Quick Credit",
+      "debt_amount": "3500"
+    }
+  }'
+```
+
+The body can come from your CRM, a Google Sheet, or your own backend, wherever that row of data lives.
+
+## What you get
+
+Send the request, and the call goes out immediately. Because the agent already had the context before the call started, the conversation is short and specific from the first line: *"Hi, this is Alex from Apex Recovery Solutions. Am I speaking with Rushil? I'm calling about your Quick Credit account with an outstanding balance of $3,500."* No setup questions, straight to the point.
+
+## Next Steps
+
+- **Get that data back automatically**: the next step is [Send Call Data Back Automatically](/getting-started/send-call-data-with-webhooks), which takes whatever the agent learns on the call and sends it back to your system the moment it ends.
+- **No phone number connected yet?** See [Connect Your Phone Number](/getting-started/connect-telephony) first, outbound calls need a telephony provider attached.
+- **Full endpoint reference**: error codes, response shape, and choosing a specific telephony configuration are in [API Trigger](/voice-agent/api-trigger).


### PR DESCRIPTION
## Summary
- Adds 4 new tutorial pages to `getting-started`, inserted right after "Your First Agent in 5 Minutes": Trigger Calls Automatically (API Trigger), Send Call Data Back Automatically (Webhook), Connect Your Phone Number (Twilio telephony), Give Your Agent Real Data (HTTP tools + Knowledge Base)
- Each page embeds its walkthrough video at the top, followed by a step-by-step practical guide extracted from the actual recorded demo (debt-collection agent for Trigger/Webhook/Telephony, QuickMart/Maya for Tools+KB)
- Updated `docs.json` nav to insert the 4 pages in series order

## Test plan
- [x] Validated `docs.json` as JSON
- [x] Confirmed all internal cross-links resolve to existing pages
- [x] Ran `mint dev` locally and read all 4 pages end to end, video embeds load, nav order and prev/next pagination correct
- [x] Grepped for em dashes across all 4 files (repo style: none)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four video-backed getting-started tutorials, reorganizes the nav into a new "Build your First Agent" group, and embeds a walkthrough video on the First Agent page. Also clarifies that a default outbound telephony configuration is required for API Trigger.

- **New Features**
  - Trigger Calls using API — API Trigger guide with test/prod URLs and `initial_context` example.
  - Sync Data using Webhook — Webhook node guide showing `gathered_context` payload.
  - Connect with Telephony — Twilio setup for outbound and inbound calls.
  - Use External Tools, Knowledge — HTTP tools and Knowledge Base walkthrough.
  - First Agent page — embedded builder walkthrough video.

- **Bug Fixes**
  - API Trigger: documents that a default outbound telephony configuration is required; otherwise returns 400 “Telephony provider not configured for this organization.”
  - Telephony setup clarified: outbound calls require a connected provider; Twilio trial requires verifying the destination number (direct link to Twilio’s Verified Caller IDs page) and notes the trial message.
  - Webhook payloads: documents that unresolved variables remain in the payload with empty string values.
  - Knowledge Base: explains that Chunked Search requires an embeddings model; suggests Full Document for small files.
  - Link text aligned with the renamed “Connect with Telephony” page.

<sup>Written for commit bb2e54a027d38ac5f3c5ee8ac9a99600901ce16d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a video-backed getting-started series for building and connecting a voice agent. The main changes are:

- Adds tutorials for API Trigger, webhooks, Twilio telephony, HTTP tools, and Knowledge Base documents.
- Embeds walkthrough videos in the new tutorials and the first-agent guide.
- Reorganizes the getting-started navigation into a guided build sequence.
- Clarifies outbound telephony, Twilio trial, webhook variable, and embeddings requirements.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the latest documentation fixes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/docs.json | Adds the four tutorials to a dedicated getting-started navigation group. |
| docs/getting-started/add-tools-and-knowledge-base.mdx | Adds guidance for HTTP tools and both Knowledge Base retrieval modes. |
| docs/getting-started/connect-telephony.mdx | Adds Twilio setup guidance for inbound and outbound calls. |
| docs/getting-started/first-agent.mdx | Adds an embedded walkthrough video to the existing first-agent tutorial. |
| docs/getting-started/send-call-data-with-webhooks.mdx | Adds a webhook tutorial covering context variables and payload delivery. |
| docs/getting-started/trigger-calls-from-your-backend.mdx | Adds an API Trigger tutorial with prerequisites and a request example. |

<sub>Reviews (7): Last reviewed commit: ["docs: warn that default outbound telepho..."](https://github.com/dograh-hq/dograh/commit/bb2e54a027d38ac5f3c5ee8ac9a99600901ce16d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44173638)</sub>

<!-- /greptile_comment -->