### PR TITLE
fix: use default button style for "Save Organization Configuration"

### DIFF
--- a/ui/src/app/workflow/[workflowId]/settings/page.tsx
+++ b/ui/src/app/workflow/[workflowId]/settings/page.tsx
@@ -1431,7 +1431,6 @@ function WorkflowModelOverridesSection({
                                 {hasSavedModelOverride && (
                                     <Button
                                         type="button"
-                                        variant="outline"
                                         className="mt-3"
                                         onClick={removeV2Override}
                                         disabled={isRemovingOverride}


### PR DESCRIPTION
## Summary
- The "Save Organization Configuration" button in a workflow's Settings → Model Overrides section used `variant="outline"`, which renders as low-contrast (near-black) text in dark mode.
- Switched it to the default button variant so it matches the sibling "Save Model Override" button's style used elsewhere in the same section.

## Before / after
Before: outlined button, low text contrast.
After: solid button, matches the rest of the section's save actions.

## Test plan
- [x] `npm run lint` clean on the changed file
- [x] `npx tsc --noEmit` clean
- [x] Verified visually in a local dev instance: toggled the "Override for this workflow" switch off with a saved override present and confirmed the button now renders with proper contrast, matching the "Save Model Override" button style

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the default button style for "Save Organization Configuration" in Workflow Settings → Model Overrides. This fixes low-contrast text in dark mode and matches the "Save Model Override" button.

<sup>Written for commit c6bb2995fd8d3117f0ff19a9abd2f523993727ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the workflow Model Overrides section so the “Save Organization Configuration” action uses the Button component’s default solid style instead of the outline variant.

<h3>Confidence Score: 5/5</h3>

The focused presentation-only change appears safe to merge without functional regression.

The button retains the same type, click handler, disabled state, conditional rendering, and layout class; only its visual variant changes to the component default.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Captured the pre-change UI state of the Save Organization Configuration button, showing an outline with a translucent background and a 1px border, with the toggle switch unchecked.
- Captured the post-change UI state of the same button, showing a solid primary background and no border, with the toggle switch unchecked.
- Validated that both Playwright runs completed successfully.
- Collected and linked artifacts (videos, images, and logs) that document the UI changes and run results for review.

<a href="https://app.greptile.com/trex/runs/16053790/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/app/workflow/[workflowId]/settings/page.tsx | Removes the outline variant from one button, changing only its presentation while preserving its event handling, disabled state, and behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use default button style for &quot;Save ..."](https://github.com/dograh-hq/dograh/commit/c6bb2995fd8d3117f0ff19a9abd2f523993727ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47648374)</sub>

<!-- /greptile_comment -->