### PR TITLE
fix: fix crypto.randomUUID crash

### DIFF
--- a/ui/src/app/tools/[toolUuid]/components/TransferCallToolConfig.tsx
+++ b/ui/src/app/tools/[toolUuid]/components/TransferCallToolConfig.tsx
@@ -21,6 +21,7 @@ import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { createUuid } from "@/lib/uuid";
 
 import {
     type ContextDestinationRouteRow,
@@ -397,7 +398,7 @@ export function TransferCallToolConfig({
                                             onClick={() => onContextDestinationRoutesChange([
                                                 ...contextDestinationRoutes,
                                                 {
-                                                    id: crypto.randomUUID(),
+                                                    id: createUuid(),
                                                     context_value: "",
                                                     destination: "",
                                                 },

--- a/ui/src/app/tools/[toolUuid]/page.tsx
+++ b/ui/src/app/tools/[toolUuid]/page.tsx
@@ -43,6 +43,7 @@ import { TOOL_DOCUMENTATION_URLS } from "@/constants/documentation";
 import { useOrgConfig } from "@/context/OrgConfigContext";
 import { detailFromError } from "@/lib/apiError";
 import { useAuth } from "@/lib/auth";
+import { createUuid } from "@/lib/uuid";
 
 import {
     type ContextDestinationRouteRow,
@@ -248,7 +249,7 @@ export default function ToolDetailPage() {
                 setTransferContextDestinationRoutes(
                     (config.context_mapping?.routes || []).map((route) => ({
                         ...route,
-                        id: crypto.randomUUID(),
+                        id: createUuid(),
                     }))
                 );
                 setTransferFallbackDestination(

--- a/ui/src/components/flow/nodes/GenericNode.tsx
+++ b/ui/src/components/flow/nodes/GenericNode.tsx
@@ -15,6 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { NODE_DOCUMENTATION_URLS } from "@/constants/documentation";
 import { useAppConfig } from "@/context/AppConfigContext";
 import { cn } from "@/lib/utils";
+import { createUuid } from "@/lib/uuid";
 import { resolveWebhookBaseUrl } from "@/lib/webhookUrl";
 
 import { NodeContent } from "./common/NodeContent";
@@ -517,7 +518,7 @@ export const GenericNode = memo(({ data, selected, id, type }: GenericNodeProps)
     useEffect(() => {
         if (type !== "trigger") return;
         if (data.trigger_path) return;
-        const newPath = crypto.randomUUID();
+        const newPath = createUuid();
         handleSaveNodeData({ ...data, trigger_path: newPath });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [type]);

--- a/ui/src/lib/uuid.test.ts
+++ b/ui/src/lib/uuid.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createUuid } from "./uuid";
+
+describe("createUuid", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("uses crypto.randomUUID when it is available", () => {
+        const randomUUID = vi.fn(() => "27f3a42d-0eb3-43b1-a539-d4d09dd9065e");
+        vi.stubGlobal("crypto", { randomUUID });
+
+        expect(createUuid()).toBe("27f3a42d-0eb3-43b1-a539-d4d09dd9065e");
+        expect(randomUUID).toHaveBeenCalledOnce();
+    });
+
+    it("creates a version 4 UUID when crypto.randomUUID is unavailable", () => {
+        const getRandomValues = vi.fn((bytes: Uint8Array) => {
+            bytes.fill(0);
+            return bytes;
+        });
+        vi.stubGlobal("crypto", { getRandomValues });
+
+        expect(createUuid()).toBe("00000000-0000-4000-8000-000000000000");
+        expect(getRandomValues).toHaveBeenCalledOnce();
+    });
+});

--- a/ui/src/lib/uuid.ts
+++ b/ui/src/lib/uuid.ts
@@ -1,0 +1,26 @@
+export function createUuid(): string {
+    const webCrypto = globalThis.crypto;
+
+    if (typeof webCrypto?.randomUUID === "function") {
+        return webCrypto.randomUUID();
+    }
+
+    if (typeof webCrypto?.getRandomValues !== "function") {
+        throw new Error("Secure random number generation is unavailable");
+    }
+
+    const bytes = webCrypto.getRandomValues(new Uint8Array(16));
+
+    // Mark the generated value as an RFC 4122 version 4 UUID.
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+    return [
+        hex.slice(0, 4).join(""),
+        hex.slice(4, 6).join(""),
+        hex.slice(6, 8).join(""),
+        hex.slice(8, 10).join(""),
+        hex.slice(10, 16).join(""),
+    ].join("-");
+}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents crashes in browsers/environments where `crypto.randomUUID` is unavailable by adding a safe UUID helper and updating call sites.

- **Bug Fixes**
  - Added `createUuid` that prefers `crypto.randomUUID` and falls back to RFC 4122 v4 via `crypto.getRandomValues`.
  - Replaced direct `crypto.randomUUID()` calls in TransferCallToolConfig, ToolDetailPage, and GenericNode to use `createUuid`.
  - Added `uuid.test.ts` to cover both code paths.

<sup>Written for commit a9117f4706313114b8b22e4e287a3eaf0adc8530. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a compatible UUID generator for UI runtimes without `crypto.randomUUID`. The main changes are:

- Adds a secure `getRandomValues` fallback for version 4 UUIDs.
- Uses the helper for transfer-route IDs and workflow trigger paths.
- Tests the native and fallback generation paths.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The direct crypto.randomUUID() call failed under the simulated browser capability set, exiting with a TypeError.
- The createUuid() function worked under the same capability set, exiting with code 0 and producing a valid version-4 RFC UUID.
- The Vitest suite for the crypto capability paths ran and completed with exit code 0, showing one test for each capability path.

<a href="https://app.greptile.com/trex/runs/15533741/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ui/src/lib/uuid.ts | Adds native UUID feature detection and a secure RFC 4122 version 4 fallback. |
| ui/src/lib/uuid.test.ts | Tests native UUID delegation and deterministic fallback formatting. |
| ui/src/app/tools/[toolUuid]/components/TransferCallToolConfig.tsx | Uses the shared helper for new transfer mapping row IDs. |
| ui/src/app/tools/[toolUuid]/page.tsx | Uses the shared helper for client-side IDs assigned to loaded transfer routes. |
| ui/src/components/flow/nodes/GenericNode.tsx | Uses the shared helper when initializing trigger paths. |

<sub>Reviews (1): Last reviewed commit: ["fix: fix crypto.randomUUID crash"](https://github.com/dograh-hq/dograh/commit/a9117f4706313114b8b22e4e287a3eaf0adc8530) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46572673)</sub>

<!-- /greptile_comment -->