### PR TITLE
fix(vobiz): synchronize application number bindings

### DIFF
--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -541,7 +541,7 @@ def _phone_number_to_response(
 
 
 async def _sync_inbound_for_phone_number(
-    config_id: int, organization_id: int, address: str
+    config_id: int, organization_id: int, address: str, *, attach: bool = True
 ) -> ProviderSyncStatus:
     """Push inbound webhook configuration to the provider.
 
@@ -558,8 +558,10 @@ async def _sync_inbound_for_phone_number(
         logger.error(f"Failed to load telephony provider for config {config_id}: {e}")
         return ProviderSyncStatus(ok=False, message=f"Provider load failed: {e}")
 
-    backend_endpoint, _ = await get_backend_endpoints()
-    webhook_url = f"{backend_endpoint}/api/v1/telephony/inbound/run"
+    webhook_url = None
+    if attach:
+        backend_endpoint, _ = await get_backend_endpoints()
+        webhook_url = f"{backend_endpoint}/api/v1/telephony/inbound/run"
 
     try:
         result = await provider.configure_inbound(address, webhook_url)
@@ -869,7 +871,10 @@ async def create_phone_number(
     response = _phone_number_to_response(row)
     if request.inbound_workflow_id is not None:
         response.provider_sync = await _sync_inbound_for_phone_number(
-            config_id, user.selected_organization_id, row.address
+            config_id,
+            user.selected_organization_id,
+            row.address,
+            attach=row.is_active,
         )
     return response
 
@@ -934,7 +939,10 @@ async def update_phone_number(
     # Sync the provider application or address with the inbound
     # calling webhook address
     response.provider_sync = await _sync_inbound_for_phone_number(
-        config_id, user.selected_organization_id, row.address
+        config_id,
+        user.selected_organization_id,
+        row.address,
+        attach=row.inbound_workflow_id is not None and row.is_active,
     )
     return response
 
@@ -972,11 +980,29 @@ async def delete_phone_number(
     if not existing:
         raise HTTPException(status_code=404, detail="Phone number not found")
 
+    provider_sync = await _sync_inbound_for_phone_number(
+        config_id,
+        user.selected_organization_id,
+        existing.address,
+        attach=False,
+    )
+    if not provider_sync.ok:
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                provider_sync.message
+                or "Provider rejected the phone-number detach request"
+            ),
+        )
+
     deleted = await db_client.delete_phone_number(phone_number_id, config_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Phone number not found")
 
-    return {"message": "Phone number deleted"}
+    return {
+        "message": "Phone number deleted",
+        "provider_sync": provider_sync.model_dump(),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/api/services/telephony/providers/vobiz/provider.py
+++ b/api/services/telephony/providers/vobiz/provider.py
@@ -8,7 +8,7 @@ import hmac
 import json
 import random
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 import aiohttp
 from fastapi import HTTPException
@@ -503,22 +503,14 @@ class VobizProvider(TelephonyProvider):
     async def configure_inbound(
         self, address: str, webhook_url: Optional[str]
     ) -> ProviderSyncResult:
-        """Update answer_url on the Vobiz Application (Plivo-compatible model).
+        """Attach or detach a Vobiz number from the configured Application.
 
-        Vobiz's update is partial so we POST only ``answer_url`` and
-        ``answer_method`` — ``app_name``, ``hangup_url``, etc. stay as the
-        user set them. The URL is shared across every number on the
-        application — clearing is a no-op to avoid silently breaking
-        inbound for sibling numbers.
+        Attaching first binds this number to the Application and then updates
+        the shared Application ``answer_url``. This ordering avoids changing
+        existing numbers when the target number cannot be bound. Detaching
+        removes only the number binding; it does not clear the shared
+        ``answer_url`` because sibling numbers may still use it.
         """
-        if webhook_url is None:
-            logger.info(
-                f"Vobiz configure_inbound clear for {address}: skipping "
-                f"application update (answer_url is shared across all numbers "
-                f"on application {self.application_id})"
-            )
-            return ProviderSyncResult(ok=True)
-
         if not self.validate_config():
             return ProviderSyncResult(
                 ok=False, message="Vobiz provider not properly configured"
@@ -534,6 +526,22 @@ class VobizProvider(TelephonyProvider):
                 ),
             )
 
+        try:
+            normalized_address = normalize_telephony_address(address)
+        except ValueError as e:
+            return ProviderSyncResult(ok=False, message=f"Invalid Vobiz number: {e}")
+
+        if normalized_address.address_type != "pstn":
+            return ProviderSyncResult(
+                ok=False,
+                message="Vobiz Application attachment requires a PSTN phone number",
+            )
+
+        encoded_address = quote(normalized_address.canonical, safe="")
+        number_endpoint = (
+            f"{self.base_url}/v1/account/{self.auth_id}/numbers/"
+            f"{encoded_address}/application"
+        )
         app_endpoint = (
             f"{self.base_url}/v1/Account/{self.auth_id}/Application/"
             f"{self.application_id}/"
@@ -550,6 +558,43 @@ class VobizProvider(TelephonyProvider):
 
         try:
             async with aiohttp.ClientSession() as session:
+                if webhook_url is None:
+                    async with session.delete(
+                        number_endpoint, headers=headers
+                    ) as response:
+                        if response.status not in (200, 204):
+                            body = await response.text()
+                            logger.error(
+                                f"Vobiz number detach failed for {address}: "
+                                f"{response.status} {body}"
+                            )
+                            return ProviderSyncResult(
+                                ok=False,
+                                message=f"Vobiz API {response.status}: {body}",
+                            )
+
+                    logger.info(
+                        f"Vobiz number {normalized_address.canonical} detached "
+                        f"from application {self.application_id}"
+                    )
+                    return ProviderSyncResult(ok=True)
+
+                async with session.post(
+                    number_endpoint,
+                    json={"application_id": str(self.application_id)},
+                    headers=headers,
+                ) as response:
+                    if response.status not in (200, 201, 204):
+                        body = await response.text()
+                        logger.error(
+                            f"Vobiz number attach failed for {address}: "
+                            f"{response.status} {body}"
+                        )
+                        return ProviderSyncResult(
+                            ok=False,
+                            message=f"Vobiz API {response.status}: {body}",
+                        )
+
                 async with session.post(
                     app_endpoint, json=data, headers=headers
                 ) as response:
@@ -565,13 +610,14 @@ class VobizProvider(TelephonyProvider):
                         )
         except Exception as e:
             logger.error(
-                f"Exception updating Vobiz application {self.application_id}: {e}"
+                f"Exception syncing Vobiz application {self.application_id} "
+                f"for {address}: {e}"
             )
-            return ProviderSyncResult(ok=False, message=f"Vobiz update failed: {e}")
+            return ProviderSyncResult(ok=False, message=f"Vobiz sync failed: {e}")
 
         logger.info(
-            f"Vobiz answer_url set on application {self.application_id} "
-            f"(triggered by address {address})"
+            f"Vobiz number {normalized_address.canonical} attached to application "
+            f"{self.application_id}; answer_url set to {webhook_url}"
         )
         return ProviderSyncResult(ok=True)
 

--- a/api/services/telephony/providers/vobiz/provider.py
+++ b/api/services/telephony/providers/vobiz/provider.py
@@ -510,6 +510,10 @@ class VobizProvider(TelephonyProvider):
         existing numbers when the target number cannot be bound. Detaching
         removes only the number binding; it does not clear the shared
         ``answer_url`` because sibling numbers may still use it.
+
+        API references:
+        - Attach: https://vobiz.ai/docs/applications/attach-number
+        - Detach: https://vobiz.ai/docs/applications/detach-number
         """
         if not self.validate_config():
             return ProviderSyncResult(
@@ -539,7 +543,7 @@ class VobizProvider(TelephonyProvider):
 
         encoded_address = quote(normalized_address.canonical, safe="")
         number_endpoint = (
-            f"{self.base_url}/v1/account/{self.auth_id}/numbers/"
+            f"{self.base_url}/v1/Account/{self.auth_id}/numbers/"
             f"{encoded_address}/application"
         )
         app_endpoint = (
@@ -559,9 +563,17 @@ class VobizProvider(TelephonyProvider):
         try:
             async with aiohttp.ClientSession() as session:
                 if webhook_url is None:
+                    # https://vobiz.ai/docs/applications/detach-number
                     async with session.delete(
                         number_endpoint, headers=headers
                     ) as response:
+                        if response.status == 404:
+                            logger.info(
+                                f"Vobiz number {normalized_address.canonical} "
+                                "is already detached or absent from the account"
+                            )
+                            return ProviderSyncResult(ok=True)
+
                         if response.status not in (200, 204):
                             body = await response.text()
                             logger.error(
@@ -579,6 +591,7 @@ class VobizProvider(TelephonyProvider):
                     )
                     return ProviderSyncResult(ok=True)
 
+                # https://vobiz.ai/docs/applications/attach-number
                 async with session.post(
                     number_endpoint,
                     json={"application_id": str(self.application_id)},
@@ -590,9 +603,37 @@ class VobizProvider(TelephonyProvider):
                             f"Vobiz number attach failed for {address}: "
                             f"{response.status} {body}"
                         )
+
+                        body_lower = body.lower()
+                        if response.status == 409 or "already" in body_lower:
+                            message = (
+                                "Vobiz indicates that this phone number is already "
+                                "attached to an application. To enable inbound calls "
+                                "in Dograh, review the phone number configuration in "
+                                "Vobiz and ensure that the number is attached to the "
+                                "Application ID configured in Dograh "
+                                f"({self.application_id})."
+                            )
+                        elif response.status == 404:
+                            message = (
+                                "Vobiz could not find this phone number or the "
+                                "configured Application ID. Confirm that the number "
+                                "belongs to this Vobiz account and that Application "
+                                f"ID {self.application_id} exists."
+                            )
+                        elif 400 <= response.status < 500:
+                            message = (
+                                "Vobiz rejected the phone number attachment "
+                                f"(HTTP {response.status}). Review the number in "
+                                "Vobiz and ensure it can be attached to Application "
+                                f"ID {self.application_id}."
+                            )
+                        else:
+                            message = f"Vobiz API {response.status}: {body}"
+
                         return ProviderSyncResult(
                             ok=False,
-                            message=f"Vobiz API {response.status}: {body}",
+                            message=message,
                         )
 
                 async with session.post(

--- a/api/tests/telephony/vobiz/test_phone_number_sync.py
+++ b/api/tests/telephony/vobiz/test_phone_number_sync.py
@@ -1,0 +1,167 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.organization import (
+    _sync_inbound_for_phone_number,
+    delete_phone_number,
+    update_phone_number,
+)
+from api.schemas.telephony_phone_number import (
+    PhoneNumberUpdateRequest,
+    ProviderSyncStatus,
+)
+from api.services.telephony.base import ProviderSyncResult
+
+
+@pytest.mark.asyncio
+async def test_phone_number_sync_passes_none_to_provider_when_detaching():
+    provider = SimpleNamespace(
+        configure_inbound=AsyncMock(return_value=ProviderSyncResult(ok=True))
+    )
+
+    with (
+        patch(
+            "api.routes.organization.get_telephony_provider_by_id",
+            new_callable=AsyncMock,
+            return_value=provider,
+        ),
+        patch(
+            "api.routes.organization.get_backend_endpoints",
+            new_callable=AsyncMock,
+        ) as get_backend_endpoints,
+    ):
+        result = await _sync_inbound_for_phone_number(
+            7, 11, "+15551230002", attach=False
+        )
+
+    assert result.ok
+    get_backend_endpoints.assert_not_awaited()
+    provider.configure_inbound.assert_awaited_once_with("+15551230002", None)
+
+
+@pytest.mark.asyncio
+async def test_clearing_inbound_workflow_detaches_provider_number():
+    existing = SimpleNamespace(address="+15551230002")
+    updated = SimpleNamespace(
+        address="+15551230002",
+        inbound_workflow_id=None,
+        is_active=True,
+    )
+    response = SimpleNamespace(provider_sync=None)
+    sync_status = ProviderSyncStatus(ok=True)
+
+    with (
+        patch(
+            "api.routes.organization._ensure_config_belongs_to_org",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "api.routes.organization.db_client.get_phone_number_for_config",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            "api.routes.organization.db_client.update_phone_number",
+            new_callable=AsyncMock,
+            return_value=updated,
+        ),
+        patch(
+            "api.routes.organization._phone_number_to_response",
+            return_value=response,
+        ),
+        patch(
+            "api.routes.organization._sync_inbound_for_phone_number",
+            new_callable=AsyncMock,
+            return_value=sync_status,
+        ) as sync_inbound,
+    ):
+        result = await update_phone_number(
+            config_id=7,
+            phone_number_id=9,
+            request=PhoneNumberUpdateRequest(clear_inbound_workflow=True),
+            user=SimpleNamespace(selected_organization_id=11),
+        )
+
+    assert result.provider_sync == sync_status
+    sync_inbound.assert_awaited_once_with(7, 11, "+15551230002", attach=False)
+
+
+@pytest.mark.asyncio
+async def test_deleting_phone_number_detaches_provider_number():
+    existing = SimpleNamespace(address="+15551230002")
+    sync_status = ProviderSyncStatus(ok=True)
+
+    with (
+        patch(
+            "api.routes.organization._ensure_config_belongs_to_org",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "api.routes.organization.db_client.get_phone_number_for_config",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            "api.routes.organization.db_client.delete_phone_number",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "api.routes.organization._sync_inbound_for_phone_number",
+            new_callable=AsyncMock,
+            return_value=sync_status,
+        ) as sync_inbound,
+    ):
+        result = await delete_phone_number(
+            config_id=7,
+            phone_number_id=9,
+            user=SimpleNamespace(selected_organization_id=11),
+        )
+
+    assert result == {
+        "message": "Phone number deleted",
+        "provider_sync": {"ok": True, "message": None},
+    }
+    sync_inbound.assert_awaited_once_with(7, 11, "+15551230002", attach=False)
+
+
+@pytest.mark.asyncio
+async def test_failed_detach_preserves_local_phone_number():
+    existing = SimpleNamespace(address="+15551230002")
+    delete_local = AsyncMock(return_value=True)
+
+    with (
+        patch(
+            "api.routes.organization._ensure_config_belongs_to_org",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "api.routes.organization.db_client.get_phone_number_for_config",
+            new_callable=AsyncMock,
+            return_value=existing,
+        ),
+        patch(
+            "api.routes.organization.db_client.delete_phone_number",
+            delete_local,
+        ),
+        patch(
+            "api.routes.organization._sync_inbound_for_phone_number",
+            new_callable=AsyncMock,
+            return_value=ProviderSyncStatus(
+                ok=False, message="Vobiz API 409: number is still assigned"
+            ),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_phone_number(
+                config_id=7,
+                phone_number_id=9,
+                user=SimpleNamespace(selected_organization_id=11),
+            )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == "Vobiz API 409: number is still assigned"
+    delete_local.assert_not_awaited()

--- a/api/tests/telephony/vobiz/test_routes.py
+++ b/api/tests/telephony/vobiz/test_routes.py
@@ -272,7 +272,7 @@ async def test_vobiz_configure_inbound_updates_application_and_attaches_number()
     assert session.requests == [
         (
             "POST",
-            "https://api.vobiz.ai/api/v1/account/MA123/numbers/"
+            "https://api.vobiz.ai/api/v1/Account/MA123/numbers/"
             "%2B15551230002/application",
             {"application_id": "12345678901234567"},
         ),
@@ -304,15 +304,42 @@ async def test_vobiz_configure_inbound_does_not_update_application_when_attach_f
         )
 
     assert not result.ok
-    assert result.message == "Vobiz API 409: number already assigned"
+    assert result.message == (
+        "Vobiz indicates that this phone number is already attached to an "
+        "application. To enable inbound calls in Dograh, review the phone number "
+        "configuration in Vobiz and ensure that the number is attached to the "
+        "Application ID configured in Dograh (12345678901234567)."
+    )
     assert session.requests == [
         (
             "POST",
-            "https://api.vobiz.ai/api/v1/account/MA123/numbers/"
+            "https://api.vobiz.ai/api/v1/Account/MA123/numbers/"
             "%2B15551230002/application",
             {"application_id": "12345678901234567"},
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_vobiz_configure_inbound_explains_missing_number_or_application():
+    provider = _provider(application_id="12345678901234567")
+    session = _StubSession([_StubResponse(404, "not found")])
+
+    with patch(
+        "api.services.telephony.providers.vobiz.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.configure_inbound(
+            "+15551230002",
+            "https://voice.example.test/api/v1/telephony/inbound/run",
+        )
+
+    assert not result.ok
+    assert result.message == (
+        "Vobiz could not find this phone number or the configured Application ID. "
+        "Confirm that the number belongs to this Vobiz account and that Application "
+        "ID 12345678901234567 exists."
+    )
 
 
 @pytest.mark.asyncio
@@ -330,7 +357,29 @@ async def test_vobiz_configure_inbound_detaches_number_without_clearing_applicat
     assert session.requests == [
         (
             "DELETE",
-            "https://api.vobiz.ai/api/v1/account/MA123/numbers/"
+            "https://api.vobiz.ai/api/v1/Account/MA123/numbers/"
+            "%2B15551230002/application",
+            None,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_vobiz_configure_inbound_treats_missing_detach_as_success():
+    provider = _provider(application_id="12345678901234567")
+    session = _StubSession([_StubResponse(404, "number has no application")])
+
+    with patch(
+        "api.services.telephony.providers.vobiz.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.configure_inbound("+15551230002", None)
+
+    assert result.ok
+    assert session.requests == [
+        (
+            "DELETE",
+            "https://api.vobiz.ai/api/v1/Account/MA123/numbers/"
             "%2B15551230002/application",
             None,
         )

--- a/api/tests/telephony/vobiz/test_routes.py
+++ b/api/tests/telephony/vobiz/test_routes.py
@@ -17,11 +17,12 @@ from api.services.telephony.providers.vobiz.routes import (
 )
 
 
-def _provider() -> VobizProvider:
+def _provider(application_id: str | None = None) -> VobizProvider:
     return VobizProvider(
         {
             "auth_id": "MA123",
             "auth_token": "vobiz-auth-token",
+            "application_id": application_id,
             "from_numbers": ["+15551230002"],
         }
     )
@@ -76,6 +77,41 @@ def _signed_headers(provider: VobizProvider, *, url: str) -> dict[str, str]:
         "x-vobiz-signature-v3": signature,
         "x-vobiz-signature-v3-nonce": nonce,
     }
+
+
+class _StubResponse:
+    def __init__(self, status: int, body: str = ""):
+        self.status = status
+        self._body = body
+
+    async def text(self) -> str:
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _StubSession:
+    def __init__(self, responses: list[_StubResponse]):
+        self.responses = responses
+        self.requests: list[tuple[str, str, dict | None]] = []
+
+    def post(self, url: str, *, json: dict, headers: dict):
+        self.requests.append(("POST", url, json))
+        return self.responses.pop(0)
+
+    def delete(self, url: str, *, headers: dict):
+        self.requests.append(("DELETE", url, None))
+        return self.responses.pop(0)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
 
 
 @pytest.mark.asyncio
@@ -216,6 +252,89 @@ async def test_vobiz_verify_inbound_signature_accepts_v2():
             "X-Vobiz-Signature-V2-Nonce": nonce,
         },
     )
+
+
+@pytest.mark.asyncio
+async def test_vobiz_configure_inbound_updates_application_and_attaches_number():
+    provider = _provider(application_id="12345678901234567")
+    session = _StubSession([_StubResponse(204), _StubResponse(202)])
+
+    with patch(
+        "api.services.telephony.providers.vobiz.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.configure_inbound(
+            "+15551230002",
+            "https://voice.example.test/api/v1/telephony/inbound/run",
+        )
+
+    assert result.ok
+    assert session.requests == [
+        (
+            "POST",
+            "https://api.vobiz.ai/api/v1/account/MA123/numbers/"
+            "%2B15551230002/application",
+            {"application_id": "12345678901234567"},
+        ),
+        (
+            "POST",
+            "https://api.vobiz.ai/api/v1/Account/MA123/Application/12345678901234567/",
+            {
+                "answer_url": (
+                    "https://voice.example.test/api/v1/telephony/inbound/run"
+                ),
+                "answer_method": "POST",
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_vobiz_configure_inbound_does_not_update_application_when_attach_fails():
+    provider = _provider(application_id="12345678901234567")
+    session = _StubSession([_StubResponse(409, "number already assigned")])
+
+    with patch(
+        "api.services.telephony.providers.vobiz.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.configure_inbound(
+            "+15551230002",
+            "https://voice.example.test/api/v1/telephony/inbound/run",
+        )
+
+    assert not result.ok
+    assert result.message == "Vobiz API 409: number already assigned"
+    assert session.requests == [
+        (
+            "POST",
+            "https://api.vobiz.ai/api/v1/account/MA123/numbers/"
+            "%2B15551230002/application",
+            {"application_id": "12345678901234567"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_vobiz_configure_inbound_detaches_number_without_clearing_application():
+    provider = _provider(application_id="12345678901234567")
+    session = _StubSession([_StubResponse(204)])
+
+    with patch(
+        "api.services.telephony.providers.vobiz.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.configure_inbound("+15551230002", None)
+
+    assert result.ok
+    assert session.requests == [
+        (
+            "DELETE",
+            "https://api.vobiz.ai/api/v1/account/MA123/numbers/"
+            "%2B15551230002/application",
+            None,
+        )
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- attach a Vobiz number to the configured Application when an inbound workflow is assigned
- detach it when the workflow is cleared or the number is deleted
- bind the number before updating the shared `answer_url` to avoid partial Application changes
- preserve local phone-number state when provider detach fails

## Why
Discovered separately during E2E for #374: Dograh’s local workflow association did not bind the number in Vobiz, so callbacks could not reach Dograh. This PR is intentionally split from the signature-validation fix in #533.

## Testing
- 21 focused telephony/Vobiz tests pass in Docker
- live inbound and outbound E2E completed successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Vobiz number-to-Application bindings in sync when inbound workflows are set, cleared, numbers are deactivated, or deleted. Attaches the number before updating the Application `answer_url`, and detaches without clearing it to avoid breaking other numbers.

- **Bug Fixes**
  - Attach the number to the Application before setting `answer_url` when assigning an inbound workflow.
  - Detach on workflow clear, deactivation, or delete; do not clear the shared `answer_url`.
  - Only attach for active numbers; on update, attach only when an inbound workflow is set and the number is active.
  - Add `attach` flag to `_sync_inbound_for_phone_number`; pass `None` on detach and skip backend URL fetch.
  - Delete flow: detach first; on detach failure return 502 and keep the local number; include `provider_sync` in the delete response.
  - Provider: implement attach/detach endpoints, require PSTN numbers, URL-encode numbers, stop application update if attach fails, and return clearer error messages.
  - Tests: cover attach-before-update, detach on clear/delete, skipping backend URL on detach, delete failure handling, and provider attach/detach flows.

<sup>Written for commit e52da077b5e6ab0b5b435b966fba3b724a19edfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR synchronizes Vobiz phone-number bindings with inbound workflow state. The main changes are:

- Attach active Vobiz numbers to the configured Application when assigning inbound workflows.
- Detach Vobiz numbers when workflows are cleared, numbers are deactivated, or numbers are deleted.
- Update the shared Vobiz `answer_url` only after a successful number attach.
- Preserve local phone-number rows when provider detach fails during delete.
- Add focused tests for attach, detach, delete failure, and Vobiz provider error handling.

<h3>Confidence Score: 4/5</h3>

One contained provider-sync issue needs to be fixed before merging.

The main Vobiz attach and detach paths are covered, but inactive phone-number creation can send the wrong provider action.

`api/routes/organization.py`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Inspected the focused route code and confirmed the create path calls provider sync with attach derived from row.is\_active when inbound\_workflow\_id is present.
- Inspected the focused Vobiz provider code and confirmed configure\_inbound with webhook\_url None executes a DELETE against the number application endpoint.
- Tried to run a generated Python harness for inactive create detach, but direct imports were blocked by a Pipecat package mismatch and the step limit prevented a successful reproduction.
- Reviewed the focused pytest run artifacts and noted the initial collection error, the shim-enabled rerun, and the final failure exit code 2.
- Observed the preservation of validation shim sources for further inspection, including the sitecustomize shim and the silence\_mixer shim.

<a href="https://app.greptile.com/trex/runs/14939650/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/routes/organization.py | Adds attach/detach sync orchestration for phone-number CRUD, but inactive create currently issues a detach instead of skipping provider sync. |
| api/services/telephony/providers/vobiz/provider.py | Implements Vobiz number attach/detach before shared Application answer_url updates with normalized PSTN endpoints and provider error mapping. |
| api/tests/telephony/vobiz/test_phone_number_sync.py | Adds route-level tests for detach flows and delete failure preservation, but misses the inactive-create skip case. |
| api/tests/telephony/vobiz/test_routes.py | Extends Vobiz provider tests for attach-before-update, detach behavior, idempotent missing detach, and error messages. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client
participant OrgRoute as api/routes/organization.py
participant Provider as VobizProvider
participant Vobiz as Vobiz API

Client->>OrgRoute: create/update/delete phone number
OrgRoute->>Provider: configure_inbound(address, webhook_url or None)
alt attach active inbound workflow
    Provider->>Vobiz: "POST /numbers/{number}/application"
    Vobiz-->>Provider: 200/201/204
    Provider->>Vobiz: "POST /Application/{application_id}/ answer_url"
    Vobiz-->>Provider: 200/202
else detach cleared/deleted/inactive
    Provider->>Vobiz: "DELETE /numbers/{number}/application"
    Vobiz-->>Provider: 200/204 or 404 as success
end
Provider-->>OrgRoute: ProviderSyncResult
OrgRoute-->>Client: phone-number response with provider_sync
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client
participant OrgRoute as api/routes/organization.py
participant Provider as VobizProvider
participant Vobiz as Vobiz API

Client->>OrgRoute: create/update/delete phone number
OrgRoute->>Provider: configure_inbound(address, webhook_url or None)
alt attach active inbound workflow
    Provider->>Vobiz: "POST /numbers/{number}/application"
    Vobiz-->>Provider: 200/201/204
    Provider->>Vobiz: "POST /Application/{application_id}/ answer_url"
    Vobiz-->>Provider: 200/202
else detach cleared/deleted/inactive
    Provider->>Vobiz: "DELETE /numbers/{number}/application"
    Vobiz-->>Provider: 200/204 or 404 as success
end
Provider-->>OrgRoute: ProviderSyncResult
OrgRoute-->>Client: phone-number response with provider_sync
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `api/routes/organization.py`, line 924-946 ([link](https://github.com/dograh-hq/dograh/blob/a5e4671221912fd9ade466c1f99b7d5087f33213/api/routes/organization.py#L924-L946)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Detach failure desynchronizes state**
   `update_phone_number` commits the cleared `inbound_workflow_id` before calling the provider detach, so a Vobiz detach failure leaves Dograh showing no inbound workflow while the upstream number is still bound to the application. This is the same failure mode the delete path avoids by detaching before deleting; clearing or deactivating a number should preserve the local row when `provider_sync.ok` is false.

   **Context Used:** api/CLAUDE.md ([source](https://app.greptile.com/dograh-hq/github/dograh-hq/dograh/-/custom-context?memory=2fd3c289-c1ee-4fac-a5c3-c764274cd7ef))
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(vobiz): address number binding revie..."](https://github.com/dograh-hq/dograh/commit/e52da077b5e6ab0b5b435b966fba3b724a19edfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44416084)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - api/services/telephony/AGENTS.md ([source](https://app.greptile.com/dograh-hq/github/dograh-hq/dograh/-/custom-context?memory=5ba24b5a-a47b-4a9f-815f-2697e7295e4b))

<!-- /greptile_comment -->