### PR TITLE
fix: add Transcription Turn Start for non external STTs

### DIFF
--- a/api/services/pipecat/audio_config.py
+++ b/api/services/pipecat/audio_config.py
@@ -52,16 +52,6 @@ class AudioConfig:
             )
             self.pipeline_sample_rate = 16000
 
-        # Log configuration for auditing
-        logger.info(
-            f"AudioConfig initialized: "
-            f"transport_in={self.transport_in_sample_rate}Hz, "
-            f"transport_out={self.transport_out_sample_rate}Hz, "
-            f"vad={self.vad_sample_rate}Hz, "
-            f"pipeline={self.pipeline_sample_rate}Hz, "
-            f"buffer={self.buffer_size_seconds}s"
-        )
-
     @property
     def buffer_size_bytes(self) -> int:
         """Calculate buffer size in bytes based on pipeline sample rate."""

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -95,6 +95,9 @@ from pipecat.turns.user_start import (
     MinWordsUserTurnStartStrategy,
     ProvisionalVADUserTurnStartStrategy,
 )
+from pipecat.turns.user_start.transcription_user_turn_start_strategy import (
+    TranscriptionUserTurnStartStrategy,
+)
 from pipecat.turns.user_start.vad_user_turn_start_strategy import (
     VADUserTurnStartStrategy,
 )
@@ -160,9 +163,10 @@ def _create_non_realtime_user_turn_start_strategies(
 
     if turn_start_strategy == "provisional_vad":
         return [
+            TranscriptionUserTurnStartStrategy(),
             ProvisionalVADUserTurnStartStrategy(
                 pause_secs=_resolve_provisional_vad_pause_secs(run_configs)
-            )
+            ),
         ]
 
     if uses_external_turns:
@@ -172,7 +176,7 @@ def _create_non_realtime_user_turn_start_strategies(
         # confirms a real turn.
         return [ExternalUserTurnStartStrategy(enable_interruptions=True)]
 
-    return [VADUserTurnStartStrategy()]
+    return [TranscriptionUserTurnStartStrategy(), VADUserTurnStartStrategy()]
 
 
 def _create_non_realtime_user_turn_stop_strategies(

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -227,7 +227,6 @@ def create_stt_service(
         # Other models than flux
         # Use language from user config, defaulting to "multi" for multilingual support
         language = getattr(user_config.stt, "language", None) or "multi"
-        logger.debug(f"Using DeepGram Model - {user_config.stt.model}")
         return DeepgramSTTService(
             api_key=user_config.stt.api_key,
             settings=DeepgramSTTSettings(

--- a/api/services/telephony/providers/cloudonix/provider.py
+++ b/api/services/telephony/providers/cloudonix/provider.py
@@ -1111,9 +1111,7 @@ class CloudonixProvider(TelephonyProvider):
         from_number = random.choice(self.from_numbers)
 
         backend_endpoint, _ = await get_backend_endpoints()
-        callback_url = (
-            f"{backend_endpoint}/api/v1/telephony/cloudonix/transfer-result/{transfer_id}"
-        )
+        callback_url = f"{backend_endpoint}/api/v1/telephony/cloudonix/transfer-result/{transfer_id}"
 
         endpoint = f"{self.base_url}/calls/{self.domain_id}/application"
         data: Dict[str, Any] = {
@@ -1126,9 +1124,7 @@ class CloudonixProvider(TelephonyProvider):
 
         data.update(kwargs)
         headers = self._get_auth_headers()
-        masked_destination = (
-            f"***{destination[-4:]}" if len(destination) > 4 else "***"
-        )
+        masked_destination = f"***{destination[-4:]}" if len(destination) > 4 else "***"
         logger.info(
             f"[Cloudonix Transfer] Dialing {masked_destination} into conference "
             f"{conference_name} (transfer_id={transfer_id})"

--- a/ui/src/app/workflow/[workflowId]/settings/page.tsx
+++ b/ui/src/app/workflow/[workflowId]/settings/page.tsx
@@ -647,6 +647,11 @@ function GeneralSection({
                         </Select>
                         <p className="text-xs text-muted-foreground">
                             {selectedTurnStartStrategy?.description}
+                            {turnStartStrategy === "provisional_vad" && (
+                                <span className="ml-2 inline-flex rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                                    Experimental
+                                </span>
+                            )}
                         </p>
                     </div>
                     {turnStartStrategy === "min_words" && (


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add transcription-based user turn start for non-external STTs to improve turn detection and interruption handling. Also marks Provisional VAD as experimental in settings.

- **Bug Fixes**
  - Add `TranscriptionUserTurnStartStrategy` to non-realtime pipelines that don’t use external turns, alongside `VADUserTurnStartStrategy`.
  - For `provisional_vad`, prepend `TranscriptionUserTurnStartStrategy` before `ProvisionalVADUserTurnStartStrategy` to kick off turns on transcription.
  - Show “Experimental” badge for `provisional_vad` in workflow settings.

- **Refactors**
  - Remove noisy init/debug logs from `AudioConfig` and Deepgram STT factory.
  - Minor formatting cleanup in Cloudonix provider.

<sup>Written for commit aad6be1e323263a8a5229f27e050b76dbb2aef97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates turn-start handling for non-realtime STT flows. The main changes are:

- Adds transcription-based turn starts alongside local VAD strategies.
- Keeps external-turn STT models on their existing external turn strategy.
- Labels the provisional VAD interruption strategy as experimental in workflow settings.
- Removes or reformats logging-only backend code.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The functional change is narrowly scoped to non-realtime turn-start strategy selection and keeps external-turn STT behavior unchanged. The other edits are UI-label, logging, or formatting-only changes. No correctness or security issues were found in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The baseline turn-start strategy behavior showed VADUserTurnStartStrategy for standard STT and ProvisionalVADUserTurnStartStrategy for provisional VAD.
- The updated code path returned the expected class-name lists and the harness assertions passed.
- A targeted pytest run was attempted but was blocked by a ModuleNotFoundError: No module named 'dotenv'.
- A generated validation harness (trex-artifacts/turn\_start\_strategy\_harness.py) was created and used for the runtime proof.

<a href="https://app.greptile.com/trex/runs/14947137/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/services/pipecat/audio_config.py | Removes initialization logging from `AudioConfig` without changing audio configuration behavior. |
| api/services/pipecat/run_pipeline.py | Adds `TranscriptionUserTurnStartStrategy` alongside local VAD-based start strategies for non-realtime, non-external STT paths. |
| api/services/pipecat/service_factory.py | Removes a redundant Deepgram debug log while preserving STT service construction. |
| api/services/telephony/providers/cloudonix/provider.py | Applies formatting-only line wrapping changes in Cloudonix transfer dialing code. |
| ui/src/app/workflow/[workflowId]/settings/page.tsx | Adds an `Experimental` badge next to the provisional VAD interruption strategy description. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Workflow as Workflow settings
participant Pipeline as run_pipeline.py
participant STT as STT service
participant Aggregator as LLM user aggregator

Workflow->>Pipeline: run_configs.turn_start_strategy
Pipeline->>STT: determine stt_uses_external_turns(user_config)
alt Non-realtime external-turn STT
    Pipeline->>Aggregator: "ExternalUserTurnStartStrategy(enable_interruptions=True)"
else Non-realtime provisional_vad
    Pipeline->>Aggregator: TranscriptionUserTurnStartStrategy()
    Pipeline->>Aggregator: ProvisionalVADUserTurnStartStrategy(pause_secs)
else Non-realtime default local STT
    Pipeline->>Aggregator: TranscriptionUserTurnStartStrategy()
    Pipeline->>Aggregator: VADUserTurnStartStrategy()
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Workflow as Workflow settings
participant Pipeline as run_pipeline.py
participant STT as STT service
participant Aggregator as LLM user aggregator

Workflow->>Pipeline: run_configs.turn_start_strategy
Pipeline->>STT: determine stt_uses_external_turns(user_config)
alt Non-realtime external-turn STT
    Pipeline->>Aggregator: "ExternalUserTurnStartStrategy(enable_interruptions=True)"
else Non-realtime provisional_vad
    Pipeline->>Aggregator: TranscriptionUserTurnStartStrategy()
    Pipeline->>Aggregator: ProvisionalVADUserTurnStartStrategy(pause_secs)
else Non-realtime default local STT
    Pipeline->>Aggregator: TranscriptionUserTurnStartStrategy()
    Pipeline->>Aggregator: VADUserTurnStartStrategy()
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: add Transcription Turn Start for no..."](https://github.com/dograh-hq/dograh/commit/aad6be1e323263a8a5229f27e050b76dbb2aef97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45312679)</sub>

<!-- /greptile_comment -->