### PR TITLE
feat(openai-realtime): allow pinning input transcription language

### DIFF
--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -584,6 +584,20 @@ class SarvamLLMConfiguration(BaseLLMConfiguration):
 
 
 OPENAI_REALTIME_MODELS = ["gpt-realtime-2"]
+# ISO 639-1 codes accepted by the Realtime API's input_audio_transcription.
+# Not exhaustive — the field allows custom input.
+OPENAI_REALTIME_LANGUAGES = [
+    "en",
+    "es",
+    "pt",
+    "fr",
+    "de",
+    "it",
+    "hi",
+    "ja",
+    "ko",
+    "zh",
+]
 OPENAI_REALTIME_VOICES = [
     "alloy",
     "ash",
@@ -615,6 +629,17 @@ class OpenAIRealtimeLLMConfiguration(BaseLLMConfiguration):
         description="Voice the model speaks in.",
         json_schema_extra={
             "examples": OPENAI_REALTIME_VOICES,
+            "allow_custom_input": True,
+        },
+    )
+    language: str | None = Field(
+        default=None,
+        description=(
+            "ISO 639-1 language code for input audio transcription (e.g. 'pt', 'es'). "
+            "Improves transcription accuracy and latency. Leave unset to auto-detect."
+        ),
+        json_schema_extra={
+            "examples": OPENAI_REALTIME_LANGUAGES,
             "allow_custom_input": True,
         },
     )

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -1009,6 +1009,13 @@ def create_realtime_llm_service(user_config, audio_config: "AudioConfig"):
             SessionProperties,
         )
 
+        # Pin the transcription language when configured. Without it the model
+        # auto-detects per utterance, which misfires on short/noisy telephony
+        # audio (e.g. Portuguese transcribed as English or Chinese).
+        transcription_kwargs = {}
+        if language:
+            transcription_kwargs["language"] = language
+
         return DograhOpenAIRealtimeLLMService(
             api_key=api_key,
             settings=DograhOpenAIRealtimeLLMService.Settings(
@@ -1016,7 +1023,9 @@ def create_realtime_llm_service(user_config, audio_config: "AudioConfig"):
                 session_properties=SessionProperties(
                     audio=AudioConfiguration(
                         input=AudioInput(
-                            transcription=InputAudioTranscription(),
+                            transcription=InputAudioTranscription(
+                                **transcription_kwargs
+                            ),
                         ),
                         output=AudioOutput(
                             voice=voice or "alloy",


### PR DESCRIPTION
## Problem

The OpenAI realtime factory already reads `language` from the realtime config:

```python
language = getattr(realtime_config, "language", None)
```

…but then builds the transcription config **without it**:

```python
transcription=InputAudioTranscription(),
```

So the language is silently dropped and the model auto-detects on every utterance. On 8kHz telephony audio this misfires badly — in our tests a Brazilian-Portuguese speaker was transcribed as English, French and Chinese *within a single call*, which then corrupted downstream extraction.

This makes the OpenAI realtime provider the odd one out: every other STT branch in `create_stt_service` (Deepgram, Google, Cartesia, Dograh, Sarvam) already honors `language`, and `GoogleRealtimeLLMConfiguration` already exposes a `language` field for Gemini Live.

## Change

- Expose `language` on `OpenAIRealtimeLLMConfiguration` (optional, `default=None` → unchanged auto-detect behavior), with an `OPENAI_REALTIME_LANGUAGES` examples list.
- Forward it to `InputAudioTranscription(language=...)`, which already accepts the field.

Non-realtime providers and any config that doesn't set `language` are completely unaffected.

## Testing

Verified against the pipecat events lib that the session now carries the language:

```json
{"input": {"transcription": {"model": "gpt-realtime-whisper", "language": "pt"}}, "output": {"voice": "coral"}}
```

And end-to-end on live telephony calls (`gpt-realtime-2.1-mini`, `language: "pt"`): transcription stays in Portuguese across the whole call, where before it drifted between languages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional `language` support to OpenAI Realtime transcription to pin the input language and avoid auto-detect drift on telephony audio. Defaults to auto-detect when unset and aligns behavior with other STT providers.

- **New Features**
  - Added `language: str | None` to `OpenAIRealtimeLLMConfiguration` with example ISO 639-1 codes in `OPENAI_REALTIME_LANGUAGES`.
  - Plumbed `language` through to `InputAudioTranscription(language=...)` so sessions carry the pinned language.

<sup>Written for commit 550b1beaf78f03c7bb4eb065fb17b2b892bb9d74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds language pinning for OpenAI realtime input transcription. The main changes are:

- Adds an optional `language` field to `OpenAIRealtimeLLMConfiguration`.
- Adds example OpenAI realtime language codes while still allowing custom input.
- Passes the configured language into `InputAudioTranscription`.
- Keeps auto-detection behavior unchanged when `language` is unset.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to an optional config field and forwarding that value into the existing OpenAI realtime transcription settings. Existing configs keep the same behavior because `language` defaults to `None`.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the runtime contract validation proof and observed an exit code of 0 with serialized settings that show pt\_case.input\_transcription\_language == 'pt', pt\_case.output\_voice == 'coral', and no\_language\_case.input\_transcription\_language == null.
- The harness noted that a Python binary was unusable due to a broken symlink, so the final validation proceeded using python3.
- The final validation ran with python3 and used narrow stubs for unavailable external Pipecat/OpenAI service classes.
- Artifacts documenting the runtime proof and the validation settings were captured for review.

<a href="https://app.greptile.com/trex/runs/14881187/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/services/configuration/registry.py | Adds optional `language` metadata to `OpenAIRealtimeLLMConfiguration` with examples and custom input enabled; no issues found. |
| api/services/pipecat/service_factory.py | Forwards configured realtime language into OpenAI `InputAudioTranscription` while preserving auto-detect behavior when unset; no issues found. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Config as OpenAIRealtimeLLMConfiguration
participant Factory as create_realtime_llm_service
participant Session as SessionProperties
participant OpenAI as DograhOpenAIRealtimeLLMService

Config->>Factory: realtime.language optional value
Factory->>Factory: build transcription_kwargs when language is set
Factory->>Session: "InputAudioTranscription(language=...)"
Session->>OpenAI: audio input transcription settings
OpenAI->>OpenAI: use pinned language or auto-detect when unset
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Config as OpenAIRealtimeLLMConfiguration
participant Factory as create_realtime_llm_service
participant Session as SessionProperties
participant OpenAI as DograhOpenAIRealtimeLLMService

Config->>Factory: realtime.language optional value
Factory->>Factory: build transcription_kwargs when language is set
Factory->>Session: "InputAudioTranscription(language=...)"
Session->>OpenAI: audio input transcription settings
OpenAI->>OpenAI: use pinned language or auto-detect when unset
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(openai-realtime): allow pinning inp..."](https://github.com/dograh-hq/dograh/commit/550b1beaf78f03c7bb4eb065fb17b2b892bb9d74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45169192)</sub>

<!-- /greptile_comment -->