### PR TITLE
fix: handle Ultravox playback_clear_buffer in realtime override

### DIFF
--- a/api/services/pipecat/realtime/ultravox_realtime.py
+++ b/api/services/pipecat/realtime/ultravox_realtime.py
@@ -351,6 +351,11 @@ class DograhUltravoxRealtimeLLMService(UltravoxRealtimeLLMService):
                         case "state":
                             if self._bot_responding and data.get("state") != "speaking":
                                 await self._handle_response_end()
+                        case "playback_clear_buffer":
+                            # Ultravox's server-side barge-in signal. The base class
+                            # broadcasts an interruption here so buffered bot audio is
+                            # dropped before the following state message ends the response.
+                            await self.broadcast_interruption()
                         case "client_tool_invocation":
                             await self._handle_tool_invocation(
                                 data.get("toolName"),

--- a/api/tests/test_ultravox_realtime_wrapper.py
+++ b/api/tests/test_ultravox_realtime_wrapper.py
@@ -407,6 +407,17 @@ async def test_receive_messages_reports_unexpected_websocket_close():
     service.push_error.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_receive_messages_broadcasts_interruption_on_playback_clear_buffer():
+    service = _make_service()
+    service.broadcast_interruption = AsyncMock()
+    service._socket = _MessageSocket(['{"type":"playback_clear_buffer"}'])
+
+    await service._receive_messages()
+
+    service.broadcast_interruption.assert_awaited_once()
+
+
 def test_factory_creates_dograh_ultravox_realtime_service():
     effective_config = EffectiveAIModelConfiguration(
         is_realtime=True,


### PR DESCRIPTION
Dograh's 'DograhUltravoxRealtimeLLMService._receive_messages()' overrides the pinned pipecat 'UltravoxRealtimeLLMService._receive_messages()' dispatch, but the override does not handle Ultravox' playback_clear_buffer websocket message. The pinned base class handles that message by calling broadcast_interruption() so buffered output audio is dropped. The interruption is recorded before the following message ends the response.

So... a server-side barge-in is silently ignored by the Dograh wrapper: no 'InterruptionFrame' is broadcast and stale bot audio can keep draining.

Bottom Line: This restores the base-class handling in the override and adds a regression test.

Verification: I ran an in-container async check against the Dograh API image with the patched file mounted: a single {"type":"playback_clear_buffer"} websocket message produced exactly one broadcast_interruption() call.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing handling of Ultravox’s playback_clear_buffer message in the Dograh realtime override so server-side barge-in interrupts correctly and drops buffered bot audio.

- **Bug Fixes**
  - Broadcast an interruption on playback_clear_buffer, matching the base class behavior.
  - Add a regression test that asserts one interruption is broadcast for a single playback_clear_buffer message.

<sup>Written for commit 39ece0c8ca3943eb6ce9e7ffde15d57a17a6b62e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores Ultravox server-side interruption handling in Dograh's realtime override. The main changes are:

- Dispatch `playback_clear_buffer` messages to `broadcast_interruption()`.
- Add an async test covering the new message branch.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Ultravox playback clear-buffer harness was generated to load the repository source and assert exact await counts.
- The predecessor implementation consumed one message and recorded an interruption await count of 0.
- The patched implementation consumed the same single message and recorded an interruption await count of 1 with exit code 0.
- The after log initially showed a ModuleNotFoundError: dotenv blocker before the harness proof established successful behavior.

<a href="https://app.greptile.com/trex/runs/15317988/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/services/pipecat/realtime/ultravox_realtime.py | Adds dispatch for `playback_clear_buffer` so server-side barge-in clears buffered output through the existing interruption path. |
| api/tests/test_ultravox_realtime_wrapper.py | Adds a focused async test verifying one interruption broadcast for the new message type. |

<sub>Reviews (1): Last reviewed commit: ["fix: handle Ultravox playback\_clear\_buff..."](https://github.com/dograh-hq/dograh/commit/39ece0c8ca3943eb6ce9e7ffde15d57a17a6b62e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46106339)</sub>

<!-- /greptile_comment -->