### PR TITLE
fix: cast usage run filter JSON values to Float instead of Integer

### DIFF
--- a/api/db/filters.py
+++ b/api/db/filters.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import Float, Integer, Text, and_, cast, func
+from sqlalchemy import Float, Text, and_, cast, func
 from sqlalchemy.dialects.postgresql import JSONB
 
 from api.db.models import WorkflowRunModel
@@ -211,17 +211,16 @@ def apply_workflow_run_filters(
                 if field == "usage_info.call_duration_seconds":
                     # Use ->> operator for compatibility with all PostgreSQL versions
                     # (subscript [] only works in PostgreSQL 14+)
+                    # Cast to Float, not Integer: some rows store the value as
+                    # a JSON float (e.g. 0.0), and Postgres can't cast the text
+                    # '0.0' to integer.
                     duration_text = cast(WorkflowRunModel.usage_info, JSONB).op("->>")(
                         "call_duration_seconds"
                     )
                     if min_val is not None:
-                        filter_conditions.append(
-                            cast(duration_text, Integer) >= min_val
-                        )
+                        filter_conditions.append(cast(duration_text, Float) >= min_val)
                     if max_val is not None:
-                        filter_conditions.append(
-                            cast(duration_text, Integer) <= max_val
-                        )
+                        filter_conditions.append(cast(duration_text, Float) <= max_val)
 
                 elif field == "cost_info.total_cost_usd":
                     # Use ->> operator for compatibility with all PostgreSQL versions
@@ -229,9 +228,9 @@ def apply_workflow_run_filters(
                         "total_cost_usd"
                     )
                     if min_val is not None:
-                        filter_conditions.append(cast(cost_text, Integer) >= min_val)
+                        filter_conditions.append(cast(cost_text, Float) >= min_val)
                     if max_val is not None:
-                        filter_conditions.append(cast(cost_text, Integer) <= max_val)
+                        filter_conditions.append(cast(cost_text, Float) <= max_val)
 
     if filter_conditions:
         base_query = base_query.where(and_(*filter_conditions))

--- a/api/services/pipecat/pipeline_metrics_aggregator.py
+++ b/api/services/pipecat/pipeline_metrics_aggregator.py
@@ -113,10 +113,10 @@ class PipelineMetricsAggregator(FrameProcessor):
         """Get the aggregated STT usage metrics grouped by processor|||model."""
         return self._stt_usage_metrics
 
-    def get_call_duration(self) -> float:
+    def get_call_duration(self) -> int:
         """Get call duration"""
         if self._start_time is None:
-            return 0.0
+            return 0
 
         if self._stop_time is None:
             call_duration = time.time() - self._start_time


### PR DESCRIPTION
The duration and tokenUsage numberRange filters cast the JSON text value to INTEGER, but some rows store call_duration_seconds as a JSON float (0.0, written by get_call_duration when the pipeline never recorded a start time). Postgres cannot cast the text '0.0' to integer, so any duration filter on /organizations/usage/runs failed with InvalidTextRepresentationError. Cast to FLOAT instead, matching the duration sort clause, and make get_call_duration return an int so new rows are written as integers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken number-range filters on /organizations/usage/runs by casting JSON values to Float instead of Integer. Prevents InvalidTextRepresentationError when fields contain values like "0.0" and aligns filtering with sorting.

- **Bug Fixes**
  - Cast `usage_info.call_duration_seconds` and `cost_info.total_cost_usd` filter values to Float to handle JSON strings like "0.0".
  - Update `get_call_duration` to return an int (0 when no start time) so new rows store integer durations.

<sup>Written for commit 9e91449528795047a6622270686b11cdfdafa624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes numeric filtering for workflow-run usage data. The main changes are:

- Cast duration and total-cost JSON values to `FLOAT` in range filters.
- Return an integer zero when pipeline timing never starts.
- Align `get_call_duration()` with its integer values.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the baseline usage-filter-duration test using the regression harness and confirmed the baseline run observed integer casts and a 0.0 float.
- Ran the post-change usage-filter-duration test with the regression harness and confirmed the new behavior reported float casts and integer 0, with all assertions passing.
- Reviewed the regression harness script usage-filter-duration-regression.py to verify it drives both baseline and post-change runs.
- Attempted a focused usage-response pytest run and noted an environment blocker described in the focused-usage-response-pytest log.
- Performed a changed-file diff check and confirmed it completed successfully.

<a href="https://app.greptile.com/trex/runs/15562237/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/db/filters.py | Uses floating-point casts for duration and cost range comparisons so decimal JSON values remain queryable. |
| api/services/pipecat/pipeline_metrics_aggregator.py | Makes the no-start duration value and return annotation consistent with the function's existing rounded integer results. |

<sub>Reviews (1): Last reviewed commit: ["fix: cast usage run filter JSON values t..."](https://github.com/dograh-hq/dograh/commit/9e91449528795047a6622270686b11cdfdafa624) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46633416)</sub>

<!-- /greptile_comment -->