### PR TITLE
fix(workflow): reject duplicate tool function names

### DIFF
--- a/api/mcp_server/tools/create_workflow.py
+++ b/api/mcp_server/tools/create_workflow.py
@@ -8,7 +8,7 @@ is no prior published version to protect, so we skip the draft step.
 Execution flow mirrors `save_workflow`:
     1. Parse via the Node TS validator — AST-only, never executes the code.
     2. Pydantic validation via `ReactFlowDTO.model_validate`.
-    3. Graph validation via `WorkflowGraph`.
+    3. Graph and resolved custom-tool name validation.
     4. Persist via `db_client.create_workflow` — workflow row + v1
        published definition in a single transaction.
 
@@ -34,6 +34,9 @@ from api.mcp_server.ts_bridge import TsBridgeError, parse_code
 from api.services.posthog_client import capture_event
 from api.services.workflow.dto import ReactFlowDTO
 from api.services.workflow.layout import reconcile_positions
+from api.services.workflow.tool_name_validation import (
+    validate_workflow_tool_name_collisions,
+)
 from api.services.workflow.trigger_paths import (
     extract_trigger_paths,
     validate_trigger_paths,
@@ -137,6 +140,17 @@ async def create_workflow(code: str) -> dict[str, Any]:
         WorkflowGraph(dto)
     except (ValueError, Exception) as e:  # WorkflowGraph raises ValueError
         return _error_result("graph_validation", str(e))
+
+    tool_name_errors = await validate_workflow_tool_name_collisions(
+        payload,
+        user.selected_organization_id,
+    )
+    if tool_name_errors:
+        return _error_result(
+            "graph_validation",
+            "\n".join(error["message"] for error in tool_name_errors),
+            errors=tool_name_errors,
+        )
 
     # 4. Reject upfront if any trigger path collides with another workflow's
     # trigger in this org so we don't leave an orphan workflow record.

--- a/api/mcp_server/tools/save_workflow.py
+++ b/api/mcp_server/tools/save_workflow.py
@@ -6,7 +6,7 @@ Execution flow:
     2. Pydantic validation via `ReactFlowDTO.model_validate` (defence in
        depth; the parser is already spec-driven, but the DTO layer is the
        authoritative wire-format gate).
-    3. Graph validation via `WorkflowGraph`.
+    3. Graph and resolved custom-tool name validation.
     4. Save as a new draft via `db_client.save_workflow_draft` — the
        published version stays intact, so edits are rollback-safe.
 
@@ -35,6 +35,9 @@ from api.mcp_server.tracing import traced_tool
 from api.mcp_server.ts_bridge import TsBridgeError, parse_code
 from api.services.workflow.dto import ReactFlowDTO
 from api.services.workflow.layout import reconcile_positions
+from api.services.workflow.tool_name_validation import (
+    validate_workflow_tool_name_collisions,
+)
 from api.services.workflow.trigger_paths import validate_trigger_paths
 from api.services.workflow.workflow_graph import WorkflowGraph
 
@@ -140,6 +143,17 @@ async def save_workflow(workflow_id: int, code: str) -> dict[str, Any]:
         WorkflowGraph(dto)
     except (ValueError, Exception) as e:  # WorkflowGraph raises ValueError
         return _error_result("graph_validation", str(e))
+
+    tool_name_errors = await validate_workflow_tool_name_collisions(
+        payload,
+        user.selected_organization_id,
+    )
+    if tool_name_errors:
+        return _error_result(
+            "graph_validation",
+            "\n".join(error["message"] for error in tool_name_errors),
+            errors=tool_name_errors,
+        )
 
     # 4a. If the `new Workflow({ name })` in the edited source differs from
     # the stored name, rename the workflow. Name is a workflow-level field

--- a/api/routes/workflow.py
+++ b/api/routes/workflow.py
@@ -57,6 +57,9 @@ from api.services.workflow.run_usage_response import (
     format_public_cost_info,
     format_public_usage_info,
 )
+from api.services.workflow.tool_name_validation import (
+    validate_workflow_tool_name_collisions,
+)
 from api.services.workflow.trigger_paths import (
     TriggerPathIssue,
     ensure_trigger_paths,
@@ -68,6 +71,7 @@ from api.services.workflow.trigger_paths import (
 from api.services.workflow.workflow_graph import (
     WorkflowGraph,
     validate_node_instance_constraints,
+    validate_unique_transition_tool_names,
 )
 from api.utils.artifacts import artifact_url
 from api.utils.recording_artifacts import (
@@ -129,9 +133,10 @@ def _trigger_path_validation_http_exception(
 
 async def _validate_workflow_definition(
     workflow_definition: Optional[dict],
+    organization_id: int,
     exclude_workflow_id: Optional[int] = None,
 ) -> list[WorkflowError]:
-    """Run DTO + graph + trigger-conflict checks on a workflow definition.
+    """Run DTO, graph, tool-name, and trigger checks on a workflow definition.
 
     Returns the list of errors (empty if the definition is valid). This is
     the single source of truth for "is this workflow valid?" — used by the
@@ -165,6 +170,13 @@ async def _validate_workflow_definition(
                 message=issue.message,
             )
         )
+
+    errors.extend(
+        await validate_workflow_tool_name_collisions(
+            workflow_definition,
+            organization_id,
+        )
+    )
 
     # ----------- Trigger Path Conflict Check ------------
     trigger_paths = extract_trigger_paths(workflow_definition)
@@ -221,6 +233,35 @@ def _node_instance_validation_errors(
         node_types,
         enforce_min_instances=False,
     )
+
+
+def _transition_tool_name_validation_errors(
+    workflow_definition: Optional[dict],
+) -> list[WorkflowError]:
+    """Validate transition names without requiring a complete draft DTO."""
+    if not workflow_definition:
+        return []
+    edges = workflow_definition.get("edges")
+    if not isinstance(edges, list):
+        return []
+
+    transitions: list[tuple[str, str, str]] = []
+    for edge in edges:
+        if not isinstance(edge, dict):
+            continue
+        edge_id = edge.get("id")
+        source = edge.get("source")
+        data = edge.get("data")
+        label = data.get("label") if isinstance(data, dict) else None
+        if (
+            isinstance(edge_id, str)
+            and isinstance(source, str)
+            and isinstance(label, str)
+            and label
+        ):
+            transitions.append((edge_id, source, label))
+
+    return validate_unique_transition_tool_names(transitions)
 
 
 class CallDispositionCodes(BaseModel):
@@ -364,7 +405,9 @@ async def validate_workflow(
     )
 
     errors = await _validate_workflow_definition(
-        workflow_definition, exclude_workflow_id=workflow_id
+        workflow_definition,
+        organization_id=user.selected_organization_id,
+        exclude_workflow_id=workflow_id,
     )
 
     if errors:
@@ -421,6 +464,15 @@ async def create_workflow(
     instance_errors = _node_instance_validation_errors(workflow_definition)
     if instance_errors:
         raise _validation_errors_http_exception(instance_errors)
+    transition_errors = _transition_tool_name_validation_errors(workflow_definition)
+    if transition_errors:
+        raise _validation_errors_http_exception(transition_errors)
+    tool_name_errors = await validate_workflow_tool_name_collisions(
+        workflow_definition,
+        user.selected_organization_id,
+    )
+    if tool_name_errors:
+        raise _validation_errors_http_exception(tool_name_errors)
 
     # Validate trigger path uniqueness BEFORE creating the workflow so we
     # don't leave an orphaned workflow record when the trigger conflicts.
@@ -814,7 +866,9 @@ async def publish_workflow(
         raise HTTPException(status_code=400, detail="No draft to publish")
 
     errors = await _validate_workflow_definition(
-        draft.workflow_json, exclude_workflow_id=workflow_id
+        draft.workflow_json,
+        organization_id=user.selected_organization_id,
+        exclude_workflow_id=workflow_id,
     )
     if errors:
         raise _validation_errors_http_exception(errors)
@@ -1030,6 +1084,18 @@ async def update_workflow(
         instance_errors = _node_instance_validation_errors(workflow_definition)
         if instance_errors:
             raise _validation_errors_http_exception(instance_errors, status_code=409)
+        transition_errors = _transition_tool_name_validation_errors(workflow_definition)
+        if transition_errors:
+            raise _validation_errors_http_exception(transition_errors, status_code=409)
+        tool_name_errors = await validate_workflow_tool_name_collisions(
+            workflow_definition,
+            user.selected_organization_id,
+        )
+        if tool_name_errors:
+            raise _validation_errors_http_exception(
+                tool_name_errors,
+                status_code=409,
+            )
         if workflow_definition:
             existing_workflow = await db_client.get_workflow(
                 workflow_id, organization_id=user.selected_organization_id

--- a/api/services/workflow/tool_name_validation.py
+++ b/api/services/workflow/tool_name_validation.py
@@ -1,0 +1,121 @@
+"""Validate the LLM function-name namespace within workflow nodes."""
+
+from collections import defaultdict
+from typing import Any
+
+from api.db import db_client
+from api.enums import ToolCategory
+from api.services.workflow.errors import ItemKind, WorkflowError
+from api.services.workflow.tools.custom_tool import custom_tool_function_name
+from api.services.workflow.workflow_graph import transition_tool_name
+
+_DYNAMIC_SCHEMA_CATEGORIES = {
+    ToolCategory.CALCULATOR.value,
+    ToolCategory.MCP.value,
+}
+
+
+async def validate_workflow_tool_name_collisions(
+    workflow_definition: dict[str, Any] | None,
+    organization_id: int,
+) -> list[WorkflowError]:
+    """Find custom-tool names that collide within a node's LLM namespace.
+
+    Calculator and MCP tool schemas have their own runtime-provided function
+    names, so a saved tool's display name cannot be used to validate them here.
+    """
+    if not workflow_definition:
+        return []
+
+    nodes = workflow_definition.get("nodes")
+    edges = workflow_definition.get("edges")
+    if not isinstance(nodes, list) or not isinstance(edges, list):
+        return []
+
+    tool_uuids_by_node: dict[str, set[str]] = {}
+    all_tool_uuids: set[str] = set()
+    for node in nodes:
+        if not isinstance(node, dict) or not isinstance(node.get("id"), str):
+            continue
+        data = node.get("data")
+        raw_tool_uuids = data.get("tool_uuids") if isinstance(data, dict) else None
+        if not isinstance(raw_tool_uuids, list):
+            continue
+        tool_uuids = {uuid for uuid in raw_tool_uuids if isinstance(uuid, str)}
+        if tool_uuids:
+            tool_uuids_by_node[node["id"]] = tool_uuids
+            all_tool_uuids.update(tool_uuids)
+
+    if not all_tool_uuids:
+        return []
+
+    tools = await db_client.get_tools_by_uuids(
+        sorted(all_tool_uuids),
+        organization_id,
+    )
+    tools_by_uuid = {
+        tool.tool_uuid: tool
+        for tool in tools
+        if tool.category not in _DYNAMIC_SCHEMA_CATEGORIES
+    }
+
+    custom_tools_by_node: dict[str, dict[str, list[Any]]] = {}
+    errors: list[WorkflowError] = []
+    for node_id, tool_uuids in tool_uuids_by_node.items():
+        by_function_name: dict[str, list[Any]] = defaultdict(list)
+        for tool_uuid in sorted(tool_uuids):
+            tool = tools_by_uuid.get(tool_uuid)
+            if tool is not None:
+                by_function_name[custom_tool_function_name(tool.name)].append(tool)
+        custom_tools_by_node[node_id] = by_function_name
+
+        for function_name, matching_tools in by_function_name.items():
+            if len(matching_tools) < 2:
+                continue
+            tool_names = ", ".join(f'"{tool.name}"' for tool in matching_tools)
+            errors.append(
+                WorkflowError(
+                    kind=ItemKind.node,
+                    id=node_id,
+                    field="data.tool_uuids",
+                    message=(
+                        f"Custom tools {tool_names} generate duplicate LLM tool "
+                        f'name "{function_name}" on this node. Rename one of the tools.'
+                    ),
+                )
+            )
+
+    for edge in edges:
+        if not isinstance(edge, dict):
+            continue
+        edge_id = edge.get("id")
+        source = edge.get("source")
+        data = edge.get("data")
+        label = data.get("label") if isinstance(data, dict) else None
+        if not (
+            isinstance(edge_id, str)
+            and isinstance(source, str)
+            and isinstance(label, str)
+            and label
+        ):
+            continue
+
+        function_name = transition_tool_name(label)
+        matching_tools = custom_tools_by_node.get(source, {}).get(function_name, [])
+        if not matching_tools:
+            continue
+        tool_names = ", ".join(f'"{tool.name}"' for tool in matching_tools)
+        errors.append(
+            WorkflowError(
+                kind=ItemKind.edge,
+                id=edge_id,
+                field="data.label",
+                message=(
+                    f'Transition tool name "{function_name}" conflicts with custom '
+                    f"tool {tool_names} attached to this node. Use a unique edge "
+                    "label or rename the custom tool."
+                ),
+            )
+        )
+
+    return errors

--- a/api/services/workflow/tools/custom_tool.py
+++ b/api/services/workflow/tools/custom_tool.py
@@ -22,6 +22,12 @@ TYPE_MAP = {
 }
 
 
+def custom_tool_function_name(name: str) -> str:
+    """Return the LLM function name generated for a custom tool."""
+    function_name = re.sub(r"[^a-z0-9_]", "_", name.lower())
+    return re.sub(r"_+", "_", function_name).strip("_")
+
+
 def serialize_query_params(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """JSON-stringify dict/list values so they're safe to pass as query params.
 
@@ -110,10 +116,7 @@ def tool_to_function_schema(tool: Any) -> Dict[str, Any]:
         }
         required.append("reason")
 
-    # Sanitize tool name for function name (lowercase, underscores only)
-    function_name = re.sub(r"[^a-z0-9_]", "_", tool.name.lower())
-    # Remove consecutive underscores and trim
-    function_name = re.sub(r"_+", "_", function_name).strip("_")
+    function_name = custom_tool_function_name(tool.name)
 
     return {
         "type": "function",

--- a/api/services/workflow/workflow_graph.py
+++ b/api/services/workflow/workflow_graph.py
@@ -1,6 +1,6 @@
 import re
 from collections import Counter
-from typing import Dict, List, Set
+from typing import Dict, Iterable, List, Set
 
 from api.services.workflow.dto import EdgeDataDTO, NodeType, ReactFlowDTO
 from api.services.workflow.errors import ItemKind, WorkflowError
@@ -14,6 +14,44 @@ TEMPLATE_VAR_PATTERN = r"\{\{\s*([^|\s}]+)(?:\s*\|\s*([^:}]+)(?::([^}]+))?)?\s*\
 
 # Variables injected by the system at runtime, not from source data.
 _SYSTEM_VARIABLES = {"campaign_id", "provider", "source_uuid"}
+
+
+def transition_tool_name(label: str) -> str:
+    """Return the LLM function name generated for a transition edge."""
+    return re.sub(r"[^a-z0-9]", "_", label.lower())
+
+
+def validate_unique_transition_tool_names(
+    transitions: Iterable[tuple[str, str, str]],
+) -> list[WorkflowError]:
+    """Reject outgoing edges that generate the same LLM tool name.
+
+    ``transitions`` contains ``(edge_id, source_node_id, label)`` tuples.
+    Keeping this validator independent of the DTO lets incomplete UI drafts
+    run the same targeted check as fully-valid workflows.
+    """
+    grouped_edges: dict[tuple[str, str], list[str]] = {}
+    for edge_id, source_node_id, label in transitions:
+        tool_name = transition_tool_name(label)
+        grouped_edges.setdefault((source_node_id, tool_name), []).append(edge_id)
+
+    errors: list[WorkflowError] = []
+    for (_, tool_name), edge_ids in grouped_edges.items():
+        if len(edge_ids) < 2:
+            continue
+        for edge_id in edge_ids:
+            errors.append(
+                WorkflowError(
+                    kind=ItemKind.edge,
+                    id=edge_id,
+                    field="data.label",
+                    message=(
+                        f'Transition tool name "{tool_name}" is duplicated for '
+                        "this node. Use a unique edge label."
+                    ),
+                )
+            )
+    return errors
 
 
 def extract_template_variables(text: str) -> Set[str]:
@@ -40,7 +78,8 @@ def extract_template_variables(text: str) -> Set[str]:
 
 
 class Edge:
-    def __init__(self, source: str, target: str, data: EdgeDataDTO):
+    def __init__(self, id: str, source: str, target: str, data: EdgeDataDTO):
+        self.id = id
         self.source = source
         self.target = target
 
@@ -51,7 +90,7 @@ class Edge:
         self.data = data
 
     def get_function_name(self):
-        return re.sub(r"[^a-z0-9]", "_", self.label.lower())
+        return transition_tool_name(self.label)
 
     def __eq__(self, other):
         if not isinstance(other, Edge):
@@ -197,7 +236,7 @@ class WorkflowGraph:
             target_node = self.nodes[e.target]
 
             # Create the edge with properties from dto
-            edge = Edge(source=e.source, target=e.target, data=e.data)
+            edge = Edge(id=e.id, source=e.source, target=e.target, data=e.data)
 
             # Add to the edge list
             self.edges.append(edge)
@@ -284,6 +323,11 @@ class WorkflowGraph:
             )
         )
         errors.extend(self._assert_connection_counts())
+        errors.extend(
+            validate_unique_transition_tool_names(
+                (edge.id, edge.source, edge.label) for edge in self.edges
+            )
+        )
         errors.extend(self._assert_node_configs())
         if errors:
             raise ValueError(errors)

--- a/api/tests/test_mcp_save_workflow.py
+++ b/api/tests/test_mcp_save_workflow.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import shutil
 from dataclasses import dataclass
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -292,6 +293,70 @@ async def test_graph_validation_catches_duplicate_api_triggers(mock_backends):
     assert result["saved"] is False
     assert result["error_code"] == "graph_validation"
     assert "at most one API Trigger" in result["error"]
+    save_mock.assert_not_awaited()
+    update_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_graph_validation_catches_duplicate_transition_tools(mock_backends):
+    save_mock, update_mock = mock_backends
+    code = """import { Workflow } from "@dograh/sdk";
+import { startCall, endCall } from "@dograh/sdk/typed";
+const wf = new Workflow({ name: "duplicate-transitions" });
+const start = wf.addTyped(startCall({ name: "start", prompt: "Hi." }));
+const first = wf.addTyped(endCall({ name: "first", prompt: "Bye." }));
+const second = wf.addTyped(endCall({ name: "second", prompt: "Bye." }));
+wf.edge(start, first, { label: "handoff", condition: "caller wants sales" });
+wf.edge(start, second, { label: "handoff", condition: "caller wants support" });
+"""
+
+    result = await save_workflow(workflow_id=1, code=code)
+
+    assert result["saved"] is False
+    assert result["error_code"] == "graph_validation"
+    assert 'Transition tool name "handoff" is duplicated' in result["error"]
+    save_mock.assert_not_awaited()
+    update_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_graph_validation_catches_transition_custom_tool_collision(
+    mock_backends,
+):
+    save_mock, update_mock = mock_backends
+    code = """import { Workflow } from "@dograh/sdk";
+import { startCall, endCall } from "@dograh/sdk/typed";
+const wf = new Workflow({ name: "tool-transition-collision" });
+const start = wf.addTyped(startCall({
+  name: "start",
+  prompt: "Hi.",
+  tool_uuids: ["tool-uuid-1"]
+}));
+const done = wf.addTyped(endCall({ name: "done", prompt: "Bye." }));
+wf.edge(start, done, {
+  label: "transfer callback",
+  condition: "caller requested a callback"
+});
+"""
+    tool = SimpleNamespace(
+        tool_uuid="tool-uuid-1",
+        name="Transfer Callback",
+        category="transfer_call",
+    )
+
+    with patch(
+        "api.services.workflow.tool_name_validation.db_client.get_tools_by_uuids",
+        AsyncMock(return_value=[tool]),
+    ) as get_tools_mock:
+        result = await save_workflow(workflow_id=1, code=code)
+
+    assert result["saved"] is False
+    assert result["error_code"] == "graph_validation"
+    assert (
+        'Transition tool name "transfer_callback" conflicts with custom tool '
+        '"Transfer Callback"' in result["error"]
+    )
+    get_tools_mock.assert_awaited_once_with(["tool-uuid-1"], 1)
     save_mock.assert_not_awaited()
     update_mock.assert_not_awaited()
 

--- a/api/tests/test_workflow_create_route.py
+++ b/api/tests/test_workflow_create_route.py
@@ -85,6 +85,117 @@ def test_create_workflow_rejects_duplicate_api_triggers_before_db_write():
     assert mock_db.mock_calls == []
 
 
+def test_update_workflow_rejects_duplicate_transition_tools_before_db_write():
+    app = _make_test_app()
+    client = TestClient(app)
+
+    with patch("api.routes.workflow.db_client") as mock_db:
+        response = client.put(
+            "/workflow/33",
+            json={
+                "workflow_definition": {
+                    "nodes": [],
+                    "edges": [
+                        {
+                            "id": "edge-1",
+                            "source": "agent-1",
+                            "target": "end-1",
+                            "data": {
+                                "label": "Go to sales",
+                                "condition": "Caller wants sales.",
+                            },
+                        },
+                        {
+                            "id": "edge-2",
+                            "source": "agent-1",
+                            "target": "end-2",
+                            "data": {
+                                "label": "go-to-sales",
+                                "condition": "Caller asks for sales.",
+                            },
+                        },
+                    ],
+                }
+            },
+        )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["is_valid"] is False
+    assert {error["id"] for error in detail["errors"]} == {"edge-1", "edge-2"}
+    assert all(error["kind"] == "edge" for error in detail["errors"])
+    assert all(error["field"] == "data.label" for error in detail["errors"])
+    assert all(
+        'Transition tool name "go_to_sales" is duplicated' in error["message"]
+        for error in detail["errors"]
+    )
+    assert mock_db.mock_calls == []
+
+
+def test_update_workflow_rejects_transition_custom_tool_collision_before_db_write():
+    app = _make_test_app()
+    client = TestClient(app)
+    tool = SimpleNamespace(
+        tool_uuid="tool-uuid-1",
+        name="Transfer Callback",
+        category="transfer_call",
+    )
+
+    with (
+        patch("api.routes.workflow.db_client") as mock_db,
+        patch(
+            "api.services.workflow.tool_name_validation.db_client.get_tools_by_uuids",
+            AsyncMock(return_value=[tool]),
+        ) as get_tools_mock,
+    ):
+        response = client.put(
+            "/workflow/33",
+            json={
+                "workflow_definition": {
+                    "nodes": [
+                        {
+                            "id": "agent-1",
+                            "type": "agentNode",
+                            "data": {
+                                "name": "Agent",
+                                "tool_uuids": ["tool-uuid-1"],
+                            },
+                        }
+                    ],
+                    "edges": [
+                        {
+                            "id": "edge-1",
+                            "source": "agent-1",
+                            "target": "end-1",
+                            "data": {
+                                "label": "transfer callback",
+                                "condition": "Caller requested a callback.",
+                            },
+                        }
+                    ],
+                }
+            },
+        )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["is_valid"] is False
+    assert detail["errors"] == [
+        {
+            "kind": "edge",
+            "id": "edge-1",
+            "field": "data.label",
+            "message": (
+                'Transition tool name "transfer_callback" conflicts with custom '
+                'tool "Transfer Callback" attached to this node. Use a unique '
+                "edge label or rename the custom tool."
+            ),
+        }
+    ]
+    get_tools_mock.assert_awaited_once_with(["tool-uuid-1"], 11)
+    assert mock_db.mock_calls == []
+
+
 def test_create_workflow_run_uses_draft_and_template_context():
     app = _make_test_app()
     client = TestClient(app)

--- a/api/tests/test_workflow_graph_constraints.py
+++ b/api/tests/test_workflow_graph_constraints.py
@@ -24,7 +24,10 @@ import pytest
 
 from api.services.workflow.audit import audit_definition
 from api.services.workflow.dto import ReactFlowDTO
-from api.services.workflow.workflow_graph import WorkflowGraph
+from api.services.workflow.workflow_graph import (
+    WorkflowGraph,
+    validate_unique_transition_tool_names,
+)
 
 _FIXTURES_DIR = Path(__file__).parent / "dto_fixtures"
 
@@ -164,3 +167,69 @@ def test_workflow_graph_start_semantics_come_from_node_type_not_legacy_flag():
 
     assert graph.start_node_id == "start-1"
     assert graph.nodes["start-1"].is_start is True
+
+
+def test_workflow_graph_rejects_duplicate_transition_tool_names():
+    dto = ReactFlowDTO.model_validate(
+        {
+            "nodes": [
+                {
+                    "id": "start-1",
+                    "type": "startCall",
+                    "position": {"x": 0, "y": 0},
+                    "data": {"name": "Start", "prompt": "Greet."},
+                },
+                {
+                    "id": "end-1",
+                    "type": "endCall",
+                    "position": {"x": 0, "y": 200},
+                    "data": {"name": "End one", "prompt": "Bye."},
+                },
+                {
+                    "id": "end-2",
+                    "type": "endCall",
+                    "position": {"x": 200, "y": 200},
+                    "data": {"name": "End two", "prompt": "Bye."},
+                },
+            ],
+            "edges": [
+                {
+                    "id": "edge-1",
+                    "source": "start-1",
+                    "target": "end-1",
+                    "data": {
+                        "label": "Go to sales",
+                        "condition": "Caller wants sales.",
+                    },
+                },
+                {
+                    "id": "edge-2",
+                    "source": "start-1",
+                    "target": "end-2",
+                    "data": {
+                        "label": "go-to-sales",
+                        "condition": "Caller asks for the sales team.",
+                    },
+                },
+            ],
+        }
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        WorkflowGraph(dto)
+
+    errors = exc_info.value.args[0]
+    assert {error["id"] for error in errors} == {"edge-1", "edge-2"}
+    assert all(error["field"] == "data.label" for error in errors)
+    assert all('"go_to_sales"' in error["message"] for error in errors)
+
+
+def test_duplicate_transition_tool_names_are_scoped_to_source_node():
+    errors = validate_unique_transition_tool_names(
+        [
+            ("edge-1", "source-1", "Continue"),
+            ("edge-2", "source-2", "Continue"),
+        ]
+    )
+
+    assert errors == []

--- a/api/tests/test_workflow_tool_name_validation.py
+++ b/api/tests/test_workflow_tool_name_validation.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.services.workflow.tool_name_validation import (
+    validate_workflow_tool_name_collisions,
+)
+
+
+@pytest.mark.asyncio
+async def test_duplicate_custom_tool_function_names_are_rejected_per_node():
+    definition = {
+        "nodes": [
+            {
+                "id": "agent-1",
+                "data": {"tool_uuids": ["tool-2", "tool-1"]},
+            }
+        ],
+        "edges": [],
+    }
+    tools = [
+        SimpleNamespace(
+            tool_uuid="tool-1",
+            name="Transfer Callback",
+            category="transfer_call",
+        ),
+        SimpleNamespace(
+            tool_uuid="tool-2",
+            name="transfer-callback",
+            category="http_api",
+        ),
+    ]
+
+    with patch(
+        "api.services.workflow.tool_name_validation.db_client.get_tools_by_uuids",
+        AsyncMock(return_value=tools),
+    ) as get_tools_mock:
+        errors = await validate_workflow_tool_name_collisions(definition, 11)
+
+    assert errors == [
+        {
+            "kind": "node",
+            "id": "agent-1",
+            "field": "data.tool_uuids",
+            "message": (
+                'Custom tools "Transfer Callback", "transfer-callback" generate '
+                'duplicate LLM tool name "transfer_callback" on this node. Rename '
+                "one of the tools."
+            ),
+        }
+    ]
+    get_tools_mock.assert_awaited_once_with(["tool-1", "tool-2"], 11)
+
+
+@pytest.mark.asyncio
+async def test_custom_tool_collision_is_scoped_to_its_node():
+    definition = {
+        "nodes": [
+            {
+                "id": "agent-1",
+                "data": {"tool_uuids": ["tool-1"]},
+            },
+            {
+                "id": "agent-2",
+                "data": {},
+            },
+        ],
+        "edges": [
+            {
+                "id": "edge-1",
+                "source": "agent-2",
+                "target": "end-1",
+                "data": {"label": "transfer callback"},
+            }
+        ],
+    }
+    tool = SimpleNamespace(
+        tool_uuid="tool-1",
+        name="Transfer Callback",
+        category="transfer_call",
+    )
+
+    with patch(
+        "api.services.workflow.tool_name_validation.db_client.get_tools_by_uuids",
+        AsyncMock(return_value=[tool]),
+    ):
+        errors = await validate_workflow_tool_name_collisions(definition, 11)
+
+    assert errors == []


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent function-name collisions inside workflow nodes. We now reject duplicate LLM tool names from transition labels and custom tools across create/save/validate/publish paths with clear errors.

- **Bug Fixes**
  - Added `validate_workflow_tool_name_collisions` to detect per-node collisions and transition-vs-custom tool conflicts; skips dynamic schemas (`CALCULATOR`, `MCP`).
  - Enforced unique transition tool names per source node via `validate_unique_transition_tool_names` in `WorkflowGraph` and route pre-checks.
  - Wired validations into `save_workflow`, `create_workflow`, `publish_workflow`, `update_workflow`, and the validation endpoint; errors point to `data.label` or `data.tool_uuids`.
  - Centralized custom tool function-name normalization in `custom_tool_function_name` and used it in serialization.
  - Added tests for MCP save, workflow routes, graph constraints, and unit validation of tool-name collisions.

<sup>Written for commit 4f9bab7a31e525cf67eb726644e3b6f9187f282d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds workflow validation for duplicate LLM function names.
- Extracts shared normalization helpers for custom tools and transition edges.
- Rejects duplicate outgoing transition names per source node.
- Resolves attached tools by organization and detects custom-tool/custom-tool and custom-tool/transition collisions.
- Applies the validation across REST create, update, validate, and publish operations and MCP create/save operations.
- Adds route, graph, MCP, and service-level test coverage.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until calculator function names participate in collision validation.

Calculator tools always register as "safe_calculator" alongside custom tools and transitions, but the new validator filters calculators out, so conflicting workflows can still pass validation and reach runtime with duplicate function schemas.

**Files Needing Attention:** api/services/workflow/tool_name_validation.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced the calculator collision verification by running the real validator with a mocked repository lookup for a node containing calculator and safe\_calculator tools; it returned no validation errors and the runtime schema list included safe\_calculator.
- I attempted the initial validation run (HEAD^), but it failed because the validation service did not yet exist.
- After changes, all three targeted changed-service scenarios pass with exit code 0.
- I captured environment setup and test run details, including the exact pytest command, 26 tests collected, and the creation of a Python 3.11 virtual environment.

<a href="https://app.greptile.com/trex/runs/15856865/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/services/workflow/tool_name_validation.py | Adds organization-scoped collision detection, but excluding calculators leaves their fixed runtime name outside the validated namespace. |
| api/services/workflow/workflow_graph.py | Centralizes transition-name generation and rejects duplicate normalized outgoing transition names per source node. |
| api/services/workflow/tools/custom_tool.py | Extracts the existing custom-tool name normalization without changing generated schema behavior. |
| api/routes/workflow.py | Integrates targeted and complete collision checks into REST workflow validation and persistence paths. |
| api/mcp_server/tools/create_workflow.py | Rejects detected custom-tool name collisions before MCP workflow creation. |
| api/mcp_server/tools/save_workflow.py | Rejects detected custom-tool name collisions before MCP draft persistence. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  D[Workflow definition] --> G[Graph validation]
  G --> T[Resolve attached tools by organization]
  T --> N[Normalize custom-tool and transition names]
  N --> C{Collision found?}
  C -->|Yes| R[Reject create, save, update, validate, or publish]
  C -->|No| P[Continue persistence or publication]
  X[Calculator schema: safe_calculator] -. currently excluded .-> N
```

<sub>Reviews (1): Last reviewed commit: ["fix(workflow): reject duplicate tool fun..."](https://github.com/dograh-hq/dograh/commit/4f9bab7a31e525cf67eb726644e3b6f9187f282d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47222288)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->