### PR TITLE
feat: add Atlas Cloud LLM provider

### DIFF
--- a/api/services/configuration/check_validity.py
+++ b/api/services/configuration/check_validity.py
@@ -36,6 +36,7 @@ class UserConfigurationValidator:
     def __init__(self):
         self._validator_map = {
             ServiceProviders.OPENAI.value: self._check_openai_api_key,
+            ServiceProviders.ATLASCLOUD.value: self._check_openai_api_key,
             ServiceProviders.DEEPGRAM.value: self._check_deepgram_api_key,
             ServiceProviders.GROQ.value: self._check_groq_api_key,
             ServiceProviders.OPENROUTER.value: self._check_openrouter_api_key,
@@ -228,6 +229,7 @@ class UserConfigurationValidator:
 
         if provider in (
             ServiceProviders.OPENAI.value,
+            ServiceProviders.ATLASCLOUD.value,
             ServiceProviders.OPENAI_REALTIME.value,
         ):
             return validator(provider, api_key, service_config)

--- a/api/services/configuration/check_validity.py
+++ b/api/services/configuration/check_validity.py
@@ -238,6 +238,9 @@ class UserConfigurationValidator:
     def _check_openai_api_key(
         self, model: str, api_key: str, service_config: Optional[ServiceConfig] = None
     ) -> bool:
+        provider_name = (
+            "Atlas Cloud" if model == ServiceProviders.ATLASCLOUD.value else "OpenAI"
+        )
         client_kwargs: dict[str, str] = {"api_key": api_key}
         base_url = getattr(service_config, "base_url", None) if service_config else None
         if base_url:
@@ -249,7 +252,8 @@ class UserConfigurationValidator:
         except openai.AuthenticationError:
             if base_url and "openai.com" not in base_url:
                 raise ValueError(
-                    f"Invalid OpenAI API key. The key was rejected by the API at {base_url}. "
+                    f"Invalid {provider_name} API key. The key was rejected by the API at "
+                    f"{base_url}. "
                     "Please check that your API key is correct and has not been revoked."
                 )
             raise ValueError(
@@ -281,12 +285,13 @@ class UserConfigurationValidator:
         except Exception:
             if base_url:
                 raise ValueError(
-                    f"Failed to validate the OpenAI API key using the API at {base_url}. "
+                    f"Failed to validate the {provider_name} API key using the API at "
+                    f"{base_url}. "
                     "Please verify that the base_url is correct and reachable, and that the "
                     "API key is valid."
                 )
             raise ValueError(
-                "Failed to validate the OpenAI API key. Please try again later."
+                f"Failed to validate the {provider_name} API key. Please try again later."
             )
 
     def _check_deepgram_api_key(self, model: str, api_key: str) -> bool:

--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -65,6 +65,7 @@ class ServiceType(Enum):
 
 class ServiceProviders(str, Enum):
     OPENAI = "openai"
+    ATLASCLOUD = "atlascloud"
     DEEPGRAM = "deepgram"
     GROQ = "groq"
     OPENROUTER = "openrouter"
@@ -100,6 +101,7 @@ class ServiceProviders(str, Enum):
 class BaseServiceConfiguration(BaseModel):
     provider: Literal[
         ServiceProviders.OPENAI,
+        ServiceProviders.ATLASCLOUD,
         ServiceProviders.DEEPGRAM,
         ServiceProviders.GROQ,
         ServiceProviders.OPENROUTER,
@@ -243,6 +245,10 @@ def provider_model_config(
 
 # Suggested models for each provider (used for UI dropdown)
 OPENAI_PROVIDER_MODEL_CONFIG = provider_model_config("OpenAI")
+ATLASCLOUD_PROVIDER_MODEL_CONFIG = provider_model_config(
+    "Atlas Cloud",
+    description="Atlas Cloud OpenAI-compatible LLM API.",
+)
 GOOGLE_PROVIDER_MODEL_CONFIG = provider_model_config("Google")
 GROQ_PROVIDER_MODEL_CONFIG = provider_model_config("Groq")
 OPENROUTER_PROVIDER_MODEL_CONFIG = provider_model_config("Open Router")
@@ -310,6 +316,11 @@ OPENAI_MODELS = [
     "gpt-3.5-turbo",
 ]
 
+ATLASCLOUD_MODELS = [
+    "qwen/qwen3.5-flash",
+    "deepseek-ai/deepseek-v4-pro",
+]
+
 GROQ_MODELS = [
     "llama-3.3-70b-versatile",
     "deepseek-r1-distill-llama-70b",
@@ -351,6 +362,21 @@ class OpenAILLMService(BaseLLMConfiguration):
     base_url: str = Field(
         default="https://api.openai.com/v1",
         description="Override only if using an OpenAI-compatible API (e.g. local LLM, proxy).",
+    )
+
+
+@register_llm
+class AtlasCloudLLMService(BaseLLMConfiguration):
+    model_config = ATLASCLOUD_PROVIDER_MODEL_CONFIG
+    provider: Literal[ServiceProviders.ATLASCLOUD] = ServiceProviders.ATLASCLOUD
+    model: str = Field(
+        default="qwen/qwen3.5-flash",
+        description="Atlas Cloud OpenAI-compatible chat model identifier.",
+        json_schema_extra={"examples": ATLASCLOUD_MODELS, "allow_custom_input": True},
+    )
+    base_url: str = Field(
+        default="https://api.atlascloud.ai/v1",
+        description="Atlas Cloud OpenAI-compatible API endpoint.",
     )
 
 
@@ -799,6 +825,7 @@ REALTIME_PROVIDERS = {
 LLMConfig = Annotated[
     Union[
         OpenAILLMService,
+        AtlasCloudLLMService,
         GoogleVertexLLMConfiguration,
         GroqLLMService,
         OpenRouterLLMConfiguration,

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -871,7 +871,10 @@ def create_llm_service_from_provider(
     Also used by create_llm_service which extracts these from user_config.
     """
     logger.info(f"Creating LLM service: provider={provider}, model={model}")
-    if provider == ServiceProviders.OPENAI.value:
+    if provider in (
+        ServiceProviders.OPENAI.value,
+        ServiceProviders.ATLASCLOUD.value,
+    ):
         kwargs = {}
         if base_url:
             _validate_runtime_service_url(base_url, "base_url")
@@ -1181,7 +1184,10 @@ def create_llm_service(user_config, correlation_id: str | None = None):
     api_key = user_config.llm.api_key
 
     kwargs = {}
-    if provider == ServiceProviders.OPENAI.value:
+    if provider in (
+        ServiceProviders.OPENAI.value,
+        ServiceProviders.ATLASCLOUD.value,
+    ):
         kwargs["base_url"] = user_config.llm.base_url
     elif provider == ServiceProviders.OPENROUTER.value:
         kwargs["base_url"] = user_config.llm.base_url

--- a/api/tests/test_atlascloud_llm_provider.py
+++ b/api/tests/test_atlascloud_llm_provider.py
@@ -1,0 +1,61 @@
+from pydantic import TypeAdapter
+
+from api.services.configuration.check_validity import UserConfigurationValidator
+from api.services.configuration.registry import (
+    AtlasCloudLLMService,
+    LLMConfig,
+    ServiceProviders,
+)
+
+
+def test_atlascloud_llm_configuration_defaults():
+    config = AtlasCloudLLMService(api_key="atlas-key")
+
+    assert config.provider == ServiceProviders.ATLASCLOUD
+    assert config.model == "qwen/qwen3.5-flash"
+    assert config.base_url == "https://api.atlascloud.ai/v1"
+
+
+def test_atlascloud_llm_discriminator_parses_llm_config():
+    config = TypeAdapter(LLMConfig).validate_python(
+        {
+            "provider": "atlascloud",
+            "api_key": "atlas-key",
+            "model": "deepseek-ai/deepseek-v4-pro",
+            "base_url": "https://api.atlascloud.ai/v1",
+        }
+    )
+
+    assert isinstance(config, AtlasCloudLLMService)
+    assert config.model == "deepseek-ai/deepseek-v4-pro"
+    assert config.base_url == "https://api.atlascloud.ai/v1"
+
+
+def test_atlascloud_api_key_validation_uses_atlascloud_base_url(monkeypatch):
+    captured = {}
+
+    class FakeModels:
+        def list(self):
+            return []
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.models = FakeModels()
+
+    monkeypatch.setattr(
+        "api.services.configuration.check_validity.openai.OpenAI", FakeOpenAI
+    )
+
+    config = AtlasCloudLLMService(api_key="atlas-key")
+    is_valid = UserConfigurationValidator()._check_api_key(
+        ServiceProviders.ATLASCLOUD.value,
+        "atlas-key",
+        config,
+    )
+
+    assert is_valid is True
+    assert captured == {
+        "api_key": "atlas-key",
+        "base_url": "https://api.atlascloud.ai/v1",
+    }

--- a/api/tests/test_atlascloud_llm_provider.py
+++ b/api/tests/test_atlascloud_llm_provider.py
@@ -1,5 +1,7 @@
+import pytest
 from pydantic import TypeAdapter
 
+from api.services.configuration import check_validity
 from api.services.configuration.check_validity import UserConfigurationValidator
 from api.services.configuration.registry import (
     AtlasCloudLLMService,
@@ -59,3 +61,33 @@ def test_atlascloud_api_key_validation_uses_atlascloud_base_url(monkeypatch):
         "api_key": "atlas-key",
         "base_url": "https://api.atlascloud.ai/v1",
     }
+
+
+def test_atlascloud_api_key_validation_uses_atlascloud_error_message(monkeypatch):
+    class FakeAuthenticationError(Exception):
+        pass
+
+    class FakeModels:
+        def list(self):
+            raise FakeAuthenticationError
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            self.models = FakeModels()
+
+    monkeypatch.setattr(check_validity.openai, "OpenAI", FakeOpenAI)
+    monkeypatch.setattr(
+        check_validity.openai, "AuthenticationError", FakeAuthenticationError
+    )
+
+    config = AtlasCloudLLMService(api_key="atlas-key")
+    with pytest.raises(ValueError) as exc_info:
+        UserConfigurationValidator()._check_api_key(
+            ServiceProviders.ATLASCLOUD.value,
+            "atlas-key",
+            config,
+        )
+
+    message = str(exc_info.value)
+    assert "Invalid Atlas Cloud API key" in message
+    assert "Invalid OpenAI API key" not in message

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "1.41.0",
+      "version": "1.42.0",
       "dependencies": {
         "@calcom/embed-react": "^1.5.3",
         "@dagrejs/dagre": "^1.1.4",


### PR DESCRIPTION
## Summary
- add Atlas Cloud as an OpenAI-compatible LLM provider with the ATLASCLOUD_API_KEY flow
- register live-verified default/suggested Atlas Cloud model IDs and pass the provider base_url through runtime service creation
- reuse the existing OpenAI-compatible key validation path for Atlas Cloud

## Validation
- `python3 -m py_compile api/services/configuration/registry.py api/services/configuration/check_validity.py api/services/pipecat/service_factory.py api/tests/test_atlascloud_llm_provider.py`
- `git diff --check`
- `cd api && uv run black --check services/configuration/registry.py services/configuration/check_validity.py services/pipecat/service_factory.py tests/test_atlascloud_llm_provider.py`
- `cd api && DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/dograh_test REDIS_URL=redis://localhost:6379/0 uv run pytest tests/test_atlascloud_llm_provider.py -q` (3 passed; existing pytest config warnings only)
- Atlas live model catalog returned 422 model IDs and includes `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

No README changes. No sponsor/logo/credits/partner promotional content added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Atlas Cloud as an OpenAI-compatible LLM provider with defaults and base URL support. Also updates validation errors to reference Atlas Cloud when used.

- **New Features**
  - New provider `atlascloud` with default model `qwen/qwen3.5-flash` and base URL `https://api.atlascloud.ai/v1`; suggested models include `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`.
  - Service factory supports `atlascloud`, forwarding `base_url` at runtime; `LLMConfig` includes `AtlasCloudLLMService`.

- **Bug Fixes**
  - API key validation now shows Atlas Cloud–specific error messages when provider is `atlascloud`; tests cover defaults, discriminator parsing, base_url forwarding, and error messages.

<sup>Written for commit a39cc4d6760d19aaa0af866d2e416576e8ae0486. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Atlas Cloud as a new OpenAI-compatible LLM provider. The main changes are:

- Registers `atlascloud` with default and suggested model IDs.
- Adds the Atlas Cloud default `base_url` to LLM configuration parsing.
- Reuses the OpenAI-compatible API key validation path with Atlas Cloud-specific messaging.
- Forwards Atlas Cloud `base_url` into runtime LLM service creation.
- Adds backend tests for defaults, discriminator parsing, validation wiring, and error messages.
- Updates the UI lockfile root package version.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are narrowly scoped and reuse existing OpenAI-compatible validation and runtime service paths. Runtime `base_url` handling keeps the existing URL validation before service creation. Focused backend tests cover the new provider defaults, parsing, validation wiring, and error message behavior. No blocking correctness or security issues were identified.

**Files Needing Attention:** No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the Atlas Cloud general-contract validation workflow and saved a detailed log documenting command lines, working directories, stdout and stderr, and per-command exit codes.
- T-Rex confirmed that no Atlas Cloud behavior changes were observed during the run, and noted that the incomplete checks were blockers related to setup/import rather than code findings.

<a href="https://app.greptile.com/trex/runs/16870448/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/services/configuration/check_validity.py | Adds Atlas Cloud to the existing OpenAI-compatible API key validation path, including provider-specific error messaging. |
| api/services/configuration/registry.py | Registers the Atlas Cloud LLM provider with defaults, suggested models, base URL, and the LLM discriminator union. |
| api/services/pipecat/service_factory.py | Routes Atlas Cloud through the OpenAI-compatible runtime service creation path and forwards its configured base URL. |
| api/tests/test_atlascloud_llm_provider.py | Adds focused tests for Atlas Cloud defaults, discriminator parsing, validation base URL wiring, and error message branding. |
| ui/package-lock.json | Updates the root lockfile package version to match the UI package version bump; no dependency graph changes. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant UserConfig as User LLM config
participant Registry as LLMConfig registry
participant Validator as UserConfigurationValidator
participant Factory as service_factory
participant OpenAICompat as OpenAI-compatible client

UserConfig->>Registry: "provider = atlascloud"
Registry-->>UserConfig: AtlasCloudLLMService defaults\nmodel + base_url
UserConfig->>Validator: validate Atlas Cloud API key
Validator->>OpenAICompat: OpenAI(api_key, base_url).models.list()
OpenAICompat-->>Validator: success or provider-specific error
UserConfig->>Factory: create_llm_service(..., base_url)
Factory->>OpenAICompat: "OpenAILLMService(settings=model, base_url)"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: use Atlas Cloud in API key validati..."](https://github.com/dograh-hq/dograh/commit/a39cc4d6760d19aaa0af866d2e416576e8ae0486) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44984195)</sub>

<!-- /greptile_comment -->