### PR TITLE
fix(telephony): surface pre-call failures on workflow runs

### DIFF
--- a/api/routes/agent_stream.py
+++ b/api/routes/agent_stream.py
@@ -25,6 +25,7 @@ from api.services.call_concurrency import (
 from api.services.quota_service import authorize_workflow_run_start
 from api.services.telephony import registry as telephony_registry
 from api.services.workflow.run_creation import prepare_workflow_run_inputs
+from api.services.workflow_run_failure import mark_workflow_run_failed
 
 router = APIRouter(prefix="/agent-stream")
 
@@ -101,6 +102,9 @@ async def agent_stream_websocket(
         logger.warning(
             f"agent-stream quota exceeded for user {workflow.user_id}: "
             f"{quota_result.error_message}"
+        )
+        await mark_workflow_run_failed(
+            workflow_run.id, quota_result.error_message or "Quota exceeded"
         )
         await call_concurrency.release_workflow_run_slot(workflow_run.id)
         await websocket.close(

--- a/api/routes/public_agent.py
+++ b/api/routes/public_agent.py
@@ -335,9 +335,7 @@ async def _execute_resolved_target(
         logger.warning(
             f"Failed to initiate call for workflow run {workflow_run.id}: {e}"
         )
-        await mark_workflow_run_failed(
-            workflow_run.id, f"Failed to initiate call: {e}"
-        )
+        await mark_workflow_run_failed(workflow_run.id, f"Failed to initiate call: {e}")
         await call_concurrency.release_workflow_run_slot(workflow_run.id)
         raise HTTPException(
             status_code=400,

--- a/api/routes/public_agent.py
+++ b/api/routes/public_agent.py
@@ -24,6 +24,7 @@ from api.services.telephony.factory import (
     get_telephony_provider_by_id,
 )
 from api.services.workflow.run_creation import prepare_workflow_run_inputs
+from api.services.workflow_run_failure import mark_workflow_run_failed
 from api.utils.common import get_backend_endpoints
 
 router = APIRouter(prefix="/public/agent")
@@ -297,6 +298,9 @@ async def _execute_resolved_target(
         workflow_run_id=workflow_run.id,
     )
     if not quota_result.has_quota:
+        await mark_workflow_run_failed(
+            workflow_run.id, quota_result.error_message or "Quota exceeded"
+        )
         await call_concurrency.release_workflow_run_slot(workflow_run.id)
         raise HTTPException(status_code=402, detail=quota_result.error_message)
 
@@ -330,6 +334,9 @@ async def _execute_resolved_target(
     except Exception as e:
         logger.warning(
             f"Failed to initiate call for workflow run {workflow_run.id}: {e}"
+        )
+        await mark_workflow_run_failed(
+            workflow_run.id, f"Failed to initiate call: {e}"
         )
         await call_concurrency.release_workflow_run_slot(workflow_run.id)
         raise HTTPException(

--- a/api/routes/telephony.py
+++ b/api/routes/telephony.py
@@ -43,6 +43,7 @@ from api.services.telephony.transfer_event_protocol import (
     TransferEventType,
 )
 from api.services.workflow.run_creation import prepare_workflow_run_inputs
+from api.services.workflow_run_failure import mark_workflow_run_failed
 from api.utils.common import get_backend_endpoints
 from api.utils.telephony_helper import (
     generic_hangup_response,
@@ -231,6 +232,9 @@ async def initiate_call(
         actor_user=user,
     )
     if not quota_result.has_quota:
+        await mark_workflow_run_failed(
+            workflow_run_id, quota_result.error_message or "Quota exceeded"
+        )
         await call_concurrency.release_workflow_run_slot(workflow_run_id)
         raise HTTPException(status_code=402, detail=quota_result.error_message)
 
@@ -260,7 +264,10 @@ async def initiate_call(
             from_number=from_number,
             **keywords,
         )
-    except Exception:
+    except Exception as e:
+        await mark_workflow_run_failed(
+            workflow_run_id, f"Failed to initiate call: {e}"
+        )
         await call_concurrency.release_workflow_run_slot(workflow_run_id)
         raise
 
@@ -867,6 +874,9 @@ async def handle_inbound_run(request: Request):
                 logger.warning(
                     f"User {user_id} has exceeded quota: {quota_result.error_message}"
                 )
+                await mark_workflow_run_failed(
+                    workflow_run_id, quota_result.error_message or "Quota exceeded"
+                )
                 await call_concurrency.release_workflow_run_slot(workflow_run_id)
                 return provider_class.generate_validation_error_response(
                     TelephonyError.QUOTA_EXCEEDED
@@ -888,8 +898,11 @@ async def handle_inbound_run(request: Request):
             return provider_class.generate_validation_error_response(
                 TelephonyError.CONCURRENT_CALL_LIMIT
             )
-        except Exception:
+        except Exception as e:
             if workflow_run_id:
+                await mark_workflow_run_failed(
+                    workflow_run_id, f"Inbound call failed to start: {e}"
+                )
                 await call_concurrency.release_workflow_run_slot(workflow_run_id)
             else:
                 await call_concurrency.release_slot(concurrency_slot)
@@ -1034,6 +1047,9 @@ async def handle_inbound_telephony(
                     f"User {user_id} has exceeded quota for inbound calls: "
                     f"{quota_result.error_message}"
                 )
+                await mark_workflow_run_failed(
+                    workflow_run_id, quota_result.error_message or "Quota exceeded"
+                )
                 await call_concurrency.release_workflow_run_slot(workflow_run_id)
                 return provider_class.generate_validation_error_response(
                     TelephonyError.QUOTA_EXCEEDED
@@ -1056,8 +1072,11 @@ async def handle_inbound_telephony(
             return provider_class.generate_validation_error_response(
                 TelephonyError.CONCURRENT_CALL_LIMIT
             )
-        except Exception:
+        except Exception as e:
             if workflow_run_id:
+                await mark_workflow_run_failed(
+                    workflow_run_id, f"Inbound call failed to start: {e}"
+                )
                 await call_concurrency.release_workflow_run_slot(workflow_run_id)
             else:
                 await call_concurrency.release_slot(concurrency_slot)

--- a/api/routes/telephony.py
+++ b/api/routes/telephony.py
@@ -265,9 +265,7 @@ async def initiate_call(
             **keywords,
         )
     except Exception as e:
-        await mark_workflow_run_failed(
-            workflow_run_id, f"Failed to initiate call: {e}"
-        )
+        await mark_workflow_run_failed(workflow_run_id, f"Failed to initiate call: {e}")
         await call_concurrency.release_workflow_run_slot(workflow_run_id)
         raise
 

--- a/api/services/gender/README.md
+++ b/api/services/gender/README.md
@@ -67,19 +67,19 @@ service = GenderService()
 
 # Predict gender for a single name
 result = await service.predict("John")
-print(f"Gender: {result.gender}")       # "male"
-print(f"Confidence: {result.confidence}") # 0.996
-print(f"Source: {result.source}")       # "model"
+print(f"Gender: {result.gender}")  # "male"
+print(f"Confidence: {result.confidence}")  # 0.996
+print(f"Source: {result.source}")  # "model"
 
 # Get salutation for a name
 greeting = await service.get_salutation("John")
-print(f"Salutation: {greeting}")        # "Mr."
+print(f"Salutation: {greeting}")  # "Mr."
 
 greeting = await service.get_salutation("Mary")
-print(f"Salutation: {greeting}")        # "Ms."
+print(f"Salutation: {greeting}")  # "Ms."
 
 greeting = await service.get_salutation("Unknown")
-print(f"Salutation: {greeting}")        # "Dear"
+print(f"Salutation: {greeting}")  # "Dear"
 
 # Clean up
 await service.close()
@@ -91,9 +91,9 @@ await service.close()
 # Custom configuration
 service = GenderService(
     model_path="custom/path/to/model.txt",  # Default: ./model.txt
-    confidence_threshold=0.85,              # Default: 0.85
-    gender_api_key="your-api-key",         # Default: from GENDER_API_KEY env
-    gender_api_url="https://..."           # Default: GenderAPI v2 endpoint
+    confidence_threshold=0.85,  # Default: 0.85
+    gender_api_key="your-api-key",  # Default: from GENDER_API_KEY env
+    gender_api_url="https://...",  # Default: GenderAPI v2 endpoint
 )
 ```
 
@@ -101,19 +101,19 @@ service = GenderService(
 
 ```python
 # Get appropriate salutation based on gender
-salutation = await service.get_salutation("John")     # "Mr."
-salutation = await service.get_salutation("Mary")     # "Ms."
+salutation = await service.get_salutation("John")  # "Mr."
+salutation = await service.get_salutation("Mary")  # "Ms."
 salutation = await service.get_salutation("Unknown")  # "Dear"
 
 # Custom confidence threshold for salutation
 salutation = await service.get_salutation(
-    "Taylor",                    # Ambiguous name
-    confidence_threshold=0.9     # Higher threshold
+    "Taylor",  # Ambiguous name
+    confidence_threshold=0.9,  # Higher threshold
 )  # Returns "Dear" due to low confidence
 
 # Salutation logic:
 # - "Mr." for male with confidence >= threshold
-# - "Ms." for female with confidence >= threshold  
+# - "Ms." for female with confidence >= threshold
 # - "Dear" for unknown gender or low confidence
 ```
 
@@ -133,8 +133,8 @@ for name, result in zip(names, results):
 ```python
 class GenderPrediction:
     gender: "male" | "female" | "unknown"  # Predicted gender
-    confidence: float                      # 0.0 to 1.0
-    source: "model" | "genderapi"         # Prediction source
+    confidence: float  # 0.0 to 1.0
+    source: "model" | "genderapi"  # Prediction source
 ```
 
 ### Service Statistics

--- a/api/services/integrations/AGENTS.md
+++ b/api/services/integrations/AGENTS.md
@@ -38,8 +38,8 @@ PACKAGE = register_package(
         name="<package_name>",
         nodes=(NODE,),
         create_runtime_sessions=create_runtime_sessions,  # optional
-        run_completion=run_completion,                    # optional
-        routers=(router,),                               # optional
+        run_completion=run_completion,  # optional
+        routers=(router,),  # optional
     )
 )
 ```

--- a/api/services/telephony/README.md
+++ b/api/services/telephony/README.md
@@ -28,7 +28,7 @@ provider = await get_telephony_provider_by_id(config_id, organization_id)
 result = await provider.initiate_call(
     to_number="+1987654321",
     webhook_url="https://your-app.com/webhook",
-    workflow_run_id=123
+    workflow_run_id=123,
 )
 ```
 
@@ -91,10 +91,10 @@ The `factory.py` loads configuration from the database:
    value: {
        "provider": "twilio",  # or "vonage"
        "account_sid": "xxx",  # for Twilio
-       "auth_token": "xxx",   # for Twilio
+       "auth_token": "xxx",  # for Twilio
        "application_id": "xxx",  # for Vonage
-       "private_key": "xxx",     # for Vonage
-       "from_numbers": [...]
+       "private_key": "xxx",  # for Vonage
+       "from_numbers": [...],
    }
    ```
 
@@ -106,14 +106,15 @@ The `factory.py` loads configuration from the database:
 class MockProvider(TelephonyProvider):
     async def initiate_call(self, to_number, webhook_url, **kwargs):
         return {"call_id": "mock_123", "status": "initiated"}
-    
+
     async def get_call_status(self, call_id):
         return {"call_id": call_id, "status": "completed"}
-    
+
     # Implement other required methods...
 
+
 # In tests
-@patch('api.services.telephony.factory.get_default_telephony_provider')
+@patch("api.services.telephony.factory.get_default_telephony_provider")
 async def test_call_initiation(mock_get_provider):
     mock_get_provider.return_value = MockProvider()
     # Test your business logic
@@ -141,6 +142,7 @@ pytest tests/integration/test_telephony.py
 Old code:
 ```python
 from api.services.telephony.twilio import TwilioService
+
 service = TwilioService(org_id)
 await service.initiate_call(...)
 ```
@@ -148,6 +150,7 @@ await service.initiate_call(...)
 New code:
 ```python
 from api.services.telephony.factory import get_default_telephony_provider
+
 provider = await get_default_telephony_provider(org_id)
 await provider.initiate_call(...)
 ```

--- a/api/services/telephony/ari_manager.py
+++ b/api/services/telephony/ari_manager.py
@@ -39,6 +39,7 @@ from api.services.telephony.transfer_event_protocol import (
     TransferEventType,
 )
 from api.services.workflow.run_creation import prepare_workflow_run_inputs
+from api.services.workflow_run_failure import mark_workflow_run_failed
 
 # Redis key pattern and TTL for channel-to-run mapping
 _CHANNEL_KEY_PREFIX = "ari:channel:"
@@ -679,6 +680,9 @@ class ARIConnection:
                     f"[ARI org={self.organization_id}] Quota exceeded for user {user_id} "
                     f"— hanging up inbound call {channel_id}"
                 )
+                await mark_workflow_run_failed(
+                    workflow_run.id, quota_result.error_message or "Quota exceeded"
+                )
                 await call_concurrency.release_workflow_run_slot(workflow_run.id)
                 await self._delete_channel(channel_id)
                 return
@@ -695,6 +699,9 @@ class ARIConnection:
             )
         except Exception as e:
             if workflow_run:
+                await mark_workflow_run_failed(
+                    workflow_run.id, f"Inbound call failed to start: {e}"
+                )
                 await call_concurrency.release_workflow_run_slot(workflow_run.id)
             elif concurrency_slot:
                 await call_concurrency.release_slot(concurrency_slot)

--- a/api/services/telephony/providers/AGENTS.md
+++ b/api/services/telephony/providers/AGENTS.md
@@ -42,15 +42,15 @@ If you find yourself editing anything else, re-read the registry plumbing first:
 
 ```python
 SPEC = ProviderSpec(
-    name="<name>",                                  # registry key, WorkflowRunMode value, stored discriminator
+    name="<name>",  # registry key, WorkflowRunMode value, stored discriminator
     provider_cls=YourProvider,
-    config_loader=_config_loader,                   # raw dict from DB → constructor dict
+    config_loader=_config_loader,  # raw dict from DB → constructor dict
     transport_factory=create_transport,
-    transport_sample_rate=8000,                     # wire-format rate; pipecat derives the full AudioConfig
+    transport_sample_rate=8000,  # wire-format rate; pipecat derives the full AudioConfig
     config_request_cls=YourProviderConfigurationRequest,
     config_response_cls=YourProviderConfigurationResponse,
-    ui_metadata=ProviderUIMetadata(...),            # drives the form UI
-    account_id_credential_field="api_key",          # "" if provider has no account-id concept
+    ui_metadata=ProviderUIMetadata(...),  # drives the form UI
+    account_id_credential_field="api_key",  # "" if provider has no account-id concept
 )
 register(SPEC)
 ```
@@ -77,7 +77,9 @@ Always:
 from api.services.telephony.factory import load_credentials_for_transport
 
 config = await load_credentials_for_transport(
-    organization_id, telephony_configuration_id, expected_provider="<name>",
+    organization_id,
+    telephony_configuration_id,
+    expected_provider="<name>",
 )
 ```
 

--- a/api/services/telephony/providers/plivo/routes.py
+++ b/api/services/telephony/providers/plivo/routes.py
@@ -13,12 +13,12 @@ from pipecat.utils.run_context import set_current_run_id
 from starlette.responses import HTMLResponse
 
 from api.db import db_client
+from api.services.telephony.call_transfer_manager import get_call_transfer_manager
 from api.services.telephony.factory import get_telephony_provider_for_run
 from api.services.telephony.status_processor import (
     StatusCallbackRequest,
     _process_status_update,
 )
-from api.services.telephony.call_transfer_manager import get_call_transfer_manager
 from api.services.telephony.transfer_event_protocol import (
     TransferEvent,
     TransferEventType,

--- a/api/services/workflow_run_failure.py
+++ b/api/services/workflow_run_failure.py
@@ -1,33 +1,72 @@
-"""Record pre-call failures on the workflow run so they surface in the UI.
+"""Finalize workflow runs that fail before the call pipeline starts.
 
 Workflow runs are created before quota authorization and call initiation.
 When either step fails, the rejection travels back to the telephony provider
 or API caller, but nothing reaches the run's owner: the run sits in
 ``initialized`` state forever with an empty detail page. Writing the error
-into ``gathered_context`` makes it visible on the run detail page and marks
-the run completed, matching the campaign dispatcher's convention.
+into ``gathered_context`` makes it available to integrations. A persisted
+real-time feedback event makes the failure visible in the run transcript, and
+the post-run integration job delivers configured webhooks.
 """
+
+from datetime import UTC, datetime
 
 from loguru import logger
 
 from api.db import db_client
-from api.enums import WorkflowRunState
+from api.enums import TelephonyCallStatus, WorkflowRunState
+from api.services.pipecat.realtime_feedback_events import (
+    build_pipeline_error_event,
+    stamp_realtime_feedback_event,
+)
+from api.tasks.function_names import FunctionNames
 
 
 async def mark_workflow_run_failed(workflow_run_id: int, error_message: str) -> None:
-    """Complete the run with a user-visible error.
+    """Complete the run with a user-visible error and notify integrations.
 
     Best-effort: callers invoke this while rejecting a call, so a bookkeeping
     failure must never mask the original rejection path.
     """
+    error_disposition = TelephonyCallStatus.ERROR.value
+    failure_event = stamp_realtime_feedback_event(
+        build_pipeline_error_event(
+            error=error_message,
+            fatal=True,
+            processor="call_start",
+        ),
+        timestamp=datetime.now(UTC).isoformat(timespec="milliseconds"),
+        turn=0,
+    )
+
     try:
         await db_client.update_workflow_run(
             run_id=workflow_run_id,
             is_completed=True,
             state=WorkflowRunState.COMPLETED.value,
-            gathered_context={"error": error_message},
+            usage_info={"call_duration_seconds": 0},
+            gathered_context={
+                "error": error_message,
+                "call_disposition": error_disposition,
+                "mapped_call_disposition": error_disposition,
+            },
+            logs={"realtime_feedback_events": [failure_event]},
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - bookkeeping must remain best-effort
+        logger.error(f"Failed to record failure on workflow run {workflow_run_id}: {e}")
+        return
+
+    try:
+        # Imported lazily to avoid loading the ARQ worker/task graph when route
+        # modules import this helper.
+        from api.tasks.arq import enqueue_job
+
+        await enqueue_job(
+            FunctionNames.RUN_INTEGRATIONS_POST_WORKFLOW_RUN,
+            workflow_run_id,
+        )
+    except Exception as e:  # noqa: BLE001 - notification must not mask rejection
         logger.error(
-            f"Failed to record failure on workflow run {workflow_run_id}: {e}"
+            f"Failed to enqueue integrations for failed workflow run "
+            f"{workflow_run_id}: {e}"
         )

--- a/api/services/workflow_run_failure.py
+++ b/api/services/workflow_run_failure.py
@@ -1,0 +1,33 @@
+"""Record pre-call failures on the workflow run so they surface in the UI.
+
+Workflow runs are created before quota authorization and call initiation.
+When either step fails, the rejection travels back to the telephony provider
+or API caller, but nothing reaches the run's owner: the run sits in
+``initialized`` state forever with an empty detail page. Writing the error
+into ``gathered_context`` makes it visible on the run detail page and marks
+the run completed, matching the campaign dispatcher's convention.
+"""
+
+from loguru import logger
+
+from api.db import db_client
+from api.enums import WorkflowRunState
+
+
+async def mark_workflow_run_failed(workflow_run_id: int, error_message: str) -> None:
+    """Complete the run with a user-visible error.
+
+    Best-effort: callers invoke this while rejecting a call, so a bookkeeping
+    failure must never mask the original rejection path.
+    """
+    try:
+        await db_client.update_workflow_run(
+            run_id=workflow_run_id,
+            is_completed=True,
+            state=WorkflowRunState.COMPLETED.value,
+            gathered_context={"error": error_message},
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to record failure on workflow run {workflow_run_id}: {e}"
+        )

--- a/api/tests/test_agent_stream_route.py
+++ b/api/tests/test_agent_stream_route.py
@@ -129,9 +129,7 @@ async def test_agent_stream_marks_run_failed_when_quota_exceeded():
         await agent_stream_websocket(websocket, "cloudonix", "agent-uuid")
 
     mark_failed_mock.assert_awaited_once_with(workflow_run.id, "Quota exceeded")
-    mock_concurrency.release_workflow_run_slot.assert_awaited_once_with(
-        workflow_run.id
-    )
+    mock_concurrency.release_workflow_run_slot.assert_awaited_once_with(workflow_run.id)
     websocket.close.assert_awaited_once_with(code=1008, reason="Quota exceeded")
     db_client.update_workflow_run.assert_not_awaited()
 

--- a/api/tests/test_agent_stream_route.py
+++ b/api/tests/test_agent_stream_route.py
@@ -85,6 +85,58 @@ async def test_agent_stream_uses_provider_path_param_not_query_param():
 
 
 @pytest.mark.asyncio
+async def test_agent_stream_marks_run_failed_when_quota_exceeded():
+    from api.routes.agent_stream import agent_stream_websocket
+
+    websocket = _FakeWebSocket()
+    workflow = SimpleNamespace(
+        id=11,
+        user_id=22,
+        organization_id=33,
+        template_context_variables={},
+        released_definition=SimpleNamespace(id=55, template_context_variables={}),
+        current_definition=None,
+    )
+    workflow_run = SimpleNamespace(id=44)
+    spec = SimpleNamespace(provider_cls=lambda _config: object())
+    mark_failed_mock = AsyncMock()
+
+    with (
+        patch("api.routes.agent_stream.telephony_registry") as registry,
+        patch("api.routes.agent_stream.db_client") as db_client,
+        patch("api.routes.agent_stream.call_concurrency") as mock_concurrency,
+        patch(
+            "api.routes.agent_stream.authorize_workflow_run_start",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    has_quota=False, error_message="Quota exceeded"
+                )
+            ),
+        ),
+        patch(
+            "api.routes.agent_stream.mark_workflow_run_failed",
+            new=mark_failed_mock,
+        ),
+    ):
+        registry.get_optional.return_value = spec
+        db_client.get_workflow_by_uuid_unscoped = AsyncMock(return_value=workflow)
+        db_client.create_workflow_run = AsyncMock(return_value=workflow_run)
+        db_client.update_workflow_run = AsyncMock()
+        mock_concurrency.acquire_org_slot = AsyncMock(return_value=object())
+        mock_concurrency.bind_workflow_run = AsyncMock()
+        mock_concurrency.release_workflow_run_slot = AsyncMock()
+
+        await agent_stream_websocket(websocket, "cloudonix", "agent-uuid")
+
+    mark_failed_mock.assert_awaited_once_with(workflow_run.id, "Quota exceeded")
+    mock_concurrency.release_workflow_run_slot.assert_awaited_once_with(
+        workflow_run.id
+    )
+    websocket.close.assert_awaited_once_with(code=1008, reason="Quota exceeded")
+    db_client.update_workflow_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_agent_stream_rejects_when_concurrency_limit_reached():
     from api.routes.agent_stream import agent_stream_websocket
 

--- a/api/tests/test_public_agent_routes.py
+++ b/api/tests/test_public_agent_routes.py
@@ -513,6 +513,7 @@ def test_trigger_route_releases_concurrency_slot_when_quota_fails():
     quota_mock = AsyncMock(
         return_value=SimpleNamespace(has_quota=False, error_message="Quota exceeded")
     )
+    mark_failed_mock = AsyncMock()
 
     with (
         patch("api.routes.public_agent.db_client") as mock_db,
@@ -520,6 +521,10 @@ def test_trigger_route_releases_concurrency_slot_when_quota_fails():
         patch(
             "api.routes.public_agent.authorize_workflow_run_start",
             new=quota_mock,
+        ),
+        patch(
+            "api.routes.public_agent.mark_workflow_run_failed",
+            new=mark_failed_mock,
         ),
         patch(
             "api.routes.public_agent.get_default_telephony_provider",
@@ -554,6 +559,7 @@ def test_trigger_route_releases_concurrency_slot_when_quota_fails():
         )
 
     assert response.status_code == 402
+    mark_failed_mock.assert_awaited_once_with(501, "Quota exceeded")
     mock_concurrency.release_workflow_run_slot.assert_awaited_once_with(501)
     provider.initiate_call.assert_not_awaited()
 

--- a/api/tests/test_workflow_run_failure.py
+++ b/api/tests/test_workflow_run_failure.py
@@ -2,30 +2,76 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from api.enums import WorkflowRunState
+from api.enums import TelephonyCallStatus, WorkflowRunState
 from api.services.workflow_run_failure import mark_workflow_run_failed
+from api.tasks.function_names import FunctionNames
 
 
 @pytest.mark.asyncio
 async def test_mark_workflow_run_failed_records_error_and_completes_run():
-    with patch("api.services.workflow_run_failure.db_client") as mock_db:
+    enqueue = AsyncMock()
+    with (
+        patch("api.services.workflow_run_failure.db_client") as mock_db,
+        patch("api.tasks.arq.enqueue_job", enqueue),
+    ):
         mock_db.update_workflow_run = AsyncMock()
 
         await mark_workflow_run_failed(597930, "You have exhausted your credits")
 
-    mock_db.update_workflow_run.assert_awaited_once_with(
-        run_id=597930,
-        is_completed=True,
-        state=WorkflowRunState.COMPLETED.value,
-        gathered_context={"error": "You have exhausted your credits"},
+    mock_db.update_workflow_run.assert_awaited_once()
+    update = mock_db.update_workflow_run.await_args.kwargs
+    assert update["run_id"] == 597930
+    assert update["is_completed"] is True
+    assert update["state"] == WorkflowRunState.COMPLETED.value
+    assert update["usage_info"] == {"call_duration_seconds": 0}
+    assert update["gathered_context"] == {
+        "error": "You have exhausted your credits",
+        "call_disposition": TelephonyCallStatus.ERROR.value,
+        "mapped_call_disposition": TelephonyCallStatus.ERROR.value,
+    }
+
+    [failure_event] = update["logs"]["realtime_feedback_events"]
+    assert failure_event["type"] == "rtf-pipeline-error"
+    assert failure_event["payload"] == {
+        "error": "You have exhausted your credits",
+        "fatal": True,
+        "processor": "call_start",
+    }
+    assert failure_event["turn"] == 0
+    assert failure_event["timestamp"]
+
+    enqueue.assert_awaited_once_with(
+        FunctionNames.RUN_INTEGRATIONS_POST_WORKFLOW_RUN,
+        597930,
     )
 
 
 @pytest.mark.asyncio
 async def test_mark_workflow_run_failed_swallows_db_errors():
-    with patch("api.services.workflow_run_failure.db_client") as mock_db:
+    enqueue = AsyncMock()
+    with (
+        patch("api.services.workflow_run_failure.db_client") as mock_db,
+        patch("api.tasks.arq.enqueue_job", enqueue),
+    ):
         mock_db.update_workflow_run = AsyncMock(
             side_effect=ValueError("Workflow run with ID 1 not found")
         )
 
         await mark_workflow_run_failed(1, "Quota exceeded")
+
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mark_workflow_run_failed_swallows_enqueue_errors():
+    enqueue = AsyncMock(side_effect=RuntimeError("Redis unavailable"))
+    with (
+        patch("api.services.workflow_run_failure.db_client") as mock_db,
+        patch("api.tasks.arq.enqueue_job", enqueue),
+    ):
+        mock_db.update_workflow_run = AsyncMock()
+
+        await mark_workflow_run_failed(2, "Failed to initiate call")
+
+    mock_db.update_workflow_run.assert_awaited_once()
+    enqueue.assert_awaited_once()

--- a/api/tests/test_workflow_run_failure.py
+++ b/api/tests/test_workflow_run_failure.py
@@ -1,0 +1,31 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.enums import WorkflowRunState
+from api.services.workflow_run_failure import mark_workflow_run_failed
+
+
+@pytest.mark.asyncio
+async def test_mark_workflow_run_failed_records_error_and_completes_run():
+    with patch("api.services.workflow_run_failure.db_client") as mock_db:
+        mock_db.update_workflow_run = AsyncMock()
+
+        await mark_workflow_run_failed(597930, "You have exhausted your credits")
+
+    mock_db.update_workflow_run.assert_awaited_once_with(
+        run_id=597930,
+        is_completed=True,
+        state=WorkflowRunState.COMPLETED.value,
+        gathered_context={"error": "You have exhausted your credits"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_mark_workflow_run_failed_swallows_db_errors():
+    with patch("api.services.workflow_run_failure.db_client") as mock_db:
+        mock_db.update_workflow_run = AsyncMock(
+            side_effect=ValueError("Workflow run with ID 1 not found")
+        )
+
+        await mark_workflow_run_failed(1, "Quota exceeded")


### PR DESCRIPTION
Workflow runs are created before quota authorization and call initiation. When either step failed, the rejection went back to the telephony provider or API caller but nothing was recorded on the run itself — it sat in 'initialized' state forever with an empty detail page, giving the run's owner no way to see what went wrong (e.g. run 597930: inbound call rejected for insufficient Dograh credits with no trace in the run).

Add mark_workflow_run_failed(), which completes the run and writes the error into gathered_context (the campaign dispatcher's existing convention, already rendered on the run detail page), and call it from every path that creates a run and can then fail before the call starts:

- POST /telephony/initiate-call: quota failure and initiate_call failure
- /telephony/inbound/run dispatcher: quota failure and start failures
- legacy per-workflow inbound handler: quota failure and start failures
- public agent trigger/workflow routes: quota and initiate_call failure
- agent-stream websocket: quota failure
- ARI inbound StasisStart: quota failure and setup failures

The helper is best-effort and never raises so bookkeeping can't mask the original rejection path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface pre-call failures on workflow runs by recording the error, completing the run, and triggering post-run webhooks, so owners see why it failed instead of staying stuck in "initialized." Applies to quota and call start failures across outbound, inbound, agent-stream, and ARI paths.

- **Bug Fixes**
  - Added `mark_workflow_run_failed` to write the error to `gathered_context`, add a realtime feedback event, complete the run, and enqueue `RUN_INTEGRATIONS_POST_WORKFLOW_RUN`; best-effort and non-throwing.
  - Wired into failures before call start across: outbound initiate-call, public agent trigger/workflow routes, inbound dispatcher/legacy handler, `agent-stream` websocket, and ARI `StasisStart`.

<sup>Written for commit 08062ac1ba8dd2777fb45190ffcc70c815219064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds best-effort workflow-run finalization for pre-call failures.
- Records quota and call-start errors as completed runs with error disposition and a real-time feedback event.
- Enqueues post-run integrations after successfully recording a failure.
- Applies the helper across outbound, inbound, agent-stream, public-agent, and ARI call entry points.
- Adds focused tests for the helper and selected route integrations.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because public-agent endpoint resolution and two ARI external-media failure branches can still strand workflow runs.

The new helper covers many pre-call rejection paths, but backend endpoint resolution still re-raises after run creation without finalization, while ARI missing or mismatched external-media IDs return normally and therefore bypass the new outer exception handler.

**Files Needing Attention:** api/routes/public_agent.py; api/services/telephony/ari_manager.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the pre-change behavior where the helper persisted completion and the error but did not emit a realtime event or enqueue integrations.
- Validated that run 597930 persisted all expected fields and enqueued run\_integrations\_post\_workflow\_run with the run ID.
- Confirmed that a database failure returned normally without enqueueing, and that a Redis enqueue failure also returned normally after the database update.
- Observed that every proof log records its exact command, working directory, and exit code.

<a href="https://app.greptile.com/trex/runs/16361982/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/services/workflow_run_failure.py | Adds a best-effort helper that completes failed pre-call runs, persists diagnostic context and feedback, and queues integrations. |
| api/routes/public_agent.py | Adds finalization for quota and provider-initiation failures, but the previously reported backend endpoint-resolution path remains unfinalized. |
| api/services/telephony/ari_manager.py | Adds finalization to the outer inbound exception path, but the previously reported normal-return setup failures still bypass it. |
| api/routes/telephony.py | Finalizes outbound and inbound workflow runs when quota authorization or call setup fails. |
| api/routes/agent_stream.py | Finalizes agent-stream runs when quota authorization rejects the call. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Create workflow run] --> B[Authorize quota]
  B -->|Denied| C[Mark run completed with error]
  B -->|Allowed| D[Resolve call setup]
  D -->|Failure| C
  D -->|Success| E[Start call pipeline]
  C --> F[Enqueue post-run integrations]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: hit webhook on call failures"](https://github.com/dograh-hq/dograh/commit/08062ac1ba8dd2777fb45190ffcc70c815219064) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48244329)</sub>

<!-- /greptile_comment -->