### PR TITLE
docs: flesh out all 5 voice agent node pages

### DIFF
--- a/docs/voice-agent/agent.mdx
+++ b/docs/voice-agent/agent.mdx
@@ -61,7 +61,7 @@ Nodes pass context forward automatically. Variables extracted in one node are st
     Write shared instructions that apply to every node.
   </Card>
   <Card title="Context and Variables" href="/core-concepts/context-and-variables">
-    Understand how gathered_context flows between nodes.
+    Understand how `gathered_context` flows between nodes.
   </Card>
   <Card title="QA Node" href="/voice-agent/qa">
     Evaluate agent performance automatically after each call.

--- a/docs/voice-agent/agent.mdx
+++ b/docs/voice-agent/agent.mdx
@@ -37,6 +37,29 @@ Write edge conditions as specifically as possible:
 If the agent keeps routing to the wrong edge, make the condition more specific. Conditions like "user responds" or "conversation ends" are too broad and will route unpredictably.
 </Tip>
 
+## Extracting variables
+
+Agent Node can extract structured data from the conversation after the node completes. Enable this in the node settings under "Enable Variable Extraction."
+
+Once enabled, configure two things:
+
+- **Extraction Prompt:** overall instructions telling the LLM how to approach the extraction.
+- **Variables to Extract:** a list of variables, each with a name, a data type (`string`, `number`, `boolean`), and a per-variable hint describing what to capture.
+
+For example:
+
+```
+Extraction Prompt:
+Extract the payment outcome from this debt collection call.
+
+Variables:
+- amount_user_will_pay (string): Amount the user said they will pay.
+- payment_method (string): How they said they will pay, e.g. card, bank transfer.
+- sentiment (string): User tone: cooperative, hesitant, angry, refused.
+```
+
+Each extracted value is stored in `gathered_context` and can be referenced in downstream nodes and webhook payloads as `{{gathered_context.variable_name}}`.
+
 ## Using multiple Agent Nodes
 
 Break complex conversations into phases. Each Agent Node handles one part of the flow. A debt collection workflow, for example, might chain three Agent Nodes: identity verification, offer presentation, and objection handling.

--- a/docs/voice-agent/agent.mdx
+++ b/docs/voice-agent/agent.mdx
@@ -56,7 +56,7 @@ Once enabled, configure two things:
 
 For example:
 
-```
+```text
 Extraction Prompt:
 Extract the payment outcome from this debt collection call.
 
@@ -66,35 +66,35 @@ Variables:
 - sentiment (string): User tone: cooperative, hesitant, angry, refused.
 ```
 
-Each extracted value is stored in `gathered_context` and can be referenced in downstream nodes and webhook payloads as `{{gathered_context.variable_name}}`.
+Each extracted value is stored in `gathered_context`. It is not available in any node's Prompt - reference it in [Webhook node](./webhook) payloads as `{{gathered_context.variable_name}}`, or read it from the run record after the call completes.
 
 ## Using multiple Agent Nodes
 
 Break complex conversations into phases. Each Agent Node handles one part of the flow. A debt collection workflow, for example, might chain three Agent Nodes: identity verification, offer presentation, and objection handling.
 
-Nodes pass context forward automatically. Variables extracted in one node are stored in `gathered_context` and available in the prompt of the next node using `{{gathered_context.field_name}}` syntax.
+Nodes pass context forward automatically, but not into prompts. Variables extracted in one node are stored in `gathered_context` and merged with variables from later nodes as the call progresses. `gathered_context` is not available in any node's Prompt - it can only be referenced in [Webhook node](./webhook) payloads and in the run record after the call completes. If a later Agent Node needs to react to something extracted earlier, that logic has to live in the prompt's own instructions, not in a `{{gathered_context...}}` reference.
 
 ## Common mistakes
 
 **No outgoing edges.** Every Agent Node needs at least one edge. A dead-end node has no exit path and will trap the call.
 
-**Putting global instructions in the Agent prompt.** Rules that apply across the entire workflow - persona, tone, compliance guardrails - belong in the [Global Node](/voice-agent/global), not repeated in every Agent Node.
+**Putting global instructions in the Agent prompt.** Rules that apply across the entire workflow - persona, tone, compliance guardrails - belong in the [Global Node](./global), not repeated in every Agent Node.
 
 **Vague edge conditions.** The LLM picks the edge that best matches the conversation state. Overly broad conditions cause unpredictable routing between nodes.
 
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="End Call Node" href="/voice-agent/end-call">
+  <Card title="End Call Node" href="./end-call">
     Terminate the conversation with a closing message.
   </Card>
-  <Card title="Global Node" href="/voice-agent/global">
+  <Card title="Global Node" href="./global">
     Write shared instructions that apply to every node.
   </Card>
-  <Card title="Context and Variables" href="/core-concepts/context-and-variables">
-    Understand how `gathered_context` flows between nodes.
+  <Card title="Context and Variables" href="../core-concepts/context-and-variables">
+    Understand how `gathered_context` is built and where it can be referenced.
   </Card>
-  <Card title="QA Node" href="/voice-agent/qa">
+  <Card title="QA Node" href="./qa">
     Evaluate agent performance automatically after each call.
   </Card>
 </CardGroup>

--- a/docs/voice-agent/agent.mdx
+++ b/docs/voice-agent/agent.mdx
@@ -15,11 +15,19 @@ The instructions for how the agent should behave at this step. Be explicit about
 
 **Tools**
 
-External functions the agent can call during this step - for example, looking up account balances or updating a CRM record. Add tools in the Tools tab of the node settings.
+External functions the agent can call during this step - for example, looking up account balances or updating a CRM record. Add tools via the "HTTP & Tools" or "MCP" tabs in the node settings panel.
 
-**Knowledge Base**
+**Allow Interruption**
 
-Documents the agent can reference when answering questions. Attach knowledge base files in the KB tab.
+When on, the caller can interrupt the agent mid-utterance.
+
+**Add Global Prompt**
+
+When on and a Global Node exists, the Global Prompt is prepended to this node's Prompt at runtime. On by default.
+
+**Knowledge Base Documents**
+
+Files the agent can reference when answering questions - product guides, FAQs, policies. Attach them via the "Manage Documents" button in the node settings panel.
 
 ## Configuring edges
 

--- a/docs/voice-agent/agent.mdx
+++ b/docs/voice-agent/agent.mdx
@@ -3,6 +3,19 @@ title: "Agent Node"
 description: "Agent node contains the prompts that drives the conversation with the Voice Agent"
 ---
 
+## Video Tutorial
+
+<iframe 
+  width="560" 
+  height="315" 
+  src="https://www.youtube.com/embed/GavcBI8JQAQ" 
+  title="Agent Node Tutorial" 
+  frameBorder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+  referrerPolicy="strict-origin-when-cross-origin" 
+  allowFullScreen
+></iframe>
+
 Agent Node is the core building block of every Dograh workflow. It holds the LLM prompt that drives the conversation, any tools the agent can call, and knowledge base documents to reference. You can have multiple Agent Nodes in a single workflow, each handling a distinct phase of the conversation.
 
 The Edges connected with Agent Nodes are pathways that the LLMs can take depending on how the conversation has been going so far.

--- a/docs/voice-agent/agent.mdx
+++ b/docs/voice-agent/agent.mdx
@@ -3,4 +3,67 @@ title: "Agent Node"
 description: "Agent node contains the prompts that drives the conversation with the Voice Agent"
 ---
 
-The Edges connected with Agent Nodes are pathways that the LLMs can take depending on how the conversation has been going so far. 
+Agent Node is the core building block of every Dograh workflow. It holds the LLM prompt that drives the conversation, any tools the agent can call, and knowledge base documents to reference. You can have multiple Agent Nodes in a single workflow, each handling a distinct phase of the conversation.
+
+The Edges connected with Agent Nodes are pathways that the LLMs can take depending on how the conversation has been going so far.
+
+## What goes in an Agent Node
+
+**Prompt**
+
+The instructions for how the agent should behave at this step. Be explicit about sequence: if the agent should confirm identity before discussing payment, say so in the prompt. Vague prompts produce inconsistent behavior.
+
+**Tools**
+
+External functions the agent can call during this step - for example, looking up account balances or updating a CRM record. Add tools in the Tools tab of the node settings.
+
+**Knowledge Base**
+
+Documents the agent can reference when answering questions. Attach knowledge base files in the KB tab.
+
+## Configuring edges
+
+Each outgoing edge has a condition written in plain language. The LLM evaluates the conversation and picks the edge whose condition best matches.
+
+Write edge conditions as specifically as possible:
+
+| Vague (avoid) | Specific (use) |
+|---------------|----------------|
+| "Debtor responds" | "Debtor confirms their identity and is ready to discuss the account" |
+| "Call ends" | "Debtor commits to a specific payment option and states the amount" |
+| "Problem" | "Debtor disputes owing the debt or requests validation documentation" |
+
+<Tip>
+If the agent keeps routing to the wrong edge, make the condition more specific. Conditions like "user responds" or "conversation ends" are too broad and will route unpredictably.
+</Tip>
+
+## Using multiple Agent Nodes
+
+Break complex conversations into phases. Each Agent Node handles one part of the flow. A debt collection workflow, for example, might chain three Agent Nodes: identity verification, offer presentation, and objection handling.
+
+Nodes pass context forward automatically. Variables extracted in one node are stored in `gathered_context` and available in the prompt of the next node using `{{gathered_context.field_name}}` syntax.
+
+## Common mistakes
+
+**No outgoing edges.** Every Agent Node needs at least one edge. A dead-end node has no exit path and will trap the call.
+
+**Putting global instructions in the Agent prompt.** Rules that apply across the entire workflow - persona, tone, compliance guardrails - belong in the [Global Node](/voice-agent/global), not repeated in every Agent Node.
+
+**Vague edge conditions.** The LLM picks the edge that best matches the conversation state. Overly broad conditions cause unpredictable routing between nodes.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="End Call Node" href="/voice-agent/end-call">
+    Terminate the conversation with a closing message.
+  </Card>
+  <Card title="Global Node" href="/voice-agent/global">
+    Write shared instructions that apply to every node.
+  </Card>
+  <Card title="Context and Variables" href="/core-concepts/context-and-variables">
+    Understand how gathered_context flows between nodes.
+  </Card>
+  <Card title="QA Node" href="/voice-agent/qa">
+    Evaluate agent performance automatically after each call.
+  </Card>
+</CardGroup>

--- a/docs/voice-agent/end-call.mdx
+++ b/docs/voice-agent/end-call.mdx
@@ -2,6 +2,66 @@
 title: "End Call"
 description: "You can use End Call node to configure how the Agent says its final message right before the call is terminated"
 ---
+
 <Note>
 You should have only one End Call node per Voice Agent.
 </Note>
+
+End Call is the final node in every workflow. It fires right before Dograh terminates the connection, giving your agent one last chance to speak. Every path through your workflow should eventually route here.
+
+## When it runs
+
+End Call executes after all conversation logic is complete. The agent delivers its Final Message, then the call drops.
+
+Multiple Agent Nodes can route into a single End Call node. You do not need separate End Call nodes for different call outcomes - handle variation in the Final Message prompt instead.
+
+## Fields
+
+**Final Message**
+
+A prompt that controls what your agent says before the call ends. You can make this conditional by describing different outcomes in the prompt.
+
+For example:
+
+```
+If the caller committed to a payment, confirm the arrangement: the
+exact amount and expected processing time. If no commitment was made,
+thank them for their time and let them know they can call back to
+discuss options. Always close professionally.
+```
+
+You can reference `gathered_context` variables in this prompt to pull in specific details from the conversation:
+
+```
+The caller committed to {{gathered_context.payment_option_chosen}}.
+Confirm this amount and thank them before ending the call.
+```
+
+## Common mistakes
+
+**Leaving the Final Message empty.** An empty Final Message means the agent says nothing before the line drops. The caller experiences an abrupt silence.
+
+**Creating multiple End Call nodes.** Each workflow supports exactly one. Route all paths to the same End Call node, and use the Final Message prompt to handle variation by outcome.
+
+**Agent Nodes that never route to End Call.** Any node without a downstream path to End Call leaves calls in an unresolvable state. Check your canvas for nodes with no outgoing connection to End Call before publishing.
+
+<Warning>
+If an Agent Node has no route to End Call, calls that reach that node may drop without a closing message. Review your full canvas before publishing the workflow.
+</Warning>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="QA Node" href="/voice-agent/qa">
+    Automatically evaluate calls after they end.
+  </Card>
+  <Card title="Webhook Node" href="/voice-agent/webhook">
+    Sync call outcomes to your CRM or external systems.
+  </Card>
+  <Card title="Agent Node" href="/voice-agent/agent">
+    Configure the conversation logic that routes into End Call.
+  </Card>
+  <Card title="Context and Variables" href="/core-concepts/context-and-variables">
+    Reference gathered_context variables in your Final Message prompt.
+  </Card>
+</CardGroup>

--- a/docs/voice-agent/end-call.mdx
+++ b/docs/voice-agent/end-call.mdx
@@ -37,10 +37,6 @@ The caller committed to {{gathered_context.payment_option_chosen}}.
 Confirm this amount and thank them before ending the call.
 ```
 
-**Allow Interruption**
-
-When on, the caller can interrupt the agent mid-utterance.
-
 **Add Global Prompt**
 
 When on and a Global Node exists, the Global Prompt is prepended to this node's Prompt at runtime. On by default.

--- a/docs/voice-agent/end-call.mdx
+++ b/docs/voice-agent/end-call.mdx
@@ -23,19 +23,14 @@ System instructions for what the agent says before the call ends. You can make t
 
 For example:
 
-```
+```text
 If the caller committed to a payment, confirm the arrangement: the
 exact amount and expected processing time. If no commitment was made,
 thank them for their time and let them know they can call back to
 discuss options. Always close professionally.
 ```
 
-You can reference `gathered_context` variables here to pull in specific details from the conversation:
-
-```
-The caller committed to {{gathered_context.payment_option_chosen}}.
-Confirm this amount and thank them before ending the call.
-```
+The Prompt cannot reference `gathered_context` - variables extracted by this or earlier nodes are not available in any node's Prompt. To act on extracted data, send it out via a [Webhook node](./webhook) instead.
 
 **Add Global Prompt**
 
@@ -60,16 +55,16 @@ Check every Agent Node for a path to End Call before publishing. Nodes with no d
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="QA Node" href="/voice-agent/qa">
+  <Card title="QA Node" href="./qa">
     Automatically evaluate calls after they end.
   </Card>
-  <Card title="Webhook Node" href="/voice-agent/webhook">
+  <Card title="Webhook Node" href="./webhook">
     Sync call outcomes to your CRM or external systems.
   </Card>
-  <Card title="Agent Node" href="/voice-agent/agent">
+  <Card title="Agent Node" href="./agent">
     Configure the conversation logic that routes into End Call.
   </Card>
-  <Card title="Context and Variables" href="/core-concepts/context-and-variables">
-    Reference `gathered_context` variables in your End Call prompt.
+  <Card title="Context and Variables" href="../core-concepts/context-and-variables">
+    Learn where `gathered_context` can and cannot be referenced.
   </Card>
 </CardGroup>

--- a/docs/voice-agent/end-call.mdx
+++ b/docs/voice-agent/end-call.mdx
@@ -3,17 +3,13 @@ title: "End Call"
 description: "You can use End Call node to configure how the Agent says its final message right before the call is terminated"
 ---
 
-<Note>
-You should have only one End Call node per Voice Agent.
-</Note>
-
-End Call is the final node in every workflow. It fires right before Dograh terminates the connection, giving your agent one last chance to speak. Every path through your workflow should eventually route here.
+End Call is the terminal node in a workflow. It fires right before Dograh terminates the connection, giving your agent one last chance to speak. Every path through your workflow must eventually reach an End Call node.
 
 ## When it runs
 
 End Call executes after all conversation logic is complete. The agent delivers its Final Message, then the call drops.
 
-Multiple Agent Nodes can route into a single End Call node. You do not need separate End Call nodes for different call outcomes - handle variation in the Final Message prompt instead.
+You can have multiple End Call nodes in one workflow, each reached by a different edge condition. For example, one for a successful outcome and one for a wrong-number path. Each can have its own distinct Final Message.
 
 ## Fields
 
@@ -41,7 +37,7 @@ Confirm this amount and thank them before ending the call.
 
 **Leaving the Final Message empty.** An empty Final Message means the agent says nothing before the line drops. The caller experiences an abrupt silence.
 
-**Creating multiple End Call nodes.** Each workflow supports exactly one. Route all paths to the same End Call node, and use the Final Message prompt to handle variation by outcome.
+**Routing all paths into one End Call when outcomes need different messages.** Multiple End Call nodes are supported. If a wrong-number path and a successful-commitment path need different closing lines, use two End Call nodes with distinct Final Messages rather than cramming both into one prompt.
 
 **Agent Nodes that never route to End Call.** Any node without a downstream path to End Call leaves calls in an unresolvable state.
 

--- a/docs/voice-agent/end-call.mdx
+++ b/docs/voice-agent/end-call.mdx
@@ -43,10 +43,10 @@ Confirm this amount and thank them before ending the call.
 
 **Creating multiple End Call nodes.** Each workflow supports exactly one. Route all paths to the same End Call node, and use the Final Message prompt to handle variation by outcome.
 
-**Agent Nodes that never route to End Call.** Any node without a downstream path to End Call leaves calls in an unresolvable state. Check your canvas for nodes with no outgoing connection to End Call before publishing.
+**Agent Nodes that never route to End Call.** Any node without a downstream path to End Call leaves calls in an unresolvable state.
 
 <Warning>
-If an Agent Node has no route to End Call, calls that reach that node may drop without a closing message. Review your full canvas before publishing the workflow.
+Check every Agent Node for a path to End Call before publishing. Nodes with no downstream connection to End Call will drop the call without a closing message.
 </Warning>
 
 ## Next Steps
@@ -62,6 +62,6 @@ If an Agent Node has no route to End Call, calls that reach that node may drop w
     Configure the conversation logic that routes into End Call.
   </Card>
   <Card title="Context and Variables" href="/core-concepts/context-and-variables">
-    Reference gathered_context variables in your Final Message prompt.
+    Reference `gathered_context` variables in your Final Message prompt.
   </Card>
 </CardGroup>

--- a/docs/voice-agent/end-call.mdx
+++ b/docs/voice-agent/end-call.mdx
@@ -13,9 +13,9 @@ You can have multiple End Call nodes in one workflow, each reached by a differen
 
 ## Fields
 
-**Final Message**
+**Prompt**
 
-A prompt that controls what your agent says before the call ends. You can make this conditional by describing different outcomes in the prompt.
+System instructions for what the agent says before the call ends. You can make this conditional by describing different outcomes in the prompt.
 
 For example:
 
@@ -26,7 +26,7 @@ thank them for their time and let them know they can call back to
 discuss options. Always close professionally.
 ```
 
-You can reference `gathered_context` variables in this prompt to pull in specific details from the conversation:
+You can reference `gathered_context` variables here to pull in specific details from the conversation:
 
 ```
 The caller committed to {{gathered_context.payment_option_chosen}}.
@@ -35,9 +35,9 @@ Confirm this amount and thank them before ending the call.
 
 ## Common mistakes
 
-**Leaving the Final Message empty.** An empty Final Message means the agent says nothing before the line drops. The caller experiences an abrupt silence.
+**Leaving the Prompt empty.** An empty Prompt means the agent says nothing before the line drops. The caller experiences an abrupt silence.
 
-**Routing all paths into one End Call when outcomes need different messages.** Multiple End Call nodes are supported. If a wrong-number path and a successful-commitment path need different closing lines, use two End Call nodes with distinct Final Messages rather than cramming both into one prompt.
+**Routing all paths into one End Call when outcomes need different closing lines.** Multiple End Call nodes are supported. If a wrong-number path and a successful-commitment path need different closing lines, use two End Call nodes with distinct Prompts rather than cramming both into one.
 
 **Agent Nodes that never route to End Call.** Any node without a downstream path to End Call leaves calls in an unresolvable state.
 
@@ -58,6 +58,6 @@ Check every Agent Node for a path to End Call before publishing. Nodes with no d
     Configure the conversation logic that routes into End Call.
   </Card>
   <Card title="Context and Variables" href="/core-concepts/context-and-variables">
-    Reference `gathered_context` variables in your Final Message prompt.
+    Reference `gathered_context` variables in your End Call prompt.
   </Card>
 </CardGroup>

--- a/docs/voice-agent/end-call.mdx
+++ b/docs/voice-agent/end-call.mdx
@@ -7,11 +7,15 @@ End Call is the terminal node in a workflow. It fires right before Dograh termin
 
 ## When it runs
 
-End Call executes after all conversation logic is complete. The agent delivers its Final Message, then the call drops.
+End Call executes after all conversation logic is complete. The agent delivers its closing message, then the call drops.
 
-You can have multiple End Call nodes in one workflow, each reached by a different edge condition. For example, one for a successful outcome and one for a wrong-number path. Each can have its own distinct Final Message.
+You can have multiple End Call nodes in one workflow, each reached by a different edge condition. For example, one for a successful outcome and one for a wrong-number path. Each can have its own distinct Prompt.
 
 ## Fields
+
+**Name**
+
+Short identifier shown in the canvas and call logs. Use names that describe the ending context, for example "Successful close" or "Polite decline".
 
 **Prompt**
 
@@ -32,6 +36,18 @@ You can reference `gathered_context` variables here to pull in specific details 
 The caller committed to {{gathered_context.payment_option_chosen}}.
 Confirm this amount and thank them before ending the call.
 ```
+
+**Allow Interruption**
+
+When on, the caller can interrupt the agent mid-utterance.
+
+**Add Global Prompt**
+
+When on and a Global Node exists, the Global Prompt is prepended to this node's Prompt at runtime. On by default.
+
+**Enable Variable Extraction**
+
+When on, an LLM extraction pass runs after this node's turn to capture structured data from the conversation into `gathered_context`.
 
 ## Common mistakes
 

--- a/docs/voice-agent/end-call.mdx
+++ b/docs/voice-agent/end-call.mdx
@@ -3,6 +3,19 @@ title: "End Call"
 description: "You can use End Call node to configure how the Agent says its final message right before the call is terminated"
 ---
 
+## Video Tutorial
+
+<iframe 
+  width="560" 
+  height="315" 
+  src="https://www.youtube.com/embed/cuglQXX9nPI" 
+  title="End Call Node Tutorial" 
+  frameBorder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+  referrerPolicy="strict-origin-when-cross-origin" 
+  allowFullScreen
+></iframe>
+
 End Call is the terminal node in a workflow. It fires right before Dograh terminates the connection, giving your agent one last chance to speak. Every path through your workflow must eventually reach an End Call node.
 
 ## When it runs

--- a/docs/voice-agent/global.mdx
+++ b/docs/voice-agent/global.mdx
@@ -24,7 +24,7 @@ Avoid putting step-specific logic here. Instructions like "offer the settlement 
 
 ## How it works
 
-Global Node does not run as a separate step in the call. It has no edges and cannot be connected to other nodes. Its content is silently appended to each Agent Node prompt where "Add Global Prompt" is enabled.
+Global Node does not run as a separate step in the call. It has no edges and cannot be connected to other nodes. Its content is silently prepended to each Agent Node prompt where "Add Global Prompt" is enabled.
 
 The LLM sees one combined prompt: the global content first, followed by the node-specific instructions. The caller never notices the seam.
 

--- a/docs/voice-agent/global.mdx
+++ b/docs/voice-agent/global.mdx
@@ -26,7 +26,7 @@ Avoid putting step-specific logic here. Instructions like "offer the settlement 
 
 Global Node does not run as a separate step in the call. It has no edges and cannot be connected to other nodes. Its content is silently appended to each Agent Node prompt where "Add Global Prompt" is enabled.
 
-The LLM sees one combined prompt: your node-specific instructions, followed by the global content. The caller never notices the seam.
+The LLM sees one combined prompt: the global content first, followed by the node-specific instructions. The caller never notices the seam.
 
 ## Enabling it on an Agent Node
 

--- a/docs/voice-agent/global.mdx
+++ b/docs/voice-agent/global.mdx
@@ -9,7 +9,7 @@ You should have only one Global node per Voice Agent.
 
 ![Add Global Prompt Selector](../images/global-node.png)
 
-Global Node is a shared prompt layer for your entire workflow. Write your agent's persona, tone guidelines, and compliance rules here once. Any Agent Node with "Add Global Prompt" turned on will receive this content appended to its own prompt before each LLM call.
+Global Node is a shared prompt layer for your entire workflow. Write your agent's persona, tone guidelines, and compliance rules once in the **Global Prompt** field. Any Agent Node or Start Call node with "Add Global Prompt" turned on will receive this content prepended to its own prompt before each LLM call.
 
 ## What goes in the Global Node
 
@@ -24,7 +24,7 @@ Avoid putting step-specific logic here. Instructions like "offer the settlement 
 
 ## How it works
 
-Global Node does not run as a separate step in the call. It has no edges and cannot be connected to other nodes. Its content is silently prepended to each Agent Node prompt where "Add Global Prompt" is enabled.
+Global Node does not run as a separate step in the call. It has no edges and cannot be connected to other nodes. The Global Prompt is silently prepended to each node's prompt where "Add Global Prompt" is enabled.
 
 The LLM sees one combined prompt: the global content first, followed by the node-specific instructions. The caller never notices the seam.
 

--- a/docs/voice-agent/global.mdx
+++ b/docs/voice-agent/global.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Global Node"
-description: "Global Node contain the common prompt that is appended to the prompt of every node, in which `Add Global Prompt` is turned on."
+description: "Global Node contain the common prompt that is prepended to the prompt of every node, in which `Add Global Prompt` is turned on."
 ---
 
 <Note>
@@ -40,17 +40,17 @@ Turn the toggle off selectively when a specific node needs different behavior. A
 
 **Putting node-specific logic in the Global Node.** Global is for rules that always apply, not for conversation-specific decisions. Sequence and outcome logic belong in each Agent Node prompt.
 
-**Leaving the Global Node prompt empty with toggles on.** A blank Global Node appended to every prompt does nothing harmful, but it is also pointless. Either fill it in or leave the toggle off.
+**Leaving the Global Node prompt empty with toggles on.** A blank Global Node prepended to every prompt does nothing harmful, but it is also pointless. Either fill it in or leave the toggle off.
 
 **Adding a second Global Node.** Each workflow supports exactly one. Adding a second throws an error.
 
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Start Call Node" href="/voice-agent/start-call">
+  <Card title="Start Call Node" href="./start-call">
     Configure how your agent opens the conversation.
   </Card>
-  <Card title="Agent Node" href="/voice-agent/agent">
+  <Card title="Agent Node" href="./agent">
     Build the core conversation logic that inherits your global prompt.
   </Card>
 </CardGroup>

--- a/docs/voice-agent/global.mdx
+++ b/docs/voice-agent/global.mdx
@@ -9,4 +9,48 @@ You should have only one Global node per Voice Agent.
 
 ![Add Global Prompt Selector](../images/global-node.png)
 
-This node typically contains common instructions, that the Voice Agent should always follow, like tone of the conversation, any objection handling etc. 
+Global Node is a shared prompt layer for your entire workflow. Write your agent's persona, tone guidelines, and compliance rules here once. Any Agent Node with "Add Global Prompt" turned on will receive this content appended to its own prompt before each LLM call.
+
+## What goes in the Global Node
+
+Use Global Node for instructions that apply across every step of the conversation:
+
+- **Persona:** Who is the agent? What company do they represent?
+- **Tone rules:** How formal or warm should they be?
+- **Compliance guardrails:** What must the agent never say?
+- **Objection handling:** How should the agent respond to pushback?
+
+Avoid putting step-specific logic here. Instructions like "offer the settlement option after the debtor confirms their identity" belong in the Agent Node prompt, not in Global.
+
+## How it works
+
+Global Node does not run as a separate step in the call. It has no edges and cannot be connected to other nodes. Its content is silently appended to each Agent Node prompt where "Add Global Prompt" is enabled.
+
+The LLM sees one combined prompt: your node-specific instructions, followed by the global content. The caller never notices the seam.
+
+## Enabling it on an Agent Node
+
+Each Agent Node has an "Add Global Prompt" toggle in its settings panel. Nodes with the toggle off receive no global content for that step.
+
+<Tip>
+Turn the toggle off selectively when a specific node needs different behavior. An escalation node, for example, may need a more formal tone that should not inherit your default persona.
+</Tip>
+
+## Common mistakes
+
+**Putting node-specific logic in the Global Node.** Global is for rules that always apply, not for conversation-specific decisions. Sequence and outcome logic belong in each Agent Node prompt.
+
+**Leaving the Global Node prompt empty with toggles on.** A blank Global Node appended to every prompt does nothing harmful, but it is also pointless. Either fill it in or leave the toggle off.
+
+**Adding a second Global Node.** Each workflow supports exactly one. Adding a second throws an error.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Start Call Node" href="/voice-agent/start-call">
+    Configure how your agent opens the conversation.
+  </Card>
+  <Card title="Agent Node" href="/voice-agent/agent">
+    Build the core conversation logic that inherits your global prompt.
+  </Card>
+</CardGroup>

--- a/docs/voice-agent/global.mdx
+++ b/docs/voice-agent/global.mdx
@@ -1,7 +1,20 @@
 ---
 title: "Global Node"
-description: "Global Node contain the common prompt that is prepended to the prompt of every node, in which `Add Global Prompt` is turned on."
+description: "Global Node contains the common prompt that is prepended to the prompt of every node, in which `Add Global Prompt` is turned on."
 ---
+
+## Video Tutorial
+
+<iframe 
+  width="560" 
+  height="315" 
+  src="https://www.youtube.com/embed/ihMPJ4lCRfA" 
+  title="Global Node Tutorial" 
+  frameBorder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+  referrerPolicy="strict-origin-when-cross-origin" 
+  allowFullScreen
+></iframe>
 
 <Note>
 You should have only one Global node per Voice Agent.

--- a/docs/voice-agent/global.mdx
+++ b/docs/voice-agent/global.mdx
@@ -30,7 +30,7 @@ The LLM sees one combined prompt: the global content first, followed by the node
 
 ## Enabling it on an Agent Node
 
-Each Agent Node has an "Add Global Prompt" toggle in its settings panel. Nodes with the toggle off receive no global content for that step.
+Each Agent Node and Start Call node has an "Add Global Prompt" toggle in its settings panel. Nodes with the toggle off receive no global content for that step.
 
 <Tip>
 Turn the toggle off selectively when a specific node needs different behavior. An escalation node, for example, may need a more formal tone that should not inherit your default persona.

--- a/docs/voice-agent/introduction.mdx
+++ b/docs/voice-agent/introduction.mdx
@@ -27,7 +27,7 @@ A workflow should have only one **Start Call** node and typically ends at an **E
 | [**Global**](/voice-agent/global) | Common instructions (tone, objection handling) appended to every node with "Add Global Prompt" enabled. |
 | [**QA**](/voice-agent/qa) | Runs automated post-call quality analysis against criteria you define. |
 | [**API Trigger**](/voice-agent/api-trigger) | Exposes an endpoint so external systems (n8n, Zapier, your backend) can start outbound calls. |
-| [**End Call**](/voice-agent/end-call) | Configures the agent's final message before the call is terminated. Should have only one per workflow. |
+| [**End Call**](/voice-agent/end-call) | Configures the agent's final message before the call is terminated. A workflow can have multiple End Call nodes, each with a distinct Prompt. |
 | [**Webhook**](/voice-agent/webhook) | Sends call results to an external system (CRM, Zapier, n8n) when a run ends. |
 
 Beyond nodes, you can extend an agent with:

--- a/docs/voice-agent/introduction.mdx
+++ b/docs/voice-agent/introduction.mdx
@@ -24,7 +24,7 @@ A workflow should have only one **Start Call** node and typically ends at an **E
 | --- | --- |
 | [**Start Call**](/voice-agent/start-call) | Starts the call and configures the agent's greeting. Should have only one per workflow. |
 | [**Agent**](/voice-agent/agent) | Holds the prompt that drives conversation at a given stage; connects to other nodes via pathways. |
-| [**Global**](/voice-agent/global) | Common instructions (tone, objection handling) appended to every node with "Add Global Prompt" enabled. |
+| [**Global**](/voice-agent/global) | Common instructions (tone, objection handling) prepended to every node with "Add Global Prompt" enabled. |
 | [**QA**](/voice-agent/qa) | Runs automated post-call quality analysis against criteria you define. |
 | [**API Trigger**](/voice-agent/api-trigger) | Exposes an endpoint so external systems (n8n, Zapier, your backend) can start outbound calls. |
 | [**End Call**](/voice-agent/end-call) | Configures the agent's final message before the call is terminated. A workflow can have multiple End Call nodes, each with a distinct Prompt. |

--- a/docs/voice-agent/qa.mdx
+++ b/docs/voice-agent/qa.mdx
@@ -31,7 +31,7 @@ You can add multiple criteria. Each runs independently on the same transcript an
 Vague criteria produce inconsistent scores. Specify exactly what counts as a pass - include the behavior you expect to see, not just the general category.
 </Tip>
 
-### Viewing QA Results
+## Viewing QA Results
 
 After a call completes, the QA analysis runs automatically. You can view the results on the **Run Detail** page for each individual run.
 
@@ -55,7 +55,7 @@ Open a run and scroll to the **QA Analysis** section. Each criterion shows its r
     Send call outcomes to external systems after the call ends.
   </Card>
   <Card title="Context and Variables" href="/core-concepts/context-and-variables">
-    Learn how gathered_context is built during the call.
+    Learn how `gathered_context` is built during the call.
   </Card>
   <Card title="End Call Node" href="/voice-agent/end-call">
     Configure the final message before the call drops.

--- a/docs/voice-agent/qa.mdx
+++ b/docs/voice-agent/qa.mdx
@@ -3,7 +3,7 @@ title: "QA"
 description: "QA node allows you to run post-call quality analysis on your Voice Agent runs"
 ---
 
-The QA node lets you define quality analysis criteria that are automatically evaluated after each call ends. Use it to score agent performance, check compliance, or extract structured insights from conversations.
+The QA node runs an LLM quality review on the call transcript after each conversation ends. Use it to score agent performance, flag compliance issues, and surface patterns across calls — without listening to recordings manually.
 
 ## When it runs
 
@@ -13,29 +13,51 @@ This means QA does not affect call behavior. It only measures it.
 
 ## Where it sits on the canvas
 
-Add QA Node anywhere on the canvas. It does not need to connect to other nodes - most builders place it off to the side to make clear it is a standalone evaluator. The node runs automatically for every call once the workflow is published.
+Add QA Node anywhere on the canvas. It does not need to connect to other nodes - most builders place it off to the side to make clear it is a standalone evaluator. The node runs automatically for every eligible call once the workflow is published.
 
-### Creating a QA Node
+## Configuring the QA System Prompt
 
-You can add a QA node to your workflow from the Voice Agent Builder. Once added, configure the analysis criteria that you want to evaluate for each call.
+The core configuration is a single **QA System Prompt** — instructions to the reviewer LLM that describe how to evaluate each call. The LLM reads the transcript and returns a structured JSON result.
 
-Write each criterion as a specific, evaluable question or instruction for the LLM:
+The default prompt already covers common quality dimensions out of the box:
 
-- "Did the agent confirm the caller's identity before discussing account details? Score: Pass or Fail."
-- "Did the agent present all three payment options - full amount, settlement, and payment plan - before accepting a decision? Score: Pass or Fail."
-- "Rate the agent's tone on a scale of 1 to 5. A 5 means consistently calm and professional throughout."
+- **Tags**: named issues detected in the transcript (dead air, user frustration, agent in loop, user suspects AI, and others)
+- **Call quality score**: 1-10 rating
+- **Overall sentiment**: positive, neutral, or negative
+- **Summary**: 1-2 sentence description of the call segment
 
-You can add multiple criteria. Each runs independently on the same transcript and generates its own result.
+You can replace the default prompt with your own instructions when you need domain-specific evaluation. Write the prompt as instructions to the QA reviewer LLM, and specify the JSON structure you want it to return.
+
+For compliance use cases, for example:
+
+```
+You are a compliance reviewer for a debt collection workflow.
+
+Review the transcript and return a JSON object with the following fields:
+- "identity_verified": true or false — did the agent confirm the caller's identity before discussing the account?
+- "options_presented": true or false — did the agent offer all three payment options before accepting a decision?
+- "tone_score": 1-5 — how calm and professional was the agent throughout?
+- "summary": one sentence describing the call outcome.
+```
 
 <Tip>
-Vague criteria produce inconsistent scores. Specify exactly what counts as a pass - include the behavior you expect to see, not just the general category.
+Be specific about what counts as a pass or a valid score. Include the exact behaviors you want the LLM to look for. Vague instructions produce inconsistent results across calls.
 </Tip>
+
+## Additional settings
+
+| Setting | Default | What it does |
+|---------|---------|--------------|
+| QA Enabled | On | Toggle to disable QA without removing the node |
+| Min Call Duration | 15s | Calls shorter than this are skipped |
+| Voicemail Calls | Off | When off, voicemail calls are skipped |
+| Sample Rate | 100% | Run QA on a percentage of calls rather than all of them |
 
 ## Viewing QA Results
 
 After a call completes, the QA analysis runs automatically. You can view the results on the **Run Detail** page for each individual run.
 
-Open a run and scroll to the **QA Analysis** section. Each criterion shows its result - a pass/fail flag, a score, or a text response depending on how you wrote the criterion.
+Open a run and scroll to the **QA Analysis** section. The result shows the full JSON output your QA System Prompt requested - tags, scores, sentiment, and summary for the default prompt, or whatever structure you defined.
 
 ## Common mistakes
 
@@ -43,7 +65,9 @@ Open a run and scroll to the **QA Analysis** section. Each criterion shows its r
 
 **Connecting QA Node to other nodes.** QA has no edges. Drawing a connection from QA to another node is not possible - edges will snap back when you try.
 
-**Writing criteria that are too broad.** "Did the agent do a good job?" produces unhelpful scores. Tie each criterion to a specific, observable behavior you can verify against the transcript.
+**Writing a vague QA System Prompt.** "Was the agent good?" produces unhelpful scores. Define specific, observable behaviors and the exact JSON fields you want back.
+
+**Not specifying output format.** The LLM follows your instructions, but if you do not specify a return format, the output may be inconsistent across calls. Always describe the exact JSON structure in the prompt.
 
 ## Next Steps
 

--- a/docs/voice-agent/qa.mdx
+++ b/docs/voice-agent/qa.mdx
@@ -21,7 +21,7 @@ The core configuration is a single **QA System Prompt**: instructions to the rev
 
 The default prompt already covers common quality dimensions out of the box:
 
-- **Tags**: named issues detected in the transcript (dead air, user frustration, agent in loop, user suspects AI, and others)
+- **Tags**: named issues detected in the transcript. The default tag set includes `DEAD_AIR`, `USER_FRUSTRATED`, `ASSISTANT_IN_LOOP`, `ASSISTANT_REPLY_IMPROPER`, `USER_NOT_UNDERSTANDING`, `HEARING_ISSUES`, `UNCLEAR_CONVERSATION`, `USER_REQUESTING_FEATURE`, `ASSISTANT_LACKS_EMPATHY`, and `USER_DETECTS_AI`
 - **Call quality score**: 1-10 rating
 - **Overall sentiment**: positive, neutral, or negative
 - **Summary**: 1-2 sentence description of the call segment

--- a/docs/voice-agent/qa.mdx
+++ b/docs/voice-agent/qa.mdx
@@ -5,10 +5,59 @@ description: "QA node allows you to run post-call quality analysis on your Voice
 
 The QA node lets you define quality analysis criteria that are automatically evaluated after each call ends. Use it to score agent performance, check compliance, or extract structured insights from conversations.
 
+## When it runs
+
+QA Node runs post-call only. It is not part of the live call flow - it reads the completed transcript after the conversation ends. It has no edges and cannot connect to any other node in the workflow.
+
+This means QA does not affect call behavior. It only measures it.
+
+## Where it sits on the canvas
+
+Add QA Node anywhere on the canvas. It does not need to connect to other nodes - most builders place it off to the side to make clear it is a standalone evaluator. The node runs automatically for every call once the workflow is published.
+
 ### Creating a QA Node
 
 You can add a QA node to your workflow from the Voice Agent Builder. Once added, configure the analysis criteria that you want to evaluate for each call.
 
+Write each criterion as a specific, evaluable question or instruction for the LLM:
+
+- "Did the agent confirm the caller's identity before discussing account details? Score: Pass or Fail."
+- "Did the agent present all three payment options - full amount, settlement, and payment plan - before accepting a decision? Score: Pass or Fail."
+- "Rate the agent's tone on a scale of 1 to 5. A 5 means consistently calm and professional throughout."
+
+You can add multiple criteria. Each runs independently on the same transcript and generates its own result.
+
+<Tip>
+Vague criteria produce inconsistent scores. Specify exactly what counts as a pass - include the behavior you expect to see, not just the general category.
+</Tip>
+
 ### Viewing QA Results
 
 After a call completes, the QA analysis runs automatically. You can view the results on the **Run Detail** page for each individual run.
+
+Open a run and scroll to the **QA Analysis** section. Each criterion shows its result - a pass/fail flag, a score, or a text response depending on how you wrote the criterion.
+
+## Common mistakes
+
+**Expecting QA to affect the live call.** QA Node is read-only at runtime. It evaluates what happened; it does not change what happens.
+
+**Connecting QA Node to other nodes.** QA has no edges. Drawing a connection from QA to another node is not possible - edges will snap back when you try.
+
+**Writing criteria that are too broad.** "Did the agent do a good job?" produces unhelpful scores. Tie each criterion to a specific, observable behavior you can verify against the transcript.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Agent Node" href="/voice-agent/agent">
+    Configure the conversation logic that QA evaluates.
+  </Card>
+  <Card title="Webhook Node" href="/voice-agent/webhook">
+    Send call outcomes to external systems after the call ends.
+  </Card>
+  <Card title="Context and Variables" href="/core-concepts/context-and-variables">
+    Learn how gathered_context is built during the call.
+  </Card>
+  <Card title="End Call Node" href="/voice-agent/end-call">
+    Configure the final message before the call drops.
+  </Card>
+</CardGroup>

--- a/docs/voice-agent/qa.mdx
+++ b/docs/voice-agent/qa.mdx
@@ -30,7 +30,7 @@ You can replace the default System Prompt with your own instructions when you ne
 
 For compliance use cases, for example:
 
-```
+```text
 You are a compliance reviewer for a debt collection workflow.
 
 Review the transcript and return a JSON object with the following fields:
@@ -73,16 +73,16 @@ Open a run and scroll to the **QA Analysis** section. The result shows the full 
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Agent Node" href="/voice-agent/agent">
+  <Card title="Agent Node" href="./agent">
     Configure the conversation logic that QA evaluates.
   </Card>
-  <Card title="Webhook Node" href="/voice-agent/webhook">
+  <Card title="Webhook Node" href="./webhook">
     Send call outcomes to external systems after the call ends.
   </Card>
-  <Card title="Context and Variables" href="/core-concepts/context-and-variables">
+  <Card title="Context and Variables" href="../core-concepts/context-and-variables">
     Learn how `gathered_context` is built during the call.
   </Card>
-  <Card title="End Call Node" href="/voice-agent/end-call">
+  <Card title="End Call Node" href="./end-call">
     Configure the final message before the call drops.
   </Card>
 </CardGroup>

--- a/docs/voice-agent/qa.mdx
+++ b/docs/voice-agent/qa.mdx
@@ -3,7 +3,7 @@ title: "QA"
 description: "QA node allows you to run post-call quality analysis on your Voice Agent runs"
 ---
 
-The QA node runs an LLM quality review on the call transcript after each conversation ends. Use it to score agent performance, flag compliance issues, and surface patterns across calls — without listening to recordings manually.
+The QA node runs an LLM quality review on the call transcript after each conversation ends. Use it to score agent performance, flag compliance issues, and surface patterns across calls, without listening to recordings manually.
 
 ## When it runs
 
@@ -17,7 +17,7 @@ Add QA Node anywhere on the canvas. It does not need to connect to other nodes -
 
 ## Configuring the QA System Prompt
 
-The core configuration is a single **QA System Prompt** — instructions to the reviewer LLM that describe how to evaluate each call. The LLM reads the transcript and returns a structured JSON result.
+The core configuration is a single **QA System Prompt**: instructions to the reviewer LLM that describe how to evaluate each call. The LLM reads the transcript and returns a structured JSON result.
 
 The default prompt already covers common quality dimensions out of the box:
 

--- a/docs/voice-agent/qa.mdx
+++ b/docs/voice-agent/qa.mdx
@@ -3,6 +3,19 @@ title: "QA"
 description: "QA node allows you to run post-call quality analysis on your Voice Agent runs"
 ---
 
+## Video Tutorial
+
+<iframe 
+  width="560" 
+  height="315" 
+  src="https://www.youtube.com/embed/-_almqt7uBw" 
+  title="QA Node Tutorial" 
+  frameBorder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+  referrerPolicy="strict-origin-when-cross-origin" 
+  allowFullScreen
+></iframe>
+
 The QA node runs an LLM quality review on the call transcript after each conversation ends. Use it to score agent performance, flag compliance issues, and surface patterns across calls, without listening to recordings manually.
 
 ## When it runs

--- a/docs/voice-agent/qa.mdx
+++ b/docs/voice-agent/qa.mdx
@@ -15,9 +15,9 @@ This means QA does not affect call behavior. It only measures it.
 
 Add QA Node anywhere on the canvas. It does not need to connect to other nodes - most builders place it off to the side to make clear it is a standalone evaluator. The node runs automatically for every eligible call once the workflow is published.
 
-## Configuring the QA System Prompt
+## Configuring the System Prompt
 
-The core configuration is a single **QA System Prompt**: instructions to the reviewer LLM that describe how to evaluate each call. The LLM reads the transcript and returns a structured JSON result.
+The core configuration is a single **System Prompt**: instructions to the reviewer LLM that describe how to evaluate each call. The LLM reads the transcript and returns a structured JSON result.
 
 The default prompt already covers common quality dimensions out of the box:
 
@@ -26,7 +26,7 @@ The default prompt already covers common quality dimensions out of the box:
 - **Overall sentiment**: positive, neutral, or negative
 - **Summary**: 1-2 sentence description of the call segment
 
-You can replace the default prompt with your own instructions when you need domain-specific evaluation. Write the prompt as instructions to the QA reviewer LLM, and specify the JSON structure you want it to return.
+You can replace the default System Prompt with your own instructions when you need domain-specific evaluation. Write the prompt as instructions to the QA reviewer LLM, and specify the JSON structure you want it to return.
 
 For compliance use cases, for example:
 
@@ -48,10 +48,11 @@ Be specific about what counts as a pass or a valid score. Include the exact beha
 
 | Setting | Default | What it does |
 |---------|---------|--------------|
-| QA Enabled | On | Toggle to disable QA without removing the node |
-| Min Call Duration | 15s | Calls shorter than this are skipped |
-| Voicemail Calls | Off | When off, voicemail calls are skipped |
-| Sample Rate | 100% | Run QA on a percentage of calls rather than all of them |
+| Enabled | On | Toggle to disable QA without removing the node |
+| Use Workflow's LLM | Off | When on, uses the same LLM configured for the workflow instead of the default QA model |
+| Minimum Call Duration (seconds) | 15 | Calls shorter than this are skipped |
+| Include Voicemail Calls | Off | When off, voicemail calls are skipped |
+| Sample Rate (%) | 100 | Run QA on a percentage of calls rather than all of them |
 
 ## Viewing QA Results
 
@@ -65,9 +66,9 @@ Open a run and scroll to the **QA Analysis** section. The result shows the full 
 
 **Connecting QA Node to other nodes.** QA has no edges. Drawing a connection from QA to another node is not possible - edges will snap back when you try.
 
-**Writing a vague QA System Prompt.** "Was the agent good?" produces unhelpful scores. Define specific, observable behaviors and the exact JSON fields you want back.
+**Writing a vague System Prompt.** "Was the agent good?" produces unhelpful scores. Define specific, observable behaviors and the exact JSON fields you want back.
 
-**Not specifying output format.** The LLM follows your instructions, but if you do not specify a return format, the output may be inconsistent across calls. Always describe the exact JSON structure in the prompt.
+**Not specifying output format.** The LLM follows your instructions, but if you do not specify a return format, the output may be inconsistent across calls. Always describe the exact JSON structure in the System Prompt.
 
 ## Next Steps
 

--- a/docs/voice-agent/start-call.mdx
+++ b/docs/voice-agent/start-call.mdx
@@ -17,25 +17,45 @@ After Start Call completes, the conversation moves to the next node - typically 
 
 ## Fields
 
-**Agent Name**
+**Node Name**
 
-The name your agent introduces itself as. This is separate from the workflow name shown in the dashboard. Keep it consistent with the persona defined in your [Global Node](/voice-agent/global).
+A short label that identifies this node in the canvas and in call logs. This is not the agent's spoken name. The agent's spoken persona and name belong in the Greeting Text or the Prompt.
 
-**Greeting Prompt**
+**Greeting Text**
 
-A prompt that controls what your agent says when the call begins. You can reference `initial_context` variables here using `{{initial_context.field_name}}` syntax.
+An optional fixed line played via text-to-speech the moment the call connects, before the AI's conversational turn begins. Use it for a consistent opening line.
 
 For example:
 
 ```
-You are Alex, calling on behalf of Apex Recovery Solutions regarding
-an outstanding balance owed to FreshCart. Greet the caller by name:
-{{initial_context.debtor_name}}. Ask if this is a good time to talk.
+Hi {{initial_context.debtor_name}}, this is Alex from Apex Recovery Solutions.
+```
+
+Leave this empty if you want the agent to open the call freely based on the Prompt instead.
+
+<Note>
+You can also set Greeting Type to "Pre-recorded Audio" and attach a recording file instead of typing text. See [Pre-recorded Audio](/voice-agent/pre-recorded-audio) for setup steps.
+</Note>
+
+**Prompt**
+
+System instructions for the AI's opening conversational turn. This runs after the Greeting Text (if set). Reference `initial_context` variables with `{{initial_context.field_name}}` syntax.
+
+For example:
+
+```
+After greeting the caller, confirm you are speaking with
+{{initial_context.debtor_name}}. If they confirm, move to Debt Disclosure.
+If they say wrong number, move to End Call.
 ```
 
 <Warning>
-If a variable referenced in the Greeting Prompt is missing from the API request payload, the agent will speak the raw template placeholder out loud - for example, "Hello `{{initial_context.debtor_name}}`" - instead of the caller's name. Test with a complete payload before publishing.
+If a variable referenced in Greeting Text or Prompt is missing from the API request payload, the agent speaks the raw placeholder out loud - for example, "Hi `{{initial_context.debtor_name}}`" - instead of the caller's name. Test with a complete payload before publishing.
 </Warning>
+
+**Delayed Start**
+
+When enabled, the agent waits a configurable number of seconds before speaking after the call connects. Useful for outbound calls where the called party needs a moment before hearing the opening line. Default is off. Duration can be set between 0.1 and 10 seconds.
 
 ## Outgoing edges
 
@@ -50,7 +70,7 @@ Start Call supports two outgoing edges:
 
 **Leaving Greeting Prompt empty.** An empty greeting means your agent says nothing at the start. The caller hears silence.
 
-**Using a different name in Agent Name versus Global Node.** The Agent Name field controls what the LLM introduces itself as. A mismatch with your Global Node persona produces inconsistent self-introductions.
+**Confusing Node Name with the agent's spoken name.** Node Name is a canvas label for your own reference. The name the agent introduces itself as comes from the Greeting Text or Prompt content, or the persona you define in the [Global Node](/voice-agent/global).
 
 **Adding a second Start Call node.** Each workflow has one entry point. A second Start Call node will throw an error.
 

--- a/docs/voice-agent/start-call.mdx
+++ b/docs/voice-agent/start-call.mdx
@@ -59,12 +59,24 @@ When enabled, the agent waits a configurable number of seconds before speaking a
 
 ## Outgoing edges
 
-Start Call supports two outgoing edges:
+Start Call can have multiple outgoing edges, each with a user-defined label and a condition written in plain language. The LLM reads the conversation and picks the edge whose condition best matches.
 
-| Edge | When to use |
-|------|-------------|
-| Call continues | The caller is responsive - route to your first Agent Node |
-| Wrong number or early hangup | The caller hangs up immediately or says they have the wrong number - route to End Call |
+Each edge needs two things:
+
+- **Label:** a short name shown on the canvas (you define this)
+- **Condition:** the instruction that tells the LLM when to take this edge
+
+A typical Start Call has two edges:
+
+```
+Label: "caller confirmed"
+Condition: "The caller confirmed they are the right person and are ready to continue."
+
+Label: "wrong number"
+Condition: "The caller says this is the wrong number, asks not to be called, or refuses to confirm their identity."
+```
+
+You can add more edges if the opening turn needs to branch further.
 
 ## Common mistakes
 

--- a/docs/voice-agent/start-call.mdx
+++ b/docs/voice-agent/start-call.mdx
@@ -31,12 +31,12 @@ Optional fixed line spoken via TTS the moment the call connects, before the AI's
 
 For example:
 
-```
+```text
 Hi {{initial_context.debtor_name}}, this is Alex from Apex Recovery Solutions.
 ```
 
 <Note>
-See [Pre-recorded Audio](/voice-agent/pre-recorded-audio) to use a recording file instead of TTS text.
+See [Pre-recorded Audio](./pre-recorded-audio) to use a recording file instead of TTS text.
 </Note>
 
 **Prompt** (required)
@@ -45,7 +45,7 @@ System instructions for the AI's opening conversational turn. Runs after Greetin
 
 For example:
 
-```
+```text
 After greeting the caller, confirm you are speaking with
 {{initial_context.debtor_name}}. If they confirm, move to Debt Disclosure.
 If they say wrong number, move to End Call.
@@ -94,7 +94,7 @@ Each edge needs two things:
 
 A typical Start Call has two edges:
 
-```
+```text
 Label: "caller confirmed"
 Condition: "The caller confirmed they are the right person and are ready to continue."
 
@@ -108,23 +108,23 @@ You can add more edges if the opening turn needs to branch further.
 
 **Leaving Greeting Text empty with no Prompt.** If both Greeting Text and Prompt are empty, the agent says nothing at the start of the call. The caller hears silence.
 
-**Confusing Node Name with the agent's spoken name.** Node Name is a canvas label for your own reference. The name the agent introduces itself as comes from the Greeting Text or Prompt content, or the persona you define in the [Global Node](/voice-agent/global).
+**Confusing Node Name with the agent's spoken name.** Node Name is a canvas label for your own reference. The name the agent introduces itself as comes from the Greeting Text or Prompt content, or the persona you define in the [Global Node](./global).
 
 **Adding a second Start Call node.** Each workflow has one entry point. A second Start Call node will throw an error.
 
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Agent Node" href="/voice-agent/agent">
+  <Card title="Agent Node" href="./agent">
     Build the core conversation logic that follows the greeting.
   </Card>
-  <Card title="Global Node" href="/voice-agent/global">
+  <Card title="Global Node" href="./global">
     Set persona and tone rules that apply across all nodes.
   </Card>
-  <Card title="Context and Variables" href="/core-concepts/context-and-variables">
+  <Card title="Context and Variables" href="../core-concepts/context-and-variables">
     Learn how `initial_context` variables flow through a call.
   </Card>
-  <Card title="End Call Node" href="/voice-agent/end-call">
+  <Card title="End Call Node" href="./end-call">
     Configure the agent's final message before the call drops.
   </Card>
 </CardGroup>

--- a/docs/voice-agent/start-call.mdx
+++ b/docs/voice-agent/start-call.mdx
@@ -64,7 +64,7 @@ Start Call supports two outgoing edges:
     Set persona and tone rules that apply across all nodes.
   </Card>
   <Card title="Context and Variables" href="/core-concepts/context-and-variables">
-    Learn how initial_context variables flow through a call.
+    Learn how `initial_context` variables flow through a call.
   </Card>
   <Card title="End Call Node" href="/voice-agent/end-call">
     Configure the agent's final message before the call drops.

--- a/docs/voice-agent/start-call.mdx
+++ b/docs/voice-agent/start-call.mdx
@@ -3,6 +3,19 @@ title: "Start Call"
 description: "You can use Start Call node to Start the call and configure how Agent greets the user when the conversation starts."
 ---
 
+## Video Tutorial
+
+<iframe 
+  width="560" 
+  height="315" 
+  src="https://www.youtube.com/embed/Bpnu7Oz-YPI" 
+  title="Start Call Node Tutorial" 
+  frameBorder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+  referrerPolicy="strict-origin-when-cross-origin" 
+  allowFullScreen
+></iframe>
+
 <Note>
 You should have only one Start Call node per Voice Agent.
 </Note>

--- a/docs/voice-agent/start-call.mdx
+++ b/docs/voice-agent/start-call.mdx
@@ -17,13 +17,17 @@ After Start Call completes, the conversation moves to the next node - typically 
 
 ## Fields
 
-**Node Name**
+**Name**
 
-A short label that identifies this node in the canvas and in call logs. This is not the agent's spoken name. The agent's spoken persona and name belong in the Greeting Text or the Prompt.
+Short identifier shown in the canvas and call logs. Has no runtime effect on what the agent says.
+
+**Greeting Type**
+
+Whether the greeting is spoken via TTS from text or played from a pre-recorded audio file. Defaults to "Text (TTS)".
 
 **Greeting Text**
 
-An optional fixed line played via text-to-speech the moment the call connects, before the AI's conversational turn begins. Use it for a consistent opening line.
+Optional fixed line spoken via TTS the moment the call connects, before the AI's conversational turn begins. Supports `{{template_variables}}`. Leave empty to skip the greeting and let the Prompt handle the opening.
 
 For example:
 
@@ -31,15 +35,13 @@ For example:
 Hi {{initial_context.debtor_name}}, this is Alex from Apex Recovery Solutions.
 ```
 
-Leave this empty if you want the agent to open the call freely based on the Prompt instead.
-
 <Note>
-You can also set Greeting Type to "Pre-recorded Audio" and attach a recording file instead of typing text. See [Pre-recorded Audio](/voice-agent/pre-recorded-audio) for setup steps.
+See [Pre-recorded Audio](/voice-agent/pre-recorded-audio) to use a recording file instead of TTS text.
 </Note>
 
-**Prompt**
+**Prompt** (required)
 
-System instructions for the AI's opening conversational turn. This runs after the Greeting Text (if set). Reference `initial_context` variables with `{{initial_context.field_name}}` syntax.
+System instructions for the AI's opening conversational turn. Runs after Greeting Text (if set). Supports `{{initial_context.field_name}}` and variables from Pre-Call Data Fetch.
 
 For example:
 
@@ -53,9 +55,33 @@ If they say wrong number, move to End Call.
 If a variable referenced in Greeting Text or Prompt is missing from the API request payload, the agent speaks the raw placeholder out loud - for example, "Hi `{{initial_context.debtor_name}}`" - instead of the caller's name. Test with a complete payload before publishing.
 </Warning>
 
+**Allow Interruption**
+
+When on, the caller can interrupt the agent mid-utterance. Off by default on Start Call.
+
+**Add Global Prompt**
+
+When on and a Global Node exists, the Global Prompt is prepended to this node's Prompt at runtime. On by default.
+
 **Delayed Start**
 
-When enabled, the agent waits a configurable number of seconds before speaking after the call connects. Useful for outbound calls where the called party needs a moment before hearing the opening line. Default is off. Duration can be set between 0.1 and 10 seconds.
+When on, the agent waits before speaking after the call connects. Useful for outbound calls where the called party needs a moment to settle. Duration can be set between 0.1 and 10 seconds.
+
+**Enable Variable Extraction**
+
+When on, an LLM extraction pass runs after this node's turn to capture structured data from the conversation into `gathered_context`.
+
+**Tools**
+
+Functions the agent can call during the opening turn. Add via the "HTTP & Tools" tab (HTTP API and built-in tools) or the "MCP" tab (MCP server tools).
+
+**Knowledge Base Documents**
+
+Documents the agent can reference during this step. Attach via "Manage Documents."
+
+**Pre-Call Data Fetch**
+
+When on, Dograh makes a POST request to an external API before the call starts and merges the JSON response into the call context as template variables.
 
 ## Outgoing edges
 

--- a/docs/voice-agent/start-call.mdx
+++ b/docs/voice-agent/start-call.mdx
@@ -2,6 +2,71 @@
 title: "Start Call"
 description: "You can use Start Call node to Start the call and configure how Agent greets the user when the conversation starts."
 ---
+
 <Note>
 You should have only one Start Call node per Voice Agent.
 </Note>
+
+Start Call is the entry point for every conversation. It fires the moment a call connects and controls the first thing your agent says. Every workflow must have exactly one.
+
+## When it runs
+
+Start Call executes before any Agent Node. No other node can precede it in the call flow.
+
+After Start Call completes, the conversation moves to the next node - typically your first Agent Node. If the caller hangs up immediately or reaches a wrong-number condition, Start Call can route directly to End Call instead.
+
+## Fields
+
+**Agent Name**
+
+The name your agent introduces itself as. This is separate from the workflow name shown in the dashboard. Keep it consistent with the persona defined in your [Global Node](/voice-agent/global).
+
+**Greeting Prompt**
+
+A prompt that controls what your agent says when the call begins. You can reference `initial_context` variables here using `{{initial_context.field_name}}` syntax.
+
+For example:
+
+```
+You are Alex, calling on behalf of Apex Recovery Solutions regarding
+an outstanding balance owed to FreshCart. Greet the caller by name:
+{{initial_context.debtor_name}}. Ask if this is a good time to talk.
+```
+
+<Warning>
+If a variable referenced in the Greeting Prompt is missing from the API request payload, the agent will speak the raw template placeholder out loud - for example, "Hello `{{initial_context.debtor_name}}`" - instead of the caller's name. Test with a complete payload before publishing.
+</Warning>
+
+## Outgoing edges
+
+Start Call supports two outgoing edges:
+
+| Edge | When to use |
+|------|-------------|
+| Call continues | The caller is responsive - route to your first Agent Node |
+| Wrong number or early hangup | The caller hangs up immediately or says they have the wrong number - route to End Call |
+
+## Common mistakes
+
+**Leaving Greeting Prompt empty.** An empty greeting means your agent says nothing at the start. The caller hears silence.
+
+**Using a different name in Agent Name versus Global Node.** The Agent Name field controls what the LLM introduces itself as. A mismatch with your Global Node persona produces inconsistent self-introductions.
+
+**Adding a second Start Call node.** Each workflow has one entry point. A second Start Call node will throw an error.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Agent Node" href="/voice-agent/agent">
+    Build the core conversation logic that follows the greeting.
+  </Card>
+  <Card title="Global Node" href="/voice-agent/global">
+    Set persona and tone rules that apply across all nodes.
+  </Card>
+  <Card title="Context and Variables" href="/core-concepts/context-and-variables">
+    Learn how initial_context variables flow through a call.
+  </Card>
+  <Card title="End Call Node" href="/voice-agent/end-call">
+    Configure the agent's final message before the call drops.
+  </Card>
+</CardGroup>

--- a/docs/voice-agent/start-call.mdx
+++ b/docs/voice-agent/start-call.mdx
@@ -68,7 +68,7 @@ Start Call supports two outgoing edges:
 
 ## Common mistakes
 
-**Leaving Greeting Prompt empty.** An empty greeting means your agent says nothing at the start. The caller hears silence.
+**Leaving Greeting Text empty with no Prompt.** If both Greeting Text and Prompt are empty, the agent says nothing at the start of the call. The caller hears silence.
 
 **Confusing Node Name with the agent's spoken name.** Node Name is a canvas label for your own reference. The name the agent introduces itself as comes from the Greeting Text or Prompt content, or the persona you define in the [Global Node](/voice-agent/global).
 


### PR DESCRIPTION
## Summary

- Rewrote stub docs for all 5 voice agent nodes: Global, Start Call, Agent, End Call, QA
- Field names, toggle labels, and section headings match the Dograh UI exactly
- Each page covers: what the node does, all configurable fields, edge conditions where applicable, common mistakes, and Next Steps cards

## Pages changed

- `docs/voice-agent/global.mdx` - Global Prompt field, prepend behavior, enabling per node
- `docs/voice-agent/start-call.mdx` - Full fields: Name, Greeting Type, Greeting Text, Prompt, Allow Interruption, Add Global Prompt, Delayed Start, Enable Variable Extraction, Tools, Knowledge Base Documents, Pre-Call Data Fetch
- `docs/voice-agent/agent.mdx` - Prompt, Tools, Allow Interruption, Add Global Prompt, Knowledge Base Documents, Enable Variable Extraction; edge condition guidance; multi-node chaining
- `docs/voice-agent/end-call.mdx` - Name, Prompt, Add Global Prompt, Enable Variable Extraction; multiple End Call nodes per workflow
- `docs/voice-agent/qa.mdx` - Single System Prompt field, default tag set, settings table (Enabled, Use Workflow's LLM, Minimum Call Duration, Include Voicemail Calls, Sample Rate)

## Test plan

- [ ] `mint dev` preview renders all 5 pages without MDX errors
- [ ] Field names verified against live UI node edit panels
- [ ] No internal files included in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded and corrected all five Voice Agent node docs to match the live Dograh UI/schemas, and embedded short video tutorials on each page. Also fixed the Introduction table: Global Prompt is prepended (not appended) and multiple End Call nodes are supported.

- **Docs**
  - Global: clarified that the Global Prompt is prepended; per-node “Add Global Prompt” toggle; one Global node per workflow.
  - Start Call: split Greeting Type/Text vs Prompt; added Delayed Start; Tools/Knowledge Base; Pre-Call Data Fetch; user-defined outgoing edge labels/conditions; variable placeholder warning.
  - Agent: clear edge-condition guidance; variable extraction (`extraction_prompt`, variables) with example; multi-node chaining; `gathered_context` is not available in any node’s Prompt.
  - End Call: multiple End Call nodes supported; Prompt usage; Add Global Prompt; optional extraction; `gathered_context` not available in Prompt; routing pitfalls.
  - QA: post-call only; single System Prompt with default tags/score/sentiment/summary; settings (Enabled, Use Workflow’s LLM, Minimum Duration, Include Voicemail, Sample Rate); where to view results.
  - Introduction: fixed Global row to say “prepended”; updated End Call row to allow multiple.
  - All five node pages: added a Video Tutorial section with an embedded walkthrough.

- **Docs Hygiene**
  - Converted absolute internal links to relative paths; tagged code fences as `text`.
  - Fixed headings and Warning placement; wrapped bare `gathered_context`/`initial_context` in backticks; frontmatter grammar fix (“contain” → “contains”).

<sup>Written for commit 227315531b4799d3f0e847d6c37d7ceb45233d78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the Voice Agent node documentation. The main changes are:

- Rewrites the `Start Call`, `Agent`, `End Call`, `Global`, and `QA` pages with field-level guidance.
- Adds video tutorial embeds to the five node pages.
- Documents runtime behavior, edge conditions, variable extraction, common mistakes, and next-step links.
- Updates the introduction table for Global Prompt prepending and multiple End Call node support.

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge.

The changed MDX pages expand existing docs and address the previously noted prompt-order and End Call guidance inconsistencies.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Server readiness confirmed: the dev server log shows a successful preview ready state.
- Browser validation confirmed: the browser console validation log records HTTP 200 responses and fail=false for all five routes.
- Visual proof confirmed: a validation video and per-page screenshots show the Mintlify-rendered docs pages with repository styling/content.

<a href="https://app.greptile.com/trex/runs/15357342/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/voice-agent/agent.mdx | Expanded Agent Node docs with tutorial embed, field guidance, edge conditions, variable extraction, and relative Next Steps links; no blocking issues found. |
| docs/voice-agent/end-call.mdx | Replaced the End Call stub with tutorial, lifecycle, fields, extraction, multiple-ending guidance, and follow-up cards; no blocking issues found. |
| docs/voice-agent/global.mdx | Clarified Global Prompt prepending behavior and documented usage, toggles, common mistakes, and navigation cards; no blocking issues found. |
| docs/voice-agent/introduction.mdx | Updated the node table to align Global prompt ordering and multiple End Call node support with the expanded pages; no blocking issues found. |
| docs/voice-agent/qa.mdx | Expanded QA Node docs with tutorial, post-call behavior, default output, settings, common mistakes, and next steps; no blocking issues found. |
| docs/voice-agent/start-call.mdx | Expanded Start Call docs with tutorial, field descriptions, variable warning, outgoing edge guidance, and next steps; no blocking issues found. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant Reader
participant Intro as Introduction Page
participant Global as Global Node Docs
participant Start as Start Call Docs
participant Agent as Agent Node Docs
participant EndCall as End Call Docs
participant QA as QA Node Docs

Reader->>Intro: Review available Voice Agent nodes
Intro->>Global: Learn shared prompt prepending
Intro->>Start: Configure call entry and greeting
Start->>Agent: Route through edge conditions
Agent->>EndCall: Complete workflow with closing prompt
Agent->>QA: Transcript evaluated after call ends
QA-->>Reader: View post-call analysis results
```

<sub>Reviews (4): Last reviewed commit: ["docs: fix appended/prepended in introduc..."](https://github.com/dograh-hq/dograh/commit/227315531b4799d3f0e847d6c37d7ceb45233d78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45150827)</sub>

<!-- /greptile_comment -->