### PR TITLE
Add support for Cloudonix parameters in WebSocket start event

### DIFF
--- a/api/services/telephony/providers/cloudonix/provider.py
+++ b/api/services/telephony/providers/cloudonix/provider.py
@@ -626,18 +626,38 @@ class CloudonixProvider(TelephonyProvider):
                 )
                 return
 
+            logger.info(
+                f"Cloudonix agent-stream: inbound customParemeters "
+                f"{start.get("customParameters")}"
+            )
+
             start_context = start.get("context")
+            custom_parameters = start.get("customParameters")
+            builtin_context = {
+                "caller_number": start.get("from"),
+                "called_number": start.get("to"),
+                "direction": (
+                    "outbound" if start_context == "outbound-api" else "inbound"
+                ),
+                "cloudonix_context": start_context,
+            }
             await db_client.update_workflow_run(
                 run_id=workflow_run_id,
                 initial_context={
+                    # Flatten customParameters, but never let them overwrite a
+                    # built-in key even when the built-in's value is None.
                     key: value
                     for key, value in {
-                        "caller_number": start.get("from"),
-                        "called_number": start.get("to"),
-                        "direction": (
-                            "outbound" if start_context == "outbound-api" else "inbound"
-                        ),
-                        "cloudonix_context": start_context,
+                        **{
+                            k: v
+                            for k, v in (
+                                custom_parameters
+                                if isinstance(custom_parameters, dict)
+                                else {}
+                            ).items()
+                            if k not in builtin_context
+                        },
+                        **builtin_context,
                     }.items()
                     if value is not None
                 },
@@ -1059,7 +1079,7 @@ class CloudonixProvider(TelephonyProvider):
             "<Response>"
             "<Say>You have answered a transfer call. Connecting you now.</Say>"
             "<Dial>"
-            f'<Conference endConferenceOnExit="true" statusCallback="{callback_url}" statusCallbackEvent="join" holdMusic="false" beep="false">{conference_name}</Conference>'
+            f'<Conference endConferenceOnExit="true" statusCallback="{callback_url}" statusCallbackEvent="join" holdMusic="false">{conference_name}</Conference>'
             "</Dial>"
             "</Response>"
         )
@@ -1096,7 +1116,9 @@ class CloudonixProvider(TelephonyProvider):
         from_number = random.choice(self.from_numbers)
 
         backend_endpoint, _ = await get_backend_endpoints()
-        callback_url = f"{backend_endpoint}/api/v1/telephony/cloudonix/transfer-result/{transfer_id}"
+        callback_url = (
+            f"{backend_endpoint}/api/v1/telephony/cloudonix/transfer-result/{transfer_id}"
+        )
 
         endpoint = f"{self.base_url}/calls/{self.domain_id}/application"
         data: Dict[str, Any] = {
@@ -1109,7 +1131,9 @@ class CloudonixProvider(TelephonyProvider):
 
         data.update(kwargs)
         headers = self._get_auth_headers()
-        masked_destination = f"***{destination[-4:]}" if len(destination) > 4 else "***"
+        masked_destination = (
+            f"***{destination[-4:]}" if len(destination) > 4 else "***"
+        )
         logger.info(
             f"[Cloudonix Transfer] Dialing {masked_destination} into conference "
             f"{conference_name} (transfer_id={transfer_id})"

--- a/api/services/telephony/providers/cloudonix/provider.py
+++ b/api/services/telephony/providers/cloudonix/provider.py
@@ -626,11 +626,6 @@ class CloudonixProvider(TelephonyProvider):
                 )
                 return
 
-            logger.info(
-                f"Cloudonix agent-stream: inbound customParemeters "
-                f"{start.get("customParameters")}"
-            )
-
             start_context = start.get("context")
             custom_parameters = start.get("customParameters")
             builtin_context = {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Cloudonix `customParameters` in the WebSocket start event and merges them into the workflow run’s initial context without overriding built-in keys. Removes logging of these parameters and updates transfer conference CXML for compatibility.

- **New Features**
  - Merge `customParameters` into `initial_context` with built-in fields (`caller_number`, `called_number`, `direction`, `cloudonix_context`) taking precedence; ignore None values.

- **Bug Fixes**
  - Remove `beep="false"` from conference join CXML.
  - Remove logging of `customParameters`.

<sup>Written for commit a37c8ba6d12f2b125c12c889ee0ded3e656f6185. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Cloudonix WebSocket start-event parameters to the workflow run context. The main changes are:

- Flatten `customParameters` into `initial_context` while keeping built-in call fields in the same payload.
- Store Cloudonix call metadata such as caller, callee, direction, context, session, call SID, and stream SID.
- Remove the `beep="false"` attribute from transfer conference CXML.

<h3>Confidence Score: 4/5</h3>

Mostly safe, with one contained context merge issue to fix before merging.

The changed Cloudonix start-event merge can replace reserved workflow run context values from external parameters. The transfer CXML change is straightforward.

api/services/telephony/providers/cloudonix/provider.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced preservation of run context keys by running a focused harness against the Cloudonix WebSocket start handler, confirming initial\_context.telephony\_configuration\_id equals the external EXTERNAL-CONFIG-ID and that built-in values (caller\_number, called\_number, direction, cloudonix\_context) are preserved instead of any customParameters overrides.
- Validated the changed provider logic by executing the generated validation script with minimal stubs; the run exited with code 0 and initial\_context contained ordinary\_key and numeric\_key along with the built-in values, while a previous attempt to compare before the change could not be executed due to a SyntaxError in the before-change script.

<a href="https://app.greptile.com/trex/runs/14841173/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/services/telephony/providers/cloudonix/provider.py | Adds Cloudonix `customParameters` flattening into workflow run context and removes the transfer conference `beep` attribute; custom parameters can still overwrite reserved run context keys such as `telephony_configuration_id`. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant CX as Cloudonix WebSocket
participant Provider as CloudonixProvider
participant DB as WorkflowRun DB
participant Pipeline as run_pipeline_telephony
CX->>Provider: connected + start(customParameters)
Provider->>Provider: validate session and resolve config by domain
Provider->>DB: update initial_context with customParameters + built-ins
Provider->>Pipeline: start telephony pipeline with call/session credentials
Pipeline->>DB: read workflow_run.initial_context
Pipeline->>Pipeline: create Cloudonix transport
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant CX as Cloudonix WebSocket
participant Provider as CloudonixProvider
participant DB as WorkflowRun DB
participant Pipeline as run_pipeline_telephony
CX->>Provider: connected + start(customParameters)
Provider->>Provider: validate session and resolve config by domain
Provider->>DB: update initial_context with customParameters + built-ins
Provider->>Pipeline: start telephony pipeline with call/session credentials
Pipeline->>DB: read workflow_run.initial_context
Pipeline->>Pipeline: create Cloudonix transport
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(cloudonix): remove custom parameter ..."](https://github.com/dograh-hq/dograh/commit/a37c8ba6d12f2b125c12c889ee0ded3e656f6185) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44782769)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - api/services/telephony/providers/AGENTS.md ([source](https://app.greptile.com/dograh-hq/github/dograh-hq/dograh/-/custom-context?memory=f40b93ad-475b-4a76-9687-19ab74c6ec29))

<!-- /greptile_comment -->