### PR TITLE
Add support for native call transfers in Cloudonix telephony provider

### DIFF
--- a/api/services/telephony/providers/cloudonix/provider.py
+++ b/api/services/telephony/providers/cloudonix/provider.py
@@ -1074,7 +1074,7 @@ class CloudonixProvider(TelephonyProvider):
             "<Response>"
             "<Say>You have answered a transfer call. Connecting you now.</Say>"
             "<Dial>"
-            f'<Conference endConferenceOnExit="true" statusCallback="{callback_url}" statusCallbackEvent="join">{conference_name}</Conference>'
+            f'<Conference endConferenceOnExit="true" statusCallback="{callback_url}" statusCallbackEvent="join" holdMusic="false">{conference_name}</Conference>'
             "</Dial>"
             "</Response>"
         )

--- a/api/services/telephony/providers/cloudonix/provider.py
+++ b/api/services/telephony/providers/cloudonix/provider.py
@@ -1052,6 +1052,33 @@ class CloudonixProvider(TelephonyProvider):
 
     # ======== CALL TRANSFER METHODS ========
 
+    @staticmethod
+    def _is_sip_destination(destination: str) -> bool:
+        """A SIP destination is a SIP URI; everything else is a PSTN number."""
+        return destination.strip().lower().startswith("sip:")
+
+    @staticmethod
+    def _conference_join_cxml(destination: str, conference_name: str, callback_url: str) -> str:
+        """CXML the destination leg runs once it answers: join the conference.
+
+        PSTN destinations are dialed as a number; SIP destinations are dialed as
+        a ``<Sip>`` noun. The destination is placed into ``conference_name`` so
+        the forked caller leg meets it there.
+        """
+        if CloudonixProvider._is_sip_destination(destination):
+            dial_target = f"<Sip>{destination}</Sip>"
+        else:
+            dial_target = f"<Number>{destination}</Number>"
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            "<Response>"
+            "<Say>You have answered a transfer call. Connecting you now.</Say>"
+            "<Dial>"
+            f'<Conference endConferenceOnExit="true" statusCallback="{callback_url}" statusCallbackEvent="join">{conference_name}</Conference>'
+            "</Dial>"
+            "</Response>"
+        )
+
     async def transfer_call(
         self,
         destination: str,
@@ -1060,33 +1087,85 @@ class CloudonixProvider(TelephonyProvider):
         timeout: int = 30,
         **kwargs: Any,
     ) -> Dict[str, Any]:
+        """Dial the transfer destination into a conference via Cloudonix.
+
+        Places an outbound call whose inline CXML joins ``conference_name`` when
+        the destination answers, and sets the call object's ``callback`` to the
+        Cloudonix transfer-result route so the destination's session-status
+        transitions (``connected`` / terminal) drive transfer completion. The
+        original caller leg is later forked into the same conference by
+        ``CloudonixConferenceStrategy``.
+
+        Supports both PSTN numbers and SIP URIs as ``destination``.
+
+        Returns a dict with the destination leg's ``call_sid`` (session token).
         """
-        Initiate a call transfer via Cloudonix.
+        if not self.validate_config():
+            raise ValueError("Cloudonix provider not properly configured")
 
-        Uses inline CXML to put the destination into a conference when they answer,
-        and a status callback to track the transfer outcome.
+        if not self.from_numbers:
+            raise ValueError(
+                "No phone numbers configured for Cloudonix provider; a caller-id "
+                "is required to place the transfer call."
+            )
+        from_number = random.choice(self.from_numbers)
 
-        Args:
-            destination: The destination phone number (E.164 format)
-            transfer_id: Unique identifier for tracking this transfer
-            conference_name: Name of the conference to join the destination into
-            timeout: Transfer timeout in seconds
-            **kwargs: Additional Twilio-specific parameters
+        backend_endpoint, _ = await get_backend_endpoints()
+        callback_url = (
+            f"{backend_endpoint}/api/v1/telephony/cloudonix/transfer-result/{transfer_id}"
+        )
 
-        Returns:
-            Dict containing transfer result information
+        endpoint = f"{self.base_url}/calls/{self.domain_id}/application"
+        data: Dict[str, Any] = {
+            "destination": destination,
+            "caller-id": from_number,
+            "cxml": self._conference_join_cxml(destination, conference_name, callback_url),
+            # "callback": callback_url,
+            "timeout": timeout,
+        }
 
-        Raises:
-            ValueError: If provider configuration is invalid
-            Exception: If Twilio API call fails
-        """
-        raise NotImplementedError("Cloudonix provider does not support call transfers")
+        headers = self._get_auth_headers()
+        masked_destination = (
+            f"***{destination[-4:]}" if len(destination) > 4 else "***"
+        )
+        logger.info(
+            f"[Cloudonix Transfer] Dialing {masked_destination} into conference "
+            f"{conference_name} (transfer_id={transfer_id})"
+        )
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(endpoint, json=data, headers=headers) as response:
+                response_text = await response.text()
+                if response.status != 200:
+                    logger.error(
+                        f"[Cloudonix Transfer] Dial failed: HTTP {response.status}, "
+                        f"body: {response_text}"
+                    )
+                    raise Exception(
+                        f"Cloudonix transfer dial failed (HTTP {response.status}): "
+                        f"{response_text}"
+                    )
+
+                response_data = await response.json()
+                session_token = response_data.get("token")
+                if not session_token:
+                    raise Exception(
+                        "No session token returned from Cloudonix transfer dial"
+                    )
+
+                logger.info(
+                    f"[Cloudonix Transfer] Destination leg initiated "
+                    f"(token={session_token}, transfer_id={transfer_id})"
+                )
+                return {
+                    "call_sid": session_token,
+                    "status": response_data.get("status", "initiated"),
+                    "provider": self.PROVIDER_NAME,
+                    "from_number": from_number,
+                    "to_number": destination,
+                    "raw_response": response_data,
+                }
 
     def supports_transfers(self) -> bool:
-        """
-        Cloudonix does not support call transfers.
-
-        Returns:
-            False - Cloudonix provider does not support call transfers
-        """
-        return False
+        """Cloudonix supports conference-based call transfers."""
+        return True

--- a/api/services/telephony/providers/cloudonix/routes.py
+++ b/api/services/telephony/providers/cloudonix/routes.py
@@ -11,14 +11,103 @@ from loguru import logger
 from pipecat.utils.run_context import set_current_run_id
 
 from api.db import db_client
+from api.services.telephony.call_transfer_manager import get_call_transfer_manager
 from api.services.telephony.factory import get_telephony_provider_for_run
 from api.services.telephony.providers.cloudonix.provider import CloudonixProvider
 from api.services.telephony.status_processor import (
     StatusCallbackRequest,
     _process_status_update,
 )
+from api.services.telephony.transfer_event_protocol import (
+    TransferEvent,
+    TransferEventType,
+)
 
 router = APIRouter()
+
+# Cloudonix session statuses that terminate a transfer without an answer.
+_CLOUDONIX_TRANSFER_FAILURE_STATUSES = {
+    "busy",
+    "noanswer",
+    "cancel",
+    "nocredit",
+    "error",
+}
+
+
+@router.post("/cloudonix/transfer-result/{transfer_id}")
+async def handle_cloudonix_transfer_result(transfer_id: str, request: Request):
+    """Drive transfer completion from the destination leg's session status.
+
+    ``CloudonixProvider.transfer_call`` sets this URL as the outbound call
+    object's ``callback``. Cloudonix POSTs session-status notifications here;
+    a ``connected`` status means the destination answered (publish
+    DESTINATION_ANSWERED so the shared handler forks the caller into the
+    conference), while terminal non-answer statuses publish TRANSFER_FAILED.
+    Intermediate statuses (ringing/processing) are acked without publishing.
+    """
+    content_type = request.headers.get("content-type", "")
+    if "application/json" in content_type:
+        data = await request.json()
+    else:
+        data = dict(await request.form())
+
+    # Cloudonix session notifications may arrive as a single object or a
+    # one-element list (see session-update webhook payloads).
+    if isinstance(data, list):
+        data = data[0] if data else {}
+
+    status = str(data.get("StatusCallbackEvent", "")).lower()
+    destination_token = data.get("Session", "")
+
+    logger.info(
+        f"[Cloudonix Transfer] transfer_id={transfer_id} status={status} "
+        f"token={destination_token}"
+    )
+
+    call_transfer_manager = await get_call_transfer_manager()
+    transfer_context = await call_transfer_manager.get_transfer_context(transfer_id)
+    if not transfer_context:
+        logger.warning(
+            f"[Cloudonix Transfer] No transfer context for {transfer_id}; ignoring"
+        )
+        return {"status": "ignored", "reason": "unknown_transfer"}
+
+    original_call_sid = transfer_context.original_call_sid
+    conference_name = transfer_context.conference_name
+
+    if (status == "participant-join"):
+        event = TransferEvent(
+            type=TransferEventType.DESTINATION_ANSWERED,
+            transfer_id=transfer_id,
+            original_call_sid=original_call_sid or "",
+            transfer_call_sid=destination_token,
+            conference_name=conference_name,
+            message="Great! The destination answered. Connecting you now.",
+            status="success",
+            action="destination_answered",
+        )     
+    elif status in _CLOUDONIX_TRANSFER_FAILURE_STATUSES:
+        event = TransferEvent(
+            type=TransferEventType.TRANSFER_FAILED,
+            transfer_id=transfer_id,
+            original_call_sid=original_call_sid or "",
+            transfer_call_sid=destination_token,
+            conference_name=conference_name,
+            message="The transfer call could not be completed.",
+            status="transfer_failed",
+            action="transfer_failed",
+            reason=status,
+        )
+    else:
+        logger.info(
+            f"[Cloudonix Transfer] Intermediate status {status} for {transfer_id}, "
+            "waiting"
+        )
+        return {"status": "pending"}
+
+    await call_transfer_manager.publish_transfer_event(event)
+    return {"status": "completed"}
 
 
 @router.post("/cloudonix/status-callback/{workflow_run_id}")

--- a/api/services/telephony/providers/cloudonix/strategies.py
+++ b/api/services/telephony/providers/cloudonix/strategies.py
@@ -3,9 +3,124 @@
 from typing import Any, Dict
 
 from loguru import logger
-from pipecat.serializers.call_strategies import HangupStrategy
+from pipecat.serializers.call_strategies import HangupStrategy, TransferStrategy
 
 from api.services.telephony.providers.cloudonix.provider import CLOUDONIX_API_BASE_URL
+
+
+class CloudonixConferenceStrategy(TransferStrategy):
+    """Conference-based call transfer for Cloudonix.
+
+    Moves the original caller leg into the transfer conference by forking its
+    live session onto new CXML. Cloudonix has no live-CXML push equivalent to
+    Twilio's call-update; ``POST /calls/{domain}/sessions/{token}/fork`` is the
+    primitive that re-runs CXML on a connected session. The destination leg was
+    already dialed into the conference by ``CloudonixProvider.transfer_call``.
+
+    The fork MUST target the Cloudonix session token, which is carried on
+    ``TransferContext.original_call_sid`` (the media ``callSid`` will not
+    resolve the session).
+    """
+
+    async def execute_transfer(self, context: Dict[str, Any]) -> bool:
+        import aiohttp
+
+        transfer_context = None
+        try:
+            # call_sid here is the serializer's session token (remapped from
+            # Cloudonix call_id); use it only to locate the transfer context.
+            call_sid = context.get("call_sid") or context.get("call_id")
+            domain_id = context.get("account_sid") or context.get("domain_id")
+            bearer_token = context.get("auth_token") or context.get("bearer_token")
+
+            transfer_context = await self._find_transfer_context_for_call(call_sid)
+            if not transfer_context:
+                logger.error(
+                    f"[Cloudonix Transfer] No active transfer context for call {call_sid}"
+                )
+                return False
+
+            if not domain_id or not bearer_token:
+                logger.error(
+                    "[Cloudonix Transfer] Missing domain_id or bearer_token in context"
+                )
+                await self._cleanup_transfer_context(transfer_context.transfer_id)
+                return False
+
+            # Always fork the session token, never the media callSid.
+            session_token = transfer_context.original_call_sid
+            conference_name = transfer_context.conference_name
+
+            endpoint = (
+                f"{CLOUDONIX_API_BASE_URL}/calls/{domain_id}/sessions/"
+                f"{session_token}/application"
+            )
+            caller_cxml = (
+                '<?xml version="1.0" encoding="UTF-8"?>'
+                "<Response><Dial>"
+                f'<Conference endConferenceOnExit="true">{conference_name}</Conference>'
+                "</Dial><Hangup/></Response>"
+            )
+            payload = {"cxml": caller_cxml}
+            headers = {
+                "Authorization": f"Bearer {bearer_token}",
+                "Content-Type": "application/json",
+            }
+
+            logger.info(
+                f"[Cloudonix Transfer] Switching session {session_token} into "
+                f"conference {conference_name}"
+            )
+
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    endpoint, json=payload, headers=headers
+                ) as response:
+                    body = await response.text()
+                    if response.status in (200, 202):
+                        logger.info(
+                            f"[Cloudonix Transfer] Session {session_token} joined "
+                            f"conference {conference_name} (HTTP {response.status})"
+                        )
+                        await self._cleanup_transfer_context(
+                            transfer_context.transfer_id
+                        )
+                        return True
+                    logger.error(
+                        f"[Cloudonix Transfer] Switch Voice Application failed for session "
+                        f"{session_token}: HTTP {response.status}, body: {body}"
+                    )
+                    await self._cleanup_transfer_context(transfer_context.transfer_id)
+                    return False
+
+        except Exception as e:
+            logger.error(f"[Cloudonix Transfer] Failed to transfer call: {e}")
+            if transfer_context:
+                await self._cleanup_transfer_context(transfer_context.transfer_id)
+            return False
+
+    async def _find_transfer_context_for_call(self, call_sid: str):
+        try:
+            from api.services.telephony.call_transfer_manager import (
+                get_call_transfer_manager,
+            )
+
+            manager = await get_call_transfer_manager()
+            return await manager.find_transfer_context_for_call(call_sid)
+        except Exception as e:
+            logger.error(f"[Cloudonix Transfer] Error finding transfer context: {e}")
+            return None
+
+    async def _cleanup_transfer_context(self, transfer_id: str):
+        try:
+            from api.services.telephony.call_transfer_manager import (
+                get_call_transfer_manager,
+            )
+
+            manager = await get_call_transfer_manager()
+            await manager.remove_transfer_context(transfer_id)
+        except Exception as e:
+            logger.error(f"[Cloudonix Transfer] Error cleaning up transfer context: {e}")
 
 
 class CloudonixHangupStrategy(HangupStrategy):

--- a/api/services/telephony/providers/cloudonix/transport.py
+++ b/api/services/telephony/providers/cloudonix/transport.py
@@ -12,7 +12,7 @@ from api.services.pipecat.transport_params import realtime_param_overrides
 from api.services.telephony.factory import load_credentials_for_transport
 
 from .serializers import CloudonixFrameSerializer
-from .strategies import CloudonixHangupStrategy
+from .strategies import CloudonixConferenceStrategy, CloudonixHangupStrategy
 
 
 async def create_transport(
@@ -55,6 +55,7 @@ async def create_transport(
         domain_id=domain_id,
         bearer_token=bearer_token,
         hangup_strategy=CloudonixHangupStrategy(),
+        transfer_strategy=CloudonixConferenceStrategy(),
     )
 
     mixer = await build_audio_out_mixer(

--- a/remote_up.sh
+++ b/remote_up.sh
@@ -37,12 +37,16 @@ DOGRAH_DEPLOY_PROJECT_DIR="$SCRIPT_DIR"
 
 VALIDATE_ONLY=0
 MODE="pull"
+FOREGROUND=0
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --build)
             MODE="build"
+            ;;
+        --foreground)
+            FOREGROUND=1
             ;;
         --preflight-only|--validate-only)
             VALIDATE_ONLY=1
@@ -92,15 +96,21 @@ if dograh_is_local_ipv4 "${SERVER_IP:-}"; then
 fi
 
 if [[ "$MODE" == "build" ]]; then
-    CMD=("${COMPOSE_CMD[@]}" "${PROFILE_ARGS[@]}" up -d --build --force-recreate)
+    CMD=("${COMPOSE_CMD[@]}" "${PROFILE_ARGS[@]}" up --build --force-recreate)
 else
-    CMD=("${COMPOSE_CMD[@]}" "${PROFILE_ARGS[@]}" up -d --pull always --force-recreate)
+    CMD=("${COMPOSE_CMD[@]}" "${PROFILE_ARGS[@]}" up --pull always --force-recreate)
+fi
+
+if [[ "$FOREGROUND" == "0" ]]; then
+    CMD+=(" -d")
 fi
 
 # Bash 3.2 on macOS treats "${empty_array[@]}" as unbound under `set -u`.
 if (( ${#EXTRA_ARGS[@]} )); then
     CMD+=("${EXTRA_ARGS[@]}")
 fi
+
+echo "${CMD[@]}"
 
 # exec replaces the shell, so the EXIT trap never fires on the success path —
 # restore ownership here; everything this script writes happens before this point.

--- a/remote_up.sh
+++ b/remote_up.sh
@@ -102,7 +102,7 @@ else
 fi
 
 if [[ "$FOREGROUND" == "0" ]]; then
-    CMD+=(" -d")
+    CMD+=("-d")
 fi
 
 # Bash 3.2 on macOS treats "${empty_array[@]}" as unbound under `set -u`.


### PR DESCRIPTION
Add proper support workflow for call forking and conference handling in Cloudonix
platform call transfers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native Cloudonix conference-based call transfers with PSTN and SIP support, plus cleaner conference audio and reliable status handling. Also improves `remote_up.sh` with a foreground mode and correct detached flag behavior.

- **New Features**
  - Cloudonix transfers: dials the destination into a conference via inline CXML, supports PSTN numbers and SIP URIs, disables hold music, and sets a conference join callback to drive transfer results.
  - Transfer handling: new `/cloudonix/transfer-result/{transfer_id}` maps `participant-join` to destination answered and `busy/noanswer/cancel/nocredit/error` to failed; publishes transfer events; `CloudonixConferenceStrategy` switches the caller session into the same conference; transport wires this strategy; `supports_transfers()` returns True.
  - DevOps: `remote_up.sh` adds `--foreground` to run `docker compose up` in the foreground, fixes how `-d` is passed when detached, and echoes the final command.

<sup>Written for commit c89a43f9b043c9c212517427a09d9396ed99be81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds native Cloudonix call transfer support through a conference-based flow. The main changes are:

- Outbound Cloudonix transfer dialing with inline CXML for PSTN numbers and SIP URIs.
- A Cloudonix transfer-result webhook that publishes shared transfer events.
- A Cloudonix transfer strategy that moves the caller session into the transfer conference.
- Transport wiring for the new transfer strategy.
- `remote_up.sh` support for foreground compose runs.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge after the existing Cloudonix transfer callback concern is resolved.

The provider-local transfer wiring and script change are straightforward. The current diff still shows the destination-leg callback disabled, which affects reliable failure reporting, but that issue has already been raised on the PR.

`api/services/telephony/providers/cloudonix/provider.py`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the corresponding review comment.
- T-Rex validated the contract behavior and observed that supports\_transfers is false, no outbound Cloudonix requests were made, transfer attempts for +15551234567 and sip:agent@example.com returned NotImplementedError: Cloudonix provider does not support call transfers, and the route load reported a missing handle\_cloudonix\_transfer\_result.

<a href="https://app.greptile.com/trex/runs/14514425/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/services/telephony/providers/cloudonix/provider.py | Adds Cloudonix conference-based transfer dialing, destination-leg CXML generation, and advertises transfer support; previous callback wiring concern remains in the changed area. |
| api/services/telephony/providers/cloudonix/routes.py | Adds the transfer-result webhook that maps Cloudonix destination and conference statuses into shared Redis transfer events. |
| api/services/telephony/providers/cloudonix/strategies.py | Adds a Cloudonix transfer strategy to switch the caller session into the transfer conference and clean up Redis context. |
| api/services/telephony/providers/cloudonix/transport.py | Wires the new Cloudonix transfer strategy into the frame serializer alongside the existing hangup strategy. |
| remote_up.sh | Adds foreground mode support while preserving detached mode by appending `-d` as a separate compose argument. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Tool as Transfer tool
participant Provider as CloudonixProvider
participant CX as Cloudonix
participant Route as transfer-result route
participant Redis as CallTransferManager/Redis
participant Strategy as CloudonixConferenceStrategy

Tool->>Redis: store TransferContext
Tool->>Provider: transfer_call(destination, transfer_id, conference)
Provider->>CX: POST outbound call with inline CXML
CX-->>Provider: destination session token
Provider-->>Tool: call_sid/status
CX->>Route: POST transfer result status
Route->>Redis: publish DESTINATION_ANSWERED or TRANSFER_FAILED
Tool->>Redis: wait_for_transfer_completion
Tool->>Strategy: execute transfer after destination answered
Strategy->>CX: switch caller session into conference
Strategy->>Redis: remove TransferContext
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Tool as Transfer tool
participant Provider as CloudonixProvider
participant CX as Cloudonix
participant Route as transfer-result route
participant Redis as CallTransferManager/Redis
participant Strategy as CloudonixConferenceStrategy

Tool->>Redis: store TransferContext
Tool->>Provider: transfer_call(destination, transfer_id, conference)
Provider->>CX: POST outbound call with inline CXML
CX-->>Provider: destination session token
Provider-->>Tool: call_sid/status
CX->>Route: POST transfer result status
Route->>Redis: publish DESTINATION_ANSWERED or TRANSFER_FAILED
Tool->>Redis: wait_for_transfer_completion
Tool->>Strategy: execute transfer after destination answered
Strategy->>CX: switch caller session into conference
Strategy->>Redis: remove TransferContext
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cloudonix native transfer contract is not implemented in current checkout**

   - **Bug**
     - The validation objective expected Cloudonix to support native transfers, generate outbound destination-leg requests for PSTN and SIP destinations, and expose a transfer-result callback route. Runtime execution on current head showed the provider still reports no transfer support, `transfer_call` raises `NotImplementedError`, and the route module does not expose `handle_cloudonix_transfer_result`.
   - **Cause**
     - The current `api/services/telephony/providers/cloudonix/provider.py` implementation still returns `False` from `supports_transfers()` and raises `NotImplementedError` from `transfer_call()`. The current `routes.py` also lacks the transfer-result route handler required by the PR contract.
   - **Fix**
     - Implement `CloudonixProvider.transfer_call()` to place a mocked/local outbound Cloudonix application request with inline conference CXML for both `<Number>` and `<Sip>` destinations, return `supports_transfers() == True`, and add `/cloudonix/transfer-result/{transfer_id}` to publish answered/failure transfer events while acknowledging intermediate statuses.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Update remote\_up.sh"](https://github.com/dograh-hq/dograh/commit/c89a43f9b043c9c212517427a09d9396ed99be81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44392250)</sub>

<!-- /greptile_comment -->