### PR TITLE
fix(ui): serve public embed widget without auth redirect (#585)

### DIFF
--- a/ui/src/middleware.ts
+++ b/ui/src/middleware.ts
@@ -5,8 +5,11 @@ import { getServerBackendUrl } from '@/lib/apiClient';
 
 const OSS_TOKEN_COOKIE = 'dograh_auth_token';
 
-// Paths that don't require authentication in OSS mode
-const PUBLIC_PATHS = ['/auth/login', '/auth/signup'];
+// Paths that don't require authentication in OSS mode.
+// `/embed` serves the public website widget (e.g. /embed/dograh-widget.js),
+// which must be fetchable without a session cookie so third-party sites can
+// embed it — otherwise the middleware 307-redirects the asset to /auth/login.
+const PUBLIC_PATHS = ['/auth/login', '/auth/signup', '/embed'];
 
 let cachedAuthProvider: string | null = null;
 


### PR DESCRIPTION
## Problem
On self-hosted (OSS) deployments the embeddable website widget can't be loaded by third-party sites. Fetching it returns a redirect to the login page:

```
$ curl -ksS -D - https://<host>/embed/dograh-widget.js
HTTP/1.1 307 Temporary Redirect
location: /auth/login
```

Reported in #585 (with a suggested fix — thank you @<reporter>).

## Root cause
`ui/src/middleware.ts` guards routes in OSS (`local` auth) mode. The route matcher excludes image/font extensions but **not `.js`**, so it matches `/embed/dograh-widget.js`; `/embed` isn't in `PUBLIC_PATHS`; and an embedding site sends no `dograh_auth_token` cookie — so the middleware 307-redirects the asset to `/auth/login`. The widget therefore never loads.

## Fix
Add `/embed` to `PUBLIC_PATHS` so the public widget is served without a session cookie. The middleware still runs for the path (matcher unchanged) but returns `next()`.

I chose this **targeted** fix over the alternative of excluding all `.js` from the middleware matcher: the goal is specifically to make the public embed surface reachable, and broadly dropping every `.js` path from the guard is wider than necessary. There's no app route under `/embed` (it's a static public asset), so nothing sensitive is exposed.

## Test
- `curl /embed/dograh-widget.js` now serves the widget (200) instead of 307→`/auth/login`.
- Authenticated app routes still redirect to login when unauthenticated (unchanged).

## Note
The issue also requests a proxy/reverse-proxy-friendly docker-compose (skipping `dograh-init`/`nginx`/`cloudflared`). That's a separate infra change and out of scope here — happy to follow up if maintainers want it.

Fixes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the public embed widget without auth redirects in OSS mode by allowing `/embed` to be fetched without a session. This lets third‑party sites load `/embed/dograh-widget.js` as intended.

- **Bug Fixes**
  - Added `/embed` to `PUBLIC_PATHS` in `ui/src/middleware.ts` to prevent 307 redirects to `/auth/login`.
  - Middleware behavior for all other routes remains unchanged; protected routes still require auth.

<sup>Written for commit f6759bd12dff36f097b4c5a8ae89e6b894af209a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change allows third-party sites to fetch the public embed widget without an OSS session cookie. Local-auth middleware was exercised with an unauthenticated request: the intended `/embed/dograh-widget.js` path remained public, but `/embedded` also bypassed the login redirect. Restrict the exemption to the `/embed` route and its descendants before merging.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until T-Rex findings are addressed.

The embed widget's unauthenticated behavior works as intended, but the reproduced pathname-prefix behavior also permits unrelated sibling paths without a session.

T-Rex reproduced 2 failing behaviors at runtime in ui/src/middleware.ts; the change needs fixes before it is safe to merge.

**Files Needing Attention:** ui/src/middleware.ts needs a segment-boundary check for the `/embed` public route.

<details open><summary><h3>Security Review</h3></summary>

The `/embed` allowlist entry creates an authentication bypass for any route whose pathname begins with `/embed`. In local-auth mode, `/embedded` was reached without a session cookie instead of redirecting to `/auth/login`. A future protected sibling route such as `/embed-settings` would inherit the same bypass.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Generated proof for the posted P1 finding and attached the focused middleware execution log artifact.
- Generated an additional proof for another P1 finding.
- Validated the /embed contract by running the focused middleware harness, confirming the code changes around PUBLIC\_PATHS and path matching, and noting that no repository files were modified.

<a href="https://app.greptile.com/trex/runs/16520095/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **/embed public-path prefix bypasses local authentication for sibling routes**

   - **Bug**
     - The middleware allows any pathname beginning with `/embed`. An unauthenticated `/embedded` request in local-auth mode returned `200` with `x-middleware-next: 1`, rather than a login redirect. The same comparison also applies to paths such as `/embed-settings`.
   - **Cause**
     - `PUBLIC_PATHS` contains `/embed` at line 12 and line 57 checks `pathname.startsWith(p)` without requiring a path-segment boundary.
   - **Fix**
     - Match `/embed` exactly or require the prefix `/embed/` (for example, `pathname === '/embed' || pathname.startsWith('/embed/')`), while retaining the existing exact/public handling for auth routes.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(ui): serve public embed widget witho..."](https://github.com/dograh-hq/dograh/commit/f6759bd12dff36f097b4c5a8ae89e6b894af209a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48569887)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->