### PR TITLE
fix(ui): restore committed states in workflow undo/redo

### DIFF
--- a/ui/src/app/workflow/[workflowId]/RenderWorkflow.tsx
+++ b/ui/src/app/workflow/[workflowId]/RenderWorkflow.tsx
@@ -117,6 +117,7 @@ function RenderWorkflow({
         onConnect,
         onEdgesChange,
         onNodesChange,
+        onDelete,
     } = useWorkflowState({
         initialWorkflowName,
         workflowId,
@@ -514,6 +515,7 @@ function RenderWorkflow({
                                 edges={edges}
                                 onNodesChange={onNodesChange}
                                 onEdgesChange={onEdgesChange}
+                                onDelete={onDelete}
                                 nodeTypes={nodeTypes}
                                 edgeTypes={edgeTypes}
                                 onConnect={isViewingHistoricalVersion ? undefined : onConnect}

--- a/ui/src/app/workflow/[workflowId]/hooks/useWorkflowState.ts
+++ b/ui/src/app/workflow/[workflowId]/hooks/useWorkflowState.ts
@@ -136,6 +136,7 @@ export const useWorkflowState = ({
         templateContextVariables,
         workflowConfigurations,
         initializeWorkflow,
+        commitDeletion,
         setNodes,
         setEdges,
         setWorkflowName,
@@ -493,6 +494,10 @@ export const useWorkflowState = ({
         [setNodes],
     );
 
+    const onDelete = useCallback(() => {
+        commitDeletion();
+    }, [commitDeletion]);
+
     const onRun = async (mode: string) => {
         if (!user?.id) return;
         const workflowRunName = `WR-${getRandomId()}`;
@@ -638,6 +643,7 @@ export const useWorkflowState = ({
         onConnect,
         onEdgesChange,
         onNodesChange,
+        onDelete,
         onRun,
         saveTemplateContextVariables,
         saveWorkflowConfigurations,

--- a/ui/src/app/workflow/[workflowId]/stores/workflowStore.test.ts
+++ b/ui/src/app/workflow/[workflowId]/stores/workflowStore.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { FlowEdge, FlowNode } from '@/components/flow/types';
+
+import { useWorkflowStore } from './workflowStore';
+
+const createNode = (id: string, x = 0): FlowNode => ({
+  id,
+  type: 'agentNode',
+  position: { x, y: 0 },
+  data: { name: id },
+});
+
+const createEdge = (id: string, source: string, target: string): FlowEdge => ({
+  id,
+  source,
+  target,
+  data: { condition: 'always', label: id },
+});
+
+const nodeIds = () => useWorkflowStore.getState().nodes.map((node) => node.id);
+
+describe('workflow history', () => {
+  beforeEach(() => {
+    useWorkflowStore.getState().clearStore();
+    useWorkflowStore.getState().initializeWorkflow(1, 'Initial', [], []);
+  });
+
+  it('keeps every committed node state available to undo and redo', () => {
+    const store = useWorkflowStore.getState();
+    store.addNode(createNode('a'));
+    store.addNode(createNode('b'));
+
+    store.undo();
+    expect(nodeIds()).toEqual(['a']);
+
+    store.undo();
+    expect(nodeIds()).toEqual([]);
+
+    store.redo();
+    store.redo();
+    expect(nodeIds()).toEqual(['a', 'b']);
+  });
+
+  it('undoes a node and connected-edge deletion in one step', () => {
+    const firstNode = createNode('a');
+    const secondNode = createNode('b');
+    const edge = createEdge('a-b', 'a', 'b');
+    useWorkflowStore.getState().initializeWorkflow(
+      1,
+      'Initial',
+      [firstNode, secondNode],
+      [edge]
+    );
+
+    // React Flow emits connected-edge removals before node removals, then onDelete.
+    useWorkflowStore.getState().setEdges(
+      [],
+      [{ id: edge.id, type: 'remove' }]
+    );
+    useWorkflowStore.getState().setNodes(
+      [secondNode],
+      [{ id: firstNode.id, type: 'remove' }]
+    );
+    useWorkflowStore.getState().commitDeletion();
+    expect(nodeIds()).toEqual(['b']);
+    expect(useWorkflowStore.getState().edges).toEqual([]);
+    expect(useWorkflowStore.getState().history).toHaveLength(2);
+
+    useWorkflowStore.getState().undo();
+    expect(nodeIds()).toEqual(['a', 'b']);
+    expect(useWorkflowStore.getState().edges).toEqual([edge]);
+
+    useWorkflowStore.getState().redo();
+    expect(nodeIds()).toEqual(['b']);
+    expect(useWorkflowStore.getState().edges).toEqual([]);
+  });
+
+  it('coalesces active dragging into one committed final position', () => {
+    const initialNode = createNode('a');
+    useWorkflowStore.getState().initializeWorkflow(1, 'Initial', [initialNode], []);
+
+    for (const x of [10, 20]) {
+      useWorkflowStore.getState().setNodes(
+        [createNode('a', x)],
+        [{ id: 'a', type: 'position', position: { x, y: 0 }, dragging: true }]
+      );
+    }
+    useWorkflowStore.getState().setNodes(
+      [createNode('a', 30)],
+      [{ id: 'a', type: 'position', position: { x: 30, y: 0 }, dragging: false }]
+    );
+
+    expect(useWorkflowStore.getState().history).toHaveLength(2);
+    useWorkflowStore.getState().undo();
+    expect(useWorkflowStore.getState().nodes[0].position.x).toBe(0);
+    useWorkflowStore.getState().redo();
+    expect(useWorkflowStore.getState().nodes[0].position.x).toBe(30);
+  });
+
+  it('truncates redo history after a new edit', () => {
+    useWorkflowStore.getState().addNode(createNode('a'));
+    useWorkflowStore.getState().addNode(createNode('b'));
+    useWorkflowStore.getState().undo();
+    useWorkflowStore.getState().addNode(createNode('c'));
+
+    expect(nodeIds()).toEqual(['a', 'c']);
+    expect(useWorkflowStore.getState().canRedo()).toBe(false);
+
+    useWorkflowStore.getState().undo();
+    expect(nodeIds()).toEqual(['a']);
+    useWorkflowStore.getState().redo();
+    expect(nodeIds()).toEqual(['a', 'c']);
+  });
+
+  it('keeps the current state at the end of the bounded history', () => {
+    for (let index = 1; index <= 55; index += 1) {
+      useWorkflowStore.getState().setWorkflowName(`Edit ${index}`);
+    }
+
+    expect(useWorkflowStore.getState().history).toHaveLength(50);
+    expect(useWorkflowStore.getState().historyIndex).toBe(49);
+
+    let undoCount = 0;
+    while (useWorkflowStore.getState().canUndo()) {
+      useWorkflowStore.getState().undo();
+      undoCount += 1;
+    }
+    expect(undoCount).toBe(49);
+    expect(useWorkflowStore.getState().workflowName).toBe('Edit 6');
+
+    while (useWorkflowStore.getState().canRedo()) {
+      useWorkflowStore.getState().redo();
+    }
+    expect(useWorkflowStore.getState().workflowName).toBe('Edit 55');
+  });
+
+  it('does not track selection-only changes', () => {
+    const initialNode = createNode('a');
+    useWorkflowStore.getState().initializeWorkflow(1, 'Initial', [initialNode], []);
+
+    useWorkflowStore.getState().setNodes(
+      [{ ...initialNode, selected: true }],
+      [{ id: 'a', type: 'select', selected: true }]
+    );
+
+    expect(useWorkflowStore.getState().nodes[0].selected).toBe(true);
+    expect(useWorkflowStore.getState().history).toHaveLength(1);
+    expect(useWorkflowStore.getState().isDirty).toBe(false);
+  });
+});

--- a/ui/src/app/workflow/[workflowId]/stores/workflowStore.ts
+++ b/ui/src/app/workflow/[workflowId]/stores/workflowStore.ts
@@ -54,7 +54,7 @@ interface WorkflowActions {
   ) => void;
 
   // History management
-  pushToHistory: () => void;
+  commitDeletion: () => void;
   undo: () => void;
   redo: () => void;
   canUndo: () => boolean;
@@ -99,6 +99,30 @@ type WorkflowStore = WorkflowState & WorkflowActions;
 
 const MAX_HISTORY_SIZE = 50;
 
+const commitHistory = (
+  state: Pick<WorkflowState, 'history' | 'historyIndex'>,
+  snapshot: HistoryState
+): Pick<
+  WorkflowState,
+  'nodes' | 'edges' | 'workflowName' | 'history' | 'historyIndex' | 'isDirty'
+> => {
+  const history = [
+    ...state.history.slice(0, state.historyIndex + 1),
+    snapshot,
+  ];
+
+  if (history.length > MAX_HISTORY_SIZE) {
+    history.shift();
+  }
+
+  return {
+    ...snapshot,
+    history,
+    historyIndex: history.length - 1,
+    isDirty: true,
+  };
+};
+
 // Create the store
 export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   // Initial state
@@ -134,27 +158,14 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
     });
   },
 
-  pushToHistory: () => {
-    const state = get();
-    const currentState: HistoryState = {
-      nodes: state.nodes,
-      edges: state.edges,
-      workflowName: state.workflowName,
-    };
-
-    // Remove any forward history if we're not at the end
-    const newHistory = state.history.slice(0, state.historyIndex + 1);
-    newHistory.push(currentState);
-
-    // Limit history size
-    if (newHistory.length > MAX_HISTORY_SIZE) {
-      newHistory.shift();
-    }
-
-    set({
-      history: newHistory,
-      historyIndex: newHistory.length - 1,
-    });
+  commitDeletion: () => {
+    set((state) =>
+      commitHistory(state, {
+        nodes: state.nodes,
+        edges: state.edges,
+        workflowName: state.workflowName,
+      })
+    );
   },
 
   undo: () => {
@@ -200,10 +211,10 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   setNodes: (nodes, changes) => {
     // Determine whether to push to history and set isDirty based on change types
     if (changes && changes.length > 0) {
-      // Check for add/remove changes (always push to history)
-      const hasAddRemoveChanges = changes.some(change =>
-        change.type === 'add' || change.type === 'remove'
-      );
+      const hasAddChanges = changes.some(change => change.type === 'add');
+      // React Flow emits edge and node removals separately. They are committed
+      // together from onDelete after both live-state updates have completed.
+      const hasRemoveChanges = changes.some(change => change.type === 'remove');
 
       // Check for position changes - only push to history when drag ENDS (dragging: false)
       // but still mark as dirty during dragging
@@ -214,11 +225,16 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
         change.type === 'position' && change.dragging === true
       );
 
-      if (hasAddRemoveChanges || hasDragEndChanges) {
-        get().pushToHistory();
-        set({ nodes, isDirty: true });
-      } else if (isActiveDragging) {
-        // During active dragging, update nodes but don't push to history
+      if (hasAddChanges || hasDragEndChanges) {
+        set((state) =>
+          commitHistory(state, {
+            nodes,
+            edges: state.edges,
+            workflowName: state.workflowName,
+          })
+        );
+      } else if (hasRemoveChanges || isActiveDragging) {
+        // During active dragging or deletion, update nodes before committing.
         set({ nodes, isDirty: true });
       } else {
         // For selection changes or dimension updates, don't push to history or set dirty
@@ -231,49 +247,62 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   },
 
   addNode: (node) => {
-    const state = get();
-    get().pushToHistory();
-    set({
-      nodes: [...state.nodes, node],
-      isDirty: true
+    set((state) => {
+      const nodes = [...state.nodes, node];
+      return commitHistory(state, {
+        nodes,
+        edges: state.edges,
+        workflowName: state.workflowName,
+      });
     });
   },
 
   updateNode: (nodeId, updates) => {
-    const state = get();
-    get().pushToHistory();
-    set({
-      nodes: state.nodes.map((node) =>
+    set((state) => {
+      const nodes = state.nodes.map((node) =>
         node.id === nodeId ? { ...node, ...updates } : node
-      ),
-      isDirty: true,
+      );
+      return commitHistory(state, {
+        nodes,
+        edges: state.edges,
+        workflowName: state.workflowName,
+      });
     });
   },
 
   deleteNode: (nodeId) => {
-    const state = get();
-    get().pushToHistory();
-    set({
-      nodes: state.nodes.filter((node) => node.id !== nodeId),
-      edges: state.edges.filter(
+    set((state) => {
+      const nodes = state.nodes.filter((node) => node.id !== nodeId);
+      const edges = state.edges.filter(
         (edge) => edge.source !== nodeId && edge.target !== nodeId
-      ),
-      isDirty: true,
+      );
+      return commitHistory(state, {
+        nodes,
+        edges,
+        workflowName: state.workflowName,
+      });
     });
   },
 
   setEdges: (edges, changes) => {
     // Determine whether to push to history and set isDirty based on change types
     if (changes && changes.length > 0) {
-      // Check if any changes are user-initiated (not just selections)
-      const hasDirtyChanges = changes.some(change =>
+      const hasImmediateHistoryChanges = changes.some(change =>
         change.type === 'add' ||
-        change.type === 'remove' ||
         change.type === 'replace'
       );
+      const hasRemoveChanges = changes.some(change => change.type === 'remove');
 
-      if (hasDirtyChanges) {
-        get().pushToHistory();
+      if (hasImmediateHistoryChanges) {
+        set((state) =>
+          commitHistory(state, {
+            nodes: state.nodes,
+            edges,
+            workflowName: state.workflowName,
+          })
+        );
+      } else if (hasRemoveChanges) {
+        // React Flow calls onDelete after all edge and node removals.
         set({ edges, isDirty: true });
       } else {
         // For selection changes, don't push to history
@@ -286,37 +315,48 @@ export const useWorkflowStore = create<WorkflowStore>((set, get) => ({
   },
 
   addEdge: (edge) => {
-    const state = get();
-    get().pushToHistory();
-    set({
-      edges: [...state.edges, edge],
-      isDirty: true
+    set((state) => {
+      const edges = [...state.edges, edge];
+      return commitHistory(state, {
+        nodes: state.nodes,
+        edges,
+        workflowName: state.workflowName,
+      });
     });
   },
 
   updateEdge: (edgeId, updates) => {
-    const state = get();
-    get().pushToHistory();
-    set({
-      edges: state.edges.map((edge) =>
+    set((state) => {
+      const edges = state.edges.map((edge) =>
         edge.id === edgeId ? { ...edge, ...updates } : edge
-      ),
-      isDirty: true,
+      );
+      return commitHistory(state, {
+        nodes: state.nodes,
+        edges,
+        workflowName: state.workflowName,
+      });
     });
   },
 
   deleteEdge: (edgeId) => {
-    const state = get();
-    get().pushToHistory();
-    set({
-      edges: state.edges.filter((edge) => edge.id !== edgeId),
-      isDirty: true,
+    set((state) => {
+      const edges = state.edges.filter((edge) => edge.id !== edgeId);
+      return commitHistory(state, {
+        nodes: state.nodes,
+        edges,
+        workflowName: state.workflowName,
+      });
     });
   },
 
   setWorkflowName: (workflowName) => {
-    get().pushToHistory();
-    set({ workflowName, isDirty: true });
+    set((state) =>
+      commitHistory(state, {
+        nodes: state.nodes,
+        edges: state.edges,
+        workflowName,
+      })
+    );
   },
 
   setTemplateContextVariables: (templateContextVariables) => {


### PR DESCRIPTION
## Summary

- record completed workflow states atomically so undo and redo visit every edit
- preserve one-step undo for React Flow deletions that emit edge and node removals separately
- cover sequential edits, compound deletion, drag coalescing, redo branching, bounded history, and untracked selection changes

## Problem

Workflow mutations appended the current state before applying the change, but `undo` and `redo` treated each history entry as the resulting state. After `S0 → S1 → S2`, one undo restored `S0` instead of `S1`, and redo could only reach `S1`; the latest edit was no longer recoverable. In the editor, adding nodes A and B and pressing undo removed both nodes, while redo restored only A.

## Solution

Tracked mutations now calculate their final nodes, edges, and workflow name in one functional store update, then append that committed snapshot after truncating any redo branch and enforcing the existing 50-entry limit. Active drag frames and selection-only changes remain untracked. React Flow removal callbacks update live state first, and its final `onDelete` callback commits node-plus-connected-edge deletion as one history step.

## Validation

- `npm test -- src/app/workflow/[workflowId]/stores/workflowStore.test.ts` — 6 tests passed
- `npm test` — 20 tests passed
- `npm run fix-lint`
- `npm run build`
- `./scripts/format.sh`
- OpenAPI generation completed with no spec drift

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow undo/redo by committing the final state of each edit and treating deletions as one step. History is now predictable: undo/redo visits every edit in order and never drops the latest change.

- **Bug Fixes**
  - Commit the final snapshot after each tracked edit so S0 → S1 → S2 undoes to S1, then S0, and redoes back to S2.
  - Handle React Flow deletions as one history entry by wiring onDelete through the editor and a new store action, committing node + connected-edge removal together.
  - Coalesce drag moves; only commit on drag end. Ignore selection-only updates, but keep live dragging/deletions in state until commit.
  - Truncate redo on new edits, enforce a 50-entry limit, and keep the current state at the end of history.
  - Added unit tests for sequential edits, compound deletion, drag coalescing, redo branching, bounded history, and selection changes.

<sup>Written for commit 09e55e05b67914d18494237692c8c9c6b8875093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes workflow undo and redo history for committed editor states. The main changes are:

- Store post-mutation snapshots in workflow history.
- Group React Flow node and connected-edge deletion into one history entry.
- Keep active dragging and selection-only changes out of committed history.
- Add tests for sequential edits, deletion grouping, drag coalescing, redo branching, bounded history, and selection-only updates.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are localized to workflow history handling and match the expected undo/redo behavior. Tests cover the main editor history cases changed by this PR. No correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the targeted vitest test for the workflow editor history store undo/redo and React Flow deletion history and verified it exited with code 0.
- Ran the broader UI npm test suite for the workflow UI components and verified it exited with code 0.
- Saved and reviewed the targeted test results in the Workflow editor history store log, including the captured command metadata.
- Saved and reviewed the broader UI test results in the UI npm test log, including the captured command metadata.
- Overall, both tests completed successfully as indicated by exit code 0 in the logs.

<a href="https://app.greptile.com/trex/runs/14754370/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/app/workflow/[workflowId]/RenderWorkflow.tsx | Wires React Flow deletion completion into the workflow state hook so compound removals can be committed once. |
| ui/src/app/workflow/[workflowId]/hooks/useWorkflowState.ts | Adds an `onDelete` callback that delegates to the store deletion commit after React Flow change callbacks update live state. |
| ui/src/app/workflow/[workflowId]/stores/workflowStore.test.ts | Adds tests for committed snapshots, deletion grouping, drag coalescing, redo truncation, history bounds, and selection-only changes. |
| ui/src/app/workflow/[workflowId]/stores/workflowStore.ts | Refactors history tracking to commit post-mutation snapshots atomically and defer React Flow removal history until `onDelete`. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant ReactFlow
participant Hook as useWorkflowState
participant Store as workflowStore

User->>ReactFlow: Delete node/edge selection
ReactFlow->>Hook: onEdgesChange(remove)
Hook->>Store: setEdges(newEdges, remove changes)
Store->>Store: update live edges without history
ReactFlow->>Hook: onNodesChange(remove)
Hook->>Store: setNodes(newNodes, remove changes)
Store->>Store: update live nodes without history
ReactFlow->>Hook: onDelete()
Hook->>Store: commitDeletion()
Store->>Store: append committed snapshot and truncate redo branch
User->>Store: undo()/redo()
Store->>Store: restore adjacent committed snapshot
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant ReactFlow
participant Hook as useWorkflowState
participant Store as workflowStore

User->>ReactFlow: Delete node/edge selection
ReactFlow->>Hook: onEdgesChange(remove)
Hook->>Store: setEdges(newEdges, remove changes)
Store->>Store: update live edges without history
ReactFlow->>Hook: onNodesChange(remove)
Hook->>Store: setNodes(newNodes, remove changes)
Store->>Store: update live nodes without history
ReactFlow->>Hook: onDelete()
Hook->>Store: commitDeletion()
Store->>Store: append committed snapshot and truncate redo branch
User->>Store: undo()/redo()
Store->>Store: restore adjacent committed snapshot
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): restore committed states in wor..."](https://github.com/dograh-hq/dograh/commit/09e55e05b67914d18494237692c8c9c6b8875093) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44910664)</sub>

<!-- /greptile_comment -->