### PR TITLE
fix(realtime): speak end-call/transition messages on OpenAI Realtime (#583) [PoC]

### DIFF
--- a/api/services/pipecat/realtime/openai_realtime.py
+++ b/api/services/pipecat/realtime/openai_realtime.py
@@ -25,7 +25,10 @@ from typing import Any
 
 from loguru import logger
 
-from api.services.pipecat.realtime.static_greeting import format_static_greeting_prompt
+from api.services.pipecat.realtime.static_greeting import (
+    format_say_verbatim_prompt,
+    format_static_greeting_prompt,
+)
 from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
@@ -89,10 +92,20 @@ class DograhOpenAIRealtimeLLMService(OpenAIRealtimeLLMService):
                 else:
                     await self._handle_context(self._context)
             else:
-                logger.warning(
-                    f"{self}: TTSSpeakFrame after initial context already "
-                    "handled — OpenAI Realtime owns audio generation, ignoring"
-                )
+                # Fixed-text messages queued after the greeting — end-call
+                # goodbye messages and node-transition lines — must still be
+                # spoken. The realtime model owns audio generation, so we can't
+                # route them through TTS; instead ask the model to say the text
+                # verbatim. Previously these frames were dropped, so the caller
+                # heard nothing even though the message was still written to the
+                # transcript (#583).
+                text = frame.text.strip() if frame.text else ""
+                if text:
+                    await self._speak_verbatim(text)
+                else:
+                    logger.debug(
+                        f"{self}: empty TTSSpeakFrame after initial context, ignoring"
+                    )
             # Don't forward the frame; the audio path is owned by the realtime
             # service itself.
             return
@@ -157,6 +170,31 @@ class DograhOpenAIRealtimeLLMService(OpenAIRealtimeLLMService):
         self._handled_initial_context = True
         self._context = context
         await self._create_initial_greeting_response(greeting_text)
+
+    async def _speak_verbatim(self, text: str):
+        """Have the realtime model say a fixed mid-call line (end-call goodbye
+        or node-transition message) out loud, since these can't go through TTS.
+
+        The end-call flow ends the call with ``abort_immediately=False`` when a
+        message is queued, so the existing wait-for-bot-to-stop-speaking path
+        handles hanging up only after this response finishes.
+        """
+        if self._disconnecting:
+            return
+        if not self._api_session_ready:
+            # No deferral queue for post-greeting messages; a message that
+            # arrives before the session is ready is rare (the greeting has
+            # already completed by then). Log rather than silently drop.
+            logger.warning(
+                f"{self}: verbatim message received before session ready, "
+                f"skipping: {text!r}"
+            )
+            return
+        await self._ensure_conversation_setup()
+        await self._send_manual_response_create(
+            instructions=format_say_verbatim_prompt(text),
+            tool_choice="none",
+        )
 
     async def _create_initial_greeting_response(self, greeting_text: str):
         if self._disconnecting:

--- a/api/services/pipecat/realtime/static_greeting.py
+++ b/api/services/pipecat/realtime/static_greeting.py
@@ -6,3 +6,15 @@ def format_static_greeting_prompt(greeting_text: str) -> str:
         "caller to respond. Do not add anything before or after it.\n\n"
         f'"{greeting_text}"'
     )
+
+
+def format_say_verbatim_prompt(text: str) -> str:
+    """Instruction for a mid-call fixed message (e.g. an end-call goodbye or a
+    node-transition line): say the exact text and nothing else. Unlike the
+    greeting prompt, it makes no assumptions about the call having just
+    connected."""
+    return (
+        "Say the following line out loud, exactly as written, in a natural "
+        "spoken voice. Do not add anything before or after it.\n\n"
+        f'"{text}"'
+    )

--- a/api/tests/test_openai_realtime_end_call_message.py
+++ b/api/tests/test_openai_realtime_end_call_message.py
@@ -1,0 +1,72 @@
+"""PoC test for #583: OpenAI Realtime speaks post-greeting fixed messages.
+
+Verifies the frame-routing fix — that a TTSSpeakFrame arriving after the
+greeting (an end-call goodbye or node-transition line) triggers a forced
+"say this verbatim" response instead of being silently dropped. The live
+audio/ordering behavior still needs verification on a real OpenAI Realtime
+call; this only proves the routing.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pipecat.frames.frames import TTSSpeakFrame
+from pipecat.processors.frame_processor import FrameDirection
+
+from api.services.pipecat.realtime.openai_realtime import (
+    DograhOpenAIRealtimeLLMService,
+)
+from api.services.pipecat.realtime.static_greeting import format_say_verbatim_prompt
+
+
+def _make_service(**overrides):
+    """Build a service instance without running the heavy pipecat __init__,
+    setting only the attributes the TTSSpeakFrame path touches."""
+    svc = object.__new__(DograhOpenAIRealtimeLLMService)
+    svc._name = "DograhOpenAIRealtimeLLMService#test"
+    svc._handled_initial_context = True
+    svc._disconnecting = False
+    svc._api_session_ready = True
+    svc._ensure_conversation_setup = AsyncMock()
+    svc._send_manual_response_create = AsyncMock()
+    for key, value in overrides.items():
+        setattr(svc, key, value)
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_post_greeting_message_is_spoken_verbatim():
+    svc = _make_service()
+    message = "Thanks for calling, goodbye!"
+
+    await svc.process_frame(TTSSpeakFrame(message), FrameDirection.DOWNSTREAM)
+
+    svc._send_manual_response_create.assert_awaited_once()
+    kwargs = svc._send_manual_response_create.await_args.kwargs
+    assert kwargs["tool_choice"] == "none"
+    assert kwargs["instructions"] == format_say_verbatim_prompt(message)
+
+
+@pytest.mark.asyncio
+async def test_empty_post_greeting_message_is_ignored():
+    svc = _make_service()
+
+    await svc.process_frame(TTSSpeakFrame("   "), FrameDirection.DOWNSTREAM)
+
+    svc._send_manual_response_create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_verbatim_message_skipped_before_session_ready():
+    svc = _make_service(_api_session_ready=False)
+
+    await svc.process_frame(TTSSpeakFrame("goodbye"), FrameDirection.DOWNSTREAM)
+
+    svc._send_manual_response_create.assert_not_awaited()
+
+
+def test_say_verbatim_prompt_is_greeting_agnostic():
+    prompt = format_say_verbatim_prompt("Bye now")
+    assert "Bye now" in prompt
+    # Unlike the greeting prompt, it must not assume the call just connected.
+    assert "just connected" not in prompt


### PR DESCRIPTION
> **Scope / status:** proof-of-concept for **OpenAI Realtime only**. The routing is unit-tested, but the live audio + call-end timing can only be validated on a real speech-to-speech call — I have not been able to run that. Opening it as a reviewable first cut; happy to fan out to the other providers once the approach is confirmed and someone can verify on a live provider. See my analysis in #583.

## Problem
With `is_realtime: true`, an end-call tool configured with `messageType: "custom"` never plays its `customMessage` — the caller hears nothing, yet the message is written to the transcript (via `persist_to_logs=True`) so it looks delivered. Cascading (non-realtime) mode works fine.

## Root cause
Each realtime provider special-cases the **first** `TTSSpeakFrame` as the greeting (routing it through `_handle_initial_greeting` → `format_static_greeting_prompt`, which makes the model say the exact text) and then **drops every subsequent one** with an "owns audio generation, ignoring" log. End-call/transition messages are queued as later `TTSSpeakFrame`s, so they hit that dropped path.

## Fix (this PR)
In `DograhOpenAIRealtimeLLMService.process_frame`, post-greeting `TTSSpeakFrame`s are now spoken verbatim via a forced response (`_send_manual_response_create(instructions=format_say_verbatim_prompt(text), tool_choice="none")`) instead of being dropped. Adds `format_say_verbatim_prompt` (a greeting-agnostic variant).

Timing is already handled upstream: `_create_end_call_handler` ends the call with `abort_immediately=False` whenever a message is queued, so the existing "wait until the bot stops speaking" path hangs up only after this response finishes.

## Tests
`tests/test_openai_realtime_end_call_message.py` — a post-greeting message triggers a verbatim response; empty frames are ignored; messages before session-ready are skipped, not crashed. (Routing only — live audio still needs a real-call check.)

## Not in this PR
The same drop exists in `grok_realtime`, `azure_realtime`, `gemini_live`, and `ultravox_realtime`, each with its own response API — intentionally left for follow-up so this stays small and reviewable.

Refs #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speak end‑call and node‑transition messages during OpenAI Realtime calls instead of dropping them. This prevents silent hangups where the transcript showed a message was delivered.

- **Bug Fixes**
  - Post‑greeting `TTSSpeakFrame`s now trigger a manual response (`tool_choice: "none"`) using `format_say_verbatim_prompt(...)` so the model says the exact text.
  - Added `format_say_verbatim_prompt` for mid‑call fixed lines.
  - Empty frames are ignored; messages before session‑ready are skipped with a warning.
  - Hangup timing unchanged; the call ends after the spoken message finishes.
  - Scoped to OpenAI Realtime; unit tests cover the routing.

<sup>Written for commit c0b3c03a1cf5e9e5bbc497948db4e8e033957788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds OpenAI Realtime support for speaking fixed post-greeting messages such as node-transition lines and end-call goodbyes. Execution against the frame router reproduced two delivery failures: a message arriving while the initial greeting waits for session readiness is discarded, and back-to-back messages create overlapping Realtime responses so a later message can be rejected. Do not merge until fixed speech is retained through session initialization and serialized across response completion.

### T-Rex validation blocked
The repository's focused pytest command could not collect in the reconstructed runtime because the `dotenv` package was missing. The dedicated frame-routing harness completed successfully and reproduced both reported failures. [Configure VMs](https://app.greptile.com/-/settings/trex#environments)

<h3>Confidence Score: 3/5</h3>

Not safe to merge because the new fixed-speech path can drop caller-facing messages in normal session-start and multi-message flows.

Two independent failures were reproduced in the core behavior added by this change: one drops speech before session readiness, and the other sends overlapping responses instead of preserving message order.

**Files Needing Attention:** `api/services/pipecat/realtime/openai_realtime.py` needs deferred-message handling and response serialization; the focused tests should cover both timing paths.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proofs for a posted P1 finding, including a focused validation script and harness output that demonstrate the race condition in the TTSSpeakFrame race.
- T-Rex performed a general contract validation, running the reproduced command and inspecting harness outputs that show the fixed message was lost and how the OpenAI error handling behaves.

<a href="https://app.greptile.com/trex/runs/16525832/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Post-greeting speech is dropped while the initial greeting waits for session readiness**

   - **Bug**
     - A greeting TTSSpeakFrame sets `_handled_initial_context=True` and stores `_pending_initial_greeting_text`. If another fixed TTSSpeakFrame arrives before `_api_session_ready`, `process_frame` routes it to `_speak_verbatim`, which explicitly logs `skipping` and returns. When the session updates, only the greeting is sent; the fixed message is neither queued nor retried.
   - **Cause**
     - `_speak_verbatim` has no deferred-message queue or pending state for the not-ready branch, even though the greeting path has `_pending_initial_greeting_text` handling.
   - **Fix**
     - Queue post-greeting fixed texts received before readiness and drain them only after the initial greeting response has completed (or serialize them through a single response scheduler). Do not clear/drop the queue on `session.updated`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Back-to-back fixed TTSSpeakFrames issue concurrent OpenAI Realtime response.create requests**

   - **Bug**
     - With `_handled_initial_context=True` and `_api_session_ready=True`, two fixed TTSSpeakFrames synchronously invoke `_send_manual_response_create` twice before any response completion. The produced events target the default conversation and have no `conversation='none'` setting. OpenAI permits only one active response for that conversation, so the second create is rejected with `conversation_already_has_active_response`, losing the second fixed message.
   - **Cause**
     - `_speak_verbatim` has no active-response tracking, response-completion hook, queue, cancellation behavior, or locking; `_send_manual_response_create` always sends a new `ResponseCreateEvent`.
   - **Fix**
     - Serialize fixed messages: maintain a FIFO queue and active forced-response state, send the next item only after `response.done` for the current forced response, and clear/reconcile it on cancellation/disconnect. Alternatively explicitly cancel and replace only where interruption is desired.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(realtime): speak end-call/transition..."](https://github.com/dograh-hq/dograh/commit/c0b3c03a1cf5e9e5bbc497948db4e8e033957788) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48579968)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->