### PR TITLE
chore: tag variable extraction and QA LLM usage

### DIFF
--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -640,6 +640,12 @@ async def _run_pipeline_impl(
     else:
         user_config = resolved_user_config
 
+    workflow_graph = WorkflowGraph(
+        ReactFlowDTO.model_validate(run_workflow_json),
+        skip_instance_constraints_for={"trigger"},
+    )
+    uses_variable_extraction = workflow_graph.uses_variable_extraction()
+
     from api.services.managed_model_services import (
         MPS_CORRELATION_ID_CONTEXT_KEY,
         ensure_mps_correlation_id,
@@ -683,6 +689,20 @@ async def _run_pipeline_impl(
         llm = create_llm_service(user_config, correlation_id=mps_correlation_id)
         inference_llm = None
 
+    # A shared LLM cannot carry an extraction usage_context without also tagging
+    # normal conversation or context-summarization requests. Create a dedicated
+    # client only for the managed provider; other providers ignore usage_context.
+    variable_extraction_llm = (
+        create_llm_service(
+            user_config,
+            correlation_id=mps_correlation_id,
+            usage_context="variable_extraction",
+        )
+        if uses_variable_extraction
+        and user_config.llm.provider == ServiceProviders.DOGRAH.value
+        else inference_llm or llm
+    )
+
     # Stamp the providers/models actually resolved for this run onto
     # initial_context so they're available for post-call analytics
     # (model_overrides may have shifted them away from the org-level
@@ -711,11 +731,6 @@ async def _run_pipeline_impl(
     }
     await db_client.update_workflow_run(
         workflow_run_id, initial_context=merged_call_context_vars
-    )
-
-    workflow_graph = WorkflowGraph(
-        ReactFlowDTO.model_validate(run_workflow_json),
-        skip_instance_constraints_for={"trigger"},
     )
 
     # Pre-call fetch: fire early so it runs concurrently with remaining setup
@@ -817,6 +832,7 @@ async def _run_pipeline_impl(
     engine = PipecatEngine(
         llm=llm,
         inference_llm=inference_llm,
+        variable_extraction_llm=variable_extraction_llm,
         workflow=workflow_graph,
         call_context_vars=merged_call_context_vars,
         workflow_run_id=workflow_run_id,

--- a/api/services/workflow/pipecat_engine.py
+++ b/api/services/workflow/pipecat_engine.py
@@ -63,6 +63,7 @@ class PipecatEngine:
         task: Optional[PipelineWorker] = None,
         llm: Optional["LLMService"] = None,
         inference_llm: Optional["LLMService"] = None,
+        variable_extraction_llm: Optional["LLMService"] = None,
         context: Optional[LLMContext] = None,
         workflow: WorkflowGraph,
         call_context_vars: dict,
@@ -87,6 +88,9 @@ class PipecatEngine:
         # that does not implement run_inference, so a separate text LLM
         # must be passed in.
         self.inference_llm = inference_llm or llm
+        # Variable extraction can use a separately tagged managed-model client
+        # without rerouting normal conversation or context-summarization calls.
+        self.variable_extraction_llm = variable_extraction_llm or self.inference_llm
         self.context = context
         self.workflow = workflow
         self._call_context_vars = call_context_vars

--- a/api/services/workflow/pipecat_engine_variable_extractor.py
+++ b/api/services/workflow/pipecat_engine_variable_extractor.py
@@ -203,12 +203,14 @@ class VariableExtractionManager:
         # current node's system prompt that build_chat_completion_params
         # would otherwise prepend.
         # ------------------------------------------------------------------
-        llm_response = await self._engine.inference_llm.run_inference(
+        llm_response = await self._engine.variable_extraction_llm.run_inference(
             extraction_context, system_instruction=system_prompt
         )
 
         # Get model name for tracing
-        model_name = getattr(self._engine.inference_llm, "model_name", "unknown")
+        model_name = getattr(
+            self._engine.variable_extraction_llm, "model_name", "unknown"
+        )
 
         if ensure_tracing():
             tracer = trace.get_tracer("pipecat")
@@ -221,7 +223,7 @@ class VariableExtractionManager:
                 ]
                 add_llm_span_attributes(
                     span,
-                    service_name=self._engine.inference_llm.__class__.__name__,
+                    service_name=self._engine.variable_extraction_llm.__class__.__name__,
                     model=model_name,
                     operation_name="llm-variable-extraction",
                     messages=tracing_messages,

--- a/api/services/workflow/qa/analysis.py
+++ b/api/services/workflow/qa/analysis.py
@@ -16,7 +16,7 @@ from api.services.workflow.qa.conversation import (
     format_transcript,
     split_events_by_node,
 )
-from api.services.workflow.qa.llm_config import resolve_llm_config
+from api.services.workflow.qa.llm_config import QA_USAGE_CONTEXT, resolve_llm_config
 from api.services.workflow.qa.metrics import compute_call_metrics
 from api.services.workflow.qa.node_summary import (
     CONVERSATION_SUMMARY_SYSTEM_PROMPT,
@@ -140,7 +140,12 @@ async def run_per_node_qa_analysis(
         getattr(workflow_run, "initial_context", None)
     )
     llm = create_llm_service_from_provider(
-        provider, model, api_key, correlation_id=mps_correlation_id, **service_kwargs
+        provider,
+        model,
+        api_key,
+        correlation_id=mps_correlation_id,
+        usage_context=QA_USAGE_CONTEXT,
+        **service_kwargs,
     )
 
     node_results: dict[str, Any] = {}
@@ -304,7 +309,12 @@ async def _run_whole_call_qa_analysis(
         getattr(workflow_run, "initial_context", None)
     )
     llm = create_llm_service_from_provider(
-        provider, model, api_key, correlation_id=mps_correlation_id, **service_kwargs
+        provider,
+        model,
+        api_key,
+        correlation_id=mps_correlation_id,
+        usage_context=QA_USAGE_CONTEXT,
+        **service_kwargs,
     )
 
     try:

--- a/api/services/workflow/qa/llm_config.py
+++ b/api/services/workflow/qa/llm_config.py
@@ -5,6 +5,8 @@ import random
 from api.db.models import WorkflowRunModel
 from api.services.workflow.dto import QANodeData
 
+QA_USAGE_CONTEXT = "qa_analysis"
+
 
 async def resolve_llm_config(
     qa_data: QANodeData, workflow_run: WorkflowRunModel

--- a/api/services/workflow/qa/node_summary.py
+++ b/api/services/workflow/qa/node_summary.py
@@ -10,7 +10,7 @@ from api.db.models import WorkflowRunModel
 from api.services.managed_model_services import get_mps_correlation_id
 from api.services.pipecat.service_factory import create_llm_service_from_provider
 from api.services.workflow.dto import NodeType, QANodeData
-from api.services.workflow.qa.llm_config import resolve_llm_config
+from api.services.workflow.qa.llm_config import QA_USAGE_CONTEXT, resolve_llm_config
 from api.services.workflow.qa.tracing import create_node_summary_trace
 
 NODE_SUMMARY_SYSTEM_PROMPT = (
@@ -83,7 +83,12 @@ async def ensure_node_summaries(
         getattr(workflow_run, "initial_context", None)
     )
     llm = create_llm_service_from_provider(
-        provider, model, api_key, correlation_id=mps_correlation_id, **service_kwargs
+        provider,
+        model,
+        api_key,
+        correlation_id=mps_correlation_id,
+        usage_context=QA_USAGE_CONTEXT,
+        **service_kwargs,
     )
 
     updated_summaries = dict(existing_summaries)

--- a/api/services/workflow/text_chat_runner.py
+++ b/api/services/workflow/text_chat_runner.py
@@ -31,6 +31,7 @@ from pipecat.utils.run_context import set_current_org_id
 
 from api.db import db_client
 from api.enums import WorkflowRunMode, WorkflowRunState
+from api.services.configuration.registry import ServiceProviders
 from api.services.pipecat.audio_config import create_audio_config
 from api.services.pipecat.pipeline_builder import create_pipeline_task
 from api.services.pipecat.pipeline_metrics_aggregator import (
@@ -463,6 +464,12 @@ async def execute_text_chat_pending_turn(
     )
     if user_config.llm is None:
         raise ValueError("Text chat requires an LLM configuration")
+
+    workflow_graph = WorkflowGraph(
+        ReactFlowDTO.model_validate(run_definition.workflow_json),
+        skip_instance_constraints_for={"trigger"},
+    )
+
     from api.services.managed_model_services import (
         MPS_CORRELATION_ID_CONTEXT_KEY,
         ensure_mps_correlation_id,
@@ -477,6 +484,16 @@ async def execute_text_chat_pending_turn(
 
     llm = create_llm_service(user_config, correlation_id=mps_correlation_id)
     inference_llm = llm
+    variable_extraction_llm = (
+        create_llm_service(
+            user_config,
+            correlation_id=mps_correlation_id,
+            usage_context="variable_extraction",
+        )
+        if workflow_graph.uses_variable_extraction()
+        and user_config.llm.provider == ServiceProviders.DOGRAH.value
+        else llm
+    )
 
     runtime_configuration = {
         "llm_provider": user_config.llm.provider,
@@ -493,10 +510,6 @@ async def execute_text_chat_pending_turn(
         initial_context=initial_context,
     )
 
-    workflow_graph = WorkflowGraph(
-        ReactFlowDTO.model_validate(run_definition.workflow_json),
-        skip_instance_constraints_for={"trigger"},
-    )
     base_checkpoint = _resolve_checkpoint_for_pending_turn(session_data, checkpoint)
     context = LLMContext()
     context.set_messages(
@@ -556,6 +569,7 @@ async def execute_text_chat_pending_turn(
     engine = PipecatEngine(
         llm=llm,
         inference_llm=inference_llm,
+        variable_extraction_llm=variable_extraction_llm,
         context=context,
         workflow=workflow_graph,
         call_context_vars=initial_context,

--- a/api/services/workflow/workflow_graph.py
+++ b/api/services/workflow/workflow_graph.py
@@ -262,6 +262,13 @@ class WorkflowGraph:
         except IndexError:
             self.global_node_id = None
 
+    def uses_variable_extraction(self) -> bool:
+        """Return whether any node has a usable variable-extraction config."""
+        return any(
+            node.extraction_enabled and node.extraction_variables
+            for node in self.nodes.values()
+        )
+
     # -----------------------------------------------------------
     # template variable extraction
     # -----------------------------------------------------------

--- a/api/tests/test_dograh_llm_service_factory.py
+++ b/api/tests/test_dograh_llm_service_factory.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from api.services.configuration.registry import ServiceProviders
+from api.services.pipecat.service_factory import create_llm_service
+
+
+def test_create_dograh_llm_service_passes_variable_extraction_usage_context():
+    user_config = SimpleNamespace(
+        llm=SimpleNamespace(
+            provider=ServiceProviders.DOGRAH.value,
+            api_key="mps-key",
+            model="default",
+        )
+    )
+
+    with patch(
+        "api.services.pipecat.service_factory.DograhLLMService"
+    ) as dograh_llm_service:
+        create_llm_service(
+            user_config,
+            correlation_id="corr-123",
+            usage_context="variable_extraction",
+        )
+
+    kwargs = dograh_llm_service.call_args.kwargs
+    assert kwargs["correlation_id"] == "corr-123"
+    assert kwargs["usage_context"] == "variable_extraction"

--- a/api/tests/test_pipecat_engine_variable_extraction.py
+++ b/api/tests/test_pipecat_engine_variable_extraction.py
@@ -12,6 +12,7 @@ The key behavior being tested:
 """
 
 import asyncio
+from types import SimpleNamespace
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, patch
 
@@ -216,3 +217,38 @@ class TestVariableExtractionDuringTransitions:
             f"Expected NO extraction calls for AGENT node (extraction disabled), "
             f"but got {len(agent_extraction_calls)} calls"
         )
+
+
+@pytest.mark.asyncio
+async def test_extraction_uses_dedicated_llm(simple_workflow: WorkflowGraph):
+    """Extraction must not fall back to the conversational LLM when one is supplied."""
+    conversation_llm = SimpleNamespace(run_inference=AsyncMock())
+    extraction_llm = SimpleNamespace(
+        run_inference=AsyncMock(return_value='{"user_intent": "support"}'),
+        model_name="variable-extraction-model",
+    )
+    context = LLMContext(messages=[{"role": "user", "content": "I need help"}])
+    engine = PipecatEngine(
+        llm=conversation_llm,
+        variable_extraction_llm=extraction_llm,
+        context=context,
+        workflow=simple_workflow,
+        call_context_vars={},
+        workflow_run_id=1,
+    )
+    manager = VariableExtractionManager(engine)
+    node = simple_workflow.nodes[simple_workflow.start_node_id]
+
+    with patch(
+        "api.services.workflow.pipecat_engine_variable_extractor.ensure_tracing",
+        return_value=False,
+    ):
+        result = await manager._perform_extraction(
+            node.extraction_variables,
+            parent_ctx=None,
+            extraction_prompt=node.extraction_prompt,
+        )
+
+    assert result == {"user_intent": "support"}
+    extraction_llm.run_inference.assert_awaited_once()
+    conversation_llm.run_inference.assert_not_awaited()

--- a/api/tests/test_qa_analysis_non_dict_response.py
+++ b/api/tests/test_qa_analysis_non_dict_response.py
@@ -30,6 +30,7 @@ async def test_whole_call_qa_tolerates_array_llm_response():
         usage_info={"call_duration_seconds": 12},
     )
     warning_mock = Mock()
+    llm_factory = Mock(return_value=object())
 
     with (
         patch.object(
@@ -43,7 +44,9 @@ async def test_whole_call_qa_tolerates_array_llm_response():
             new=AsyncMock(return_value=("openai", "gpt-4o", "sk-test", {})),
         ),
         patch.object(
-            qa_analysis, "create_llm_service_from_provider", return_value=object()
+            qa_analysis,
+            "create_llm_service_from_provider",
+            llm_factory,
         ),
         patch.object(
             qa_analysis,
@@ -70,3 +73,4 @@ async def test_whole_call_qa_tolerates_array_llm_response():
     assert "run 99" in warning_message
     assert "list" in warning_message
     assert "tag1" not in warning_message
+    assert llm_factory.call_args.kwargs["usage_context"] == "qa_analysis"

--- a/api/tests/test_qa_usage_context.py
+++ b/api/tests/test_qa_usage_context.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from api.services.workflow.qa import analysis, node_summary
+
+
+@pytest.mark.asyncio
+async def test_per_node_qa_uses_qa_analysis_context():
+    qa_data = SimpleNamespace(qa_system_prompt="Review the call")
+    workflow_run = SimpleNamespace(
+        logs={"realtime_feedback_events": [{"type": "transcript"}]},
+        initial_context={},
+    )
+    llm_factory = Mock(return_value=object())
+
+    with (
+        patch.object(
+            analysis,
+            "split_events_by_node",
+            return_value=[("start", "Start", [{"type": "transcript"}])],
+        ),
+        patch.object(
+            analysis,
+            "build_conversation_structure",
+            return_value=[{"role": "user", "content": "hello"}],
+        ),
+        patch.object(analysis, "format_transcript", return_value="user: hello"),
+        patch.object(analysis, "compute_call_metrics", return_value={}),
+        patch.object(
+            analysis,
+            "resolve_llm_config",
+            new=AsyncMock(return_value=("dograh", "default", "mps-key", {})),
+        ),
+        patch.object(
+            analysis,
+            "ensure_node_summaries",
+            new=AsyncMock(return_value={"start": {"summary": "Start node"}}),
+        ),
+        patch.object(analysis, "create_llm_service_from_provider", llm_factory),
+        patch.object(
+            analysis,
+            "_run_llm_inference",
+            new=AsyncMock(return_value='{"tags": [], "summary": "ok"}'),
+        ),
+        patch.object(analysis, "setup_langfuse_parent_context", return_value=None),
+        patch.object(analysis, "add_qa_span_to_trace"),
+    ):
+        await analysis.run_per_node_qa_analysis(
+            qa_data,
+            workflow_run,
+            workflow_run_id=123,
+            workflow_definition={},
+            definition_id=None,
+        )
+
+    assert llm_factory.call_args.kwargs["usage_context"] == "qa_analysis"
+
+
+@pytest.mark.asyncio
+async def test_node_summary_uses_qa_analysis_context():
+    qa_data = SimpleNamespace()
+    workflow_run = SimpleNamespace(initial_context={}, workflow=None)
+    workflow_definition = {
+        "nodes": [
+            {
+                "id": "start",
+                "type": "startCall",
+                "data": {
+                    "name": "Start",
+                    "prompt": "Help the caller",
+                    "tool_uuids": [],
+                },
+            }
+        ],
+        "edges": [],
+    }
+    llm = SimpleNamespace(run_inference=AsyncMock(return_value="A helpful agent"))
+    llm_factory = Mock(return_value=llm)
+
+    with (
+        patch.object(
+            node_summary,
+            "resolve_llm_config",
+            new=AsyncMock(return_value=("dograh", "default", "mps-key", {})),
+        ),
+        patch.object(node_summary, "create_llm_service_from_provider", llm_factory),
+        patch.object(node_summary, "create_node_summary_trace", return_value=None),
+    ):
+        result = await node_summary.ensure_node_summaries(
+            workflow_definition,
+            definition_id=None,
+            workflow_run=workflow_run,
+            qa_data=qa_data,
+        )
+
+    assert result["start"]["summary"] == "A helpful agent"
+    assert llm_factory.call_args.kwargs["usage_context"] == "qa_analysis"


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds usage-context tagging for variable extraction and QA, and routes extraction through a dedicated client when using the managed `ServiceProviders.DOGRAH` provider to avoid tagging normal conversation.

- **New Features**
  - Added a dedicated `variable_extraction_llm` in the engine; created only for `ServiceProviders.DOGRAH` with `usage_context="variable_extraction"` and used by the extractor in both pipeline and text chat paths.
  - Introduced `WorkflowGraph.uses_variable_extraction()` to detect extraction use.
  - Tagged QA analysis and node-summary LLM calls with `usage_context="qa_analysis"` for clearer attribution.

<sup>Written for commit 7d3f77522579f0e754a1b596bb1de167e4f67de7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds usage-context attribution for variable-extraction and QA LLM requests.
- Detects workflows that use variable extraction and routes those requests through a dedicated tagged Dograh LLM client in voice and text-chat execution.
- Passes a shared QA usage context to per-node analysis, whole-call analysis, conversation summaries, and node-summary generation.
- Safely degrades non-object QA LLM responses to empty QA results.
- Adds regression coverage for dedicated extraction clients, provider-factory propagation, QA attribution, and non-object responses.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security failures identified.

Dedicated extraction-client selection matches the runtime extraction predicate, realtime paths retain a text LLM that supports inference, and provider factories intentionally apply usage metadata only to managed Dograh clients while preserving other providers.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the general-contract-validation proof and confirmed a successful run with exit 0 and 6 tests passing, including real Start-to-Agent-to-End transitions and Start-source extraction.
- Installed Speechmatics as the expected collection dependency, and the install occurred once.
- Observed a PostgreSQL persistence warning in the logs, but the pipeline completed without requiring PostgreSQL or Redis.
- Captured the run in logs to enable verification of exit status and test outcomes.

<a href="https://app.greptile.com/trex/runs/16377567/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/services/pipecat/run_pipeline.py | Detects extraction-enabled workflows and supplies a dedicated tagged managed-model client while preserving text-inference fallbacks. |
| api/services/workflow/text_chat_runner.py | Mirrors dedicated variable-extraction LLM routing for text-chat workflow turns. |
| api/services/workflow/workflow_graph.py | Adds a graph-level extraction predicate consistent with the engine’s runtime extraction guard. |
| api/services/workflow/pipecat_engine.py | Stores the optional extraction-specific LLM and safely falls back to the ordinary inference client. |
| api/services/workflow/pipecat_engine_variable_extractor.py | Routes extraction inference and tracing metadata through the extraction-specific client. |
| api/services/workflow/qa/analysis.py | Tags QA inference requests and safely handles top-level non-object JSON responses. |
| api/services/workflow/qa/node_summary.py | Tags node-summary generation as QA usage. |
| api/services/workflow/qa/llm_config.py | Defines the shared QA usage-context label. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Workflow definition] --> B{Uses variable extraction?}
  B -->|No| C[Shared conversation or inference LLM]
  B -->|Yes, Dograh provider| D[Dedicated LLM client]
  D --> E[usage_context: variable_extraction]
  C --> F[PipecatEngine]
  E --> F
  F --> G[VariableExtractionManager]
  H[Completed workflow run] --> I[QA analysis and summaries]
  I --> J[LLM client]
  J --> K[usage_context: qa_analysis]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: tag variable extraction and QA LL..."](https://github.com/dograh-hq/dograh/commit/7d3f77522579f0e754a1b596bb1de167e4f67de7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48283520)</sub>

<!-- /greptile_comment -->