### PR TITLE
fix: use clipboard fallback across UI

### DIFF
--- a/ui/src/app/telephony-configurations/[configId]/page.tsx
+++ b/ui/src/app/telephony-configurations/[configId]/page.tsx
@@ -60,6 +60,7 @@ import { useOrgConfig } from "@/context/OrgConfigContext";
 import { useOrganizationTimezone } from "@/hooks/useOrganizationTimezone";
 import { detailFromError } from "@/lib/apiError";
 import { useAuth } from "@/lib/auth";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import { formatDateTime } from "@/lib/dateTime";
 import { resolveWebhookBaseUrl } from "@/lib/webhookUrl";
 
@@ -228,8 +229,7 @@ export default function TelephonyConfigurationDetailPage() {
             <button
               type="button"
               onClick={() => {
-                navigator.clipboard
-                  .writeText(String(config.id))
+                copyTextToClipboard(String(config.id))
                   .then(() => toast.success("Configuration ID copied"))
                   .catch(() => toast.error("Failed to copy ID"));
               }}
@@ -270,8 +270,7 @@ export default function TelephonyConfigurationDetailPage() {
               type="button"
               onClick={() => {
                 const url = inboundWebhookUrl;
-                navigator.clipboard
-                  .writeText(url)
+                copyTextToClipboard(url)
                   .then(() => toast.success("Inbound webhook URL copied"))
                   .catch(() => toast.error("Failed to copy URL"));
               }}

--- a/ui/src/app/telephony-configurations/page.tsx
+++ b/ui/src/app/telephony-configurations/page.tsx
@@ -48,6 +48,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useTelephonyConfigWarnings } from "@/context/TelephonyConfigWarningsContext";
 import { detailFromError } from "@/lib/apiError";
 import { useAuth } from "@/lib/auth";
+import { copyTextToClipboard } from "@/lib/clipboard";
 
 export default function TelephonyConfigurationsPage() {
   const { user, getAccessToken, loading: authLoading } = useAuth();
@@ -263,8 +264,7 @@ export default function TelephonyConfigurationsPage() {
                         onClick={(e) => {
                           e.preventDefault();
                           e.stopPropagation();
-                          navigator.clipboard
-                            .writeText(String(item.id))
+                          copyTextToClipboard(String(item.id))
                             .then(() => toast.success("Configuration ID copied"))
                             .catch(() => toast.error("Failed to copy ID"));
                         }}

--- a/ui/src/app/workflow/[workflowId]/components/EmbedDialog.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/EmbedDialog.tsx
@@ -1,5 +1,6 @@
 import { Check, Copy, ExternalLink, Loader2, Mic, Plus, Rocket, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
 
 import {
     createOrUpdateEmbedTokenApiV1WorkflowWorkflowIdEmbedTokenPost,
@@ -26,6 +27,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { WIDGET_MODE_DOCUMENTATION_URLS } from "@/constants/documentation";
+import { copyTextToClipboard } from "@/lib/clipboard";
 
 interface EmbedDialogProps {
     open: boolean;
@@ -150,10 +152,14 @@ export function EmbedDialog({
         }
     };
 
-    const copyToClipboard = (text: string) => {
-        navigator.clipboard.writeText(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+    const copyToClipboard = async (text: string) => {
+        try {
+            await copyTextToClipboard(text);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            toast.error("Failed to copy embed code");
+        }
     };
 
     const addDomain = () => {

--- a/ui/src/app/workflow/[workflowId]/components/WorkflowEditorHeader.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/WorkflowEditorHeader.tsx
@@ -27,6 +27,7 @@ import {
     PopoverTrigger,
 } from "@/components/ui/popover";
 import { useSidebar } from "@/components/ui/sidebar";
+import { copyTextToClipboard } from "@/lib/clipboard";
 
 interface WorkflowEditorHeaderProps {
     workflowName: string;
@@ -143,7 +144,7 @@ export const WorkflowEditorHeader = ({
             return;
         }
         try {
-            await navigator.clipboard.writeText(workflowUuid);
+            await copyTextToClipboard(workflowUuid);
             toast.success("Agent UUID copied");
         } catch {
             toast.error("Failed to copy Agent UUID");

--- a/ui/src/app/workflow/[workflowId]/run/[runId]/page.tsx
+++ b/ui/src/app/workflow/[workflowId]/run/[runId]/page.tsx
@@ -18,6 +18,7 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import posthog from 'posthog-js';
 import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 import WorkflowLayout from '@/app/workflow/WorkflowLayout';
 import {
@@ -34,6 +35,7 @@ import { PostHogEvent } from '@/constants/posthog-events';
 import { WORKFLOW_RUN_MODES } from '@/constants/workflowRunModes';
 import { useOrganizationTimezone } from '@/hooks/useOrganizationTimezone';
 import { useAuth } from '@/lib/auth';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { formatDateTime } from '@/lib/dateTime';
 import { downloadFile, getSignedUrl } from '@/lib/files';
 import { cn } from '@/lib/utils';
@@ -98,9 +100,13 @@ function CopyDebugIdButton({ label, value }: { label: string; value: string }) {
     const [copied, setCopied] = useState(false);
 
     const handleCopy = async () => {
-        await navigator.clipboard.writeText(value);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        try {
+            await copyTextToClipboard(value);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            toast.error(`Failed to copy ${label}`);
+        }
     };
 
     return (
@@ -560,11 +566,15 @@ function RunMetricsSection({
 function ContextDisplay({ title, context }: { title: string; context: Record<string, string | number | boolean | object> | null }) {
     const [copied, setCopied] = useState(false);
 
-    const handleCopy = () => {
+    const handleCopy = async () => {
         if (!context) return;
-        navigator.clipboard.writeText(JSON.stringify(context, null, 2));
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        try {
+            await copyTextToClipboard(JSON.stringify(context, null, 2));
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            toast.error('Failed to copy context');
+        }
     };
 
     if (!context || Object.keys(context).length === 0) {

--- a/ui/src/app/workflow/[workflowId]/settings/page.tsx
+++ b/ui/src/app/workflow/[workflowId]/settings/page.tsx
@@ -43,6 +43,7 @@ import { UnsavedChangesProvider, useUnsavedChanges, useUnsavedChangesContext } f
 import { useAudioPlayback } from "@/hooks/useAudioPlayback";
 import { detailFromError } from "@/lib/apiError";
 import { useAuth } from "@/lib/auth";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import logger from "@/lib/logger";
 import { fetchModelConfigurationPricing } from "@/lib/modelConfigurationPricing";
 import {
@@ -1250,7 +1251,7 @@ function VoicemailSection({
 function AgentUuidSection({ workflowUuid }: { workflowUuid: string }) {
     const handleCopy = async () => {
         try {
-            await navigator.clipboard.writeText(workflowUuid);
+            await copyTextToClipboard(workflowUuid);
             toast.success("Agent UUID copied");
         } catch {
             toast.error("Failed to copy Agent UUID");

--- a/ui/src/components/MCPSection.tsx
+++ b/ui/src/components/MCPSection.tsx
@@ -3,11 +3,13 @@
 import { Check, Copy } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { useAppConfig } from "@/context/AppConfigContext";
 import { resolveBrowserBackendUrl } from "@/lib/apiClient";
+import { copyTextToClipboard } from "@/lib/clipboard";
 
 const MCP_PATH = "/api/v1/mcp/";
 
@@ -35,12 +37,16 @@ export function MCPSection() {
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
   const handleCopy = async (value: string, key: string) => {
-    await navigator.clipboard.writeText(value);
-    setCopiedKey(key);
-    setTimeout(
-      () => setCopiedKey((current) => (current === key ? null : current)),
-      2000,
-    );
+    try {
+      await copyTextToClipboard(value);
+      setCopiedKey(key);
+      setTimeout(
+        () => setCopiedKey((current) => (current === key ? null : current)),
+        2000,
+      );
+    } catch {
+      toast.error("Failed to copy MCP endpoint");
+    }
   };
 
   return (

--- a/ui/src/components/flow/nodes/GenericNode.tsx
+++ b/ui/src/components/flow/nodes/GenericNode.tsx
@@ -3,6 +3,7 @@ import * as LucideIcons from "lucide-react";
 import { Check, Circle, Copy, Edit, type LucideIcon, Trash2Icon } from "lucide-react";
 import Link from "next/link";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 
 import { useWorkflow } from "@/app/workflow/[workflowId]/contexts/WorkflowContext";
 import type { NodeSpec } from "@/client/types.gen";
@@ -14,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { NODE_DOCUMENTATION_URLS } from "@/constants/documentation";
 import { useAppConfig } from "@/context/AppConfigContext";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import { cn } from "@/lib/utils";
 import { createUuid } from "@/lib/uuid";
 import { resolveWebhookBaseUrl } from "@/lib/webhookUrl";
@@ -350,9 +352,13 @@ function ClickToCopy({
     const [copied, setCopied] = useState(false);
     const onCopy = async () => {
         if (!value) return;
-        await navigator.clipboard.writeText(value);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        try {
+            await copyTextToClipboard(value);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            toast.error("Failed to copy value");
+        }
     };
     return (
         <button
@@ -509,9 +515,13 @@ export const GenericNode = memo(({ data, selected, id, type }: GenericNodeProps)
     const handleCopyTrigger = useCallback(async () => {
         const endpoint = buildTriggerEndpoints(data.trigger_path, webhookBaseUrl).production;
         if (!endpoint) return;
-        await navigator.clipboard.writeText(endpoint);
-        setTriggerCopied(true);
-        setTimeout(() => setTriggerCopied(false), 2000);
+        try {
+            await copyTextToClipboard(endpoint);
+            setTriggerCopied(true);
+            setTimeout(() => setTriggerCopied(false), 2000);
+        } catch {
+            toast.error("Failed to copy trigger URL");
+        }
     }, [data.trigger_path, webhookBaseUrl]);
 
     // For trigger nodes without a path yet, generate one and persist.

--- a/ui/src/components/telephony/ConfigFormDialog.tsx
+++ b/ui/src/components/telephony/ConfigFormDialog.tsx
@@ -38,6 +38,7 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { detailFromError } from "@/lib/apiError";
 import { useAuth } from "@/lib/auth";
+import { copyTextToClipboard } from "@/lib/clipboard";
 
 interface ConfigFormDialogProps {
   open: boolean;
@@ -236,8 +237,7 @@ export function ConfigFormDialog({
               <button
                 type="button"
                 onClick={() => {
-                  navigator.clipboard
-                    .writeText(String(existing.id))
+                  copyTextToClipboard(String(existing.id))
                     .then(() => toast.success("Configuration ID copied"))
                     .catch(() => toast.error("Failed to copy ID"));
                 }}

--- a/ui/src/components/ui/json-editor.tsx
+++ b/ui/src/components/ui/json-editor.tsx
@@ -1,9 +1,11 @@
 import { AlertCircle, Check, Copy } from "lucide-react";
 import { useCallback, useState } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { copyTextToClipboard } from "@/lib/clipboard";
 
 interface JsonEditorProps {
     value: string;
@@ -113,9 +115,13 @@ export function JsonEditor({
     const [copied, setCopied] = useState(false);
 
     const handleCopy = useCallback(async () => {
-        await navigator.clipboard.writeText(value);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        try {
+            await copyTextToClipboard(value);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            toast.error("Failed to copy JSON");
+        }
     }, [value]);
 
     return (


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use `copyTextToClipboard` across the app to provide a reliable clipboard fallback. Fixes copy actions that failed on HTTP pages, older browsers, or when permissions are blocked.

- **Bug Fixes**
  - Replaced all `navigator.clipboard.writeText` calls with `copyTextToClipboard` across telephony pages, workflow editor/run, embed dialog, JSON editor, MCP section, and flow nodes.
  - Added consistent error toasts on failure while keeping the existing “copied” success feedback.

<sup>Written for commit 9d32842913b5845ccf0e35a6327453afb0445234. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces direct Clipboard API calls across telephony, workflow, MCP, node, and JSON-editor interfaces with the shared fallback helper, while adding consistent copy-failure feedback.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The clipboard substitutions preserve existing contracts while improving fallback and error handling. The shared helper returns the expected promise, supports both the Clipboard API and a DOM fallback, and all changed call sites execute in compatible client-side contexts with a globally mounted toaster.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the proof body and confirmed that the paired videos and poster frames depict the same MCP copy interaction before and after the change.
- Compared browser-state logs and observed clipboardType: undefined with a checkVisible transition from false to true across the before and after states.
- Noted that the before-change log shows Cannot read properties of undefined (reading 'writeText'), while the after-change log no longer reproduces that error.
- Verified that backend 502 messages in runtime logs are unrelated to the client interaction under test.
- Compiled and linked the evidence artifacts (videos, images, and logs) for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/15854915/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/app/telephony-configurations/[configId]/page.tsx | Uses the shared clipboard helper for configuration IDs and inbound webhook URLs without changing surrounding behavior. |
| ui/src/app/telephony-configurations/page.tsx | Routes configuration-ID copying through the fallback-capable helper. |
| ui/src/app/workflow/[workflowId]/components/EmbedDialog.tsx | Awaits clipboard completion before showing copied state and reports failures through the global toaster. |
| ui/src/app/workflow/[workflowId]/components/WorkflowEditorHeader.tsx | Uses the shared helper for agent UUID copying while preserving existing success and failure feedback. |
| ui/src/app/workflow/[workflowId]/run/[runId]/page.tsx | Adds fallback copying and explicit failure feedback for debug identifiers and serialized run context. |
| ui/src/app/workflow/[workflowId]/settings/page.tsx | Uses the shared clipboard helper for the agent UUID in workflow settings. |
| ui/src/components/MCPSection.tsx | Adds fallback-aware MCP endpoint copying and visible failure feedback. |
| ui/src/components/flow/nodes/GenericNode.tsx | Uses the shared helper for node values and trigger URLs, updating copied state only after success. |
| ui/src/components/telephony/ConfigFormDialog.tsx | Routes existing telephony configuration-ID copying through the shared helper. |
| ui/src/components/ui/json-editor.tsx | Adds fallback-aware JSON copying with explicit error feedback. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use clipboard fallback across UI"](https://github.com/dograh-hq/dograh/commit/9d32842913b5845ccf0e35a6327453afb0445234) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47218462)</sub>

<!-- /greptile_comment -->