### PR TITLE
feat(telephony): capability-token auth for the media WebSocket (#598)

### DIFF
--- a/api/constants.py
+++ b/api/constants.py
@@ -99,6 +99,20 @@ POSTHOG_HOST = os.getenv("POSTHOG_HOST", "https://us.i.posthog.com")
 ENABLE_ARI_STASIS = os.getenv("ENABLE_ARI_STASIS", "false").lower() == "true"
 SERIALIZE_LOG_OUTPUT = os.getenv("SERIALIZE_LOG_OUTPUT", "false").lower() == "true"
 
+# ── Telephony media WebSocket authentication ────────────────────────────────
+# The carrier/connector dials back the media socket
+# /api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}, whose
+# id triple is otherwise a guessable bearer capability. When a secret is set,
+# providers append an HMAC ``?token=`` to that URL and the handler verifies it
+# (see api/services/telephony/ws_auth.py). Two-phase, backward-compatible rollout:
+#   * secret unset            -> feature off, URLs unchanged (default)
+#   * secret set, enforce off -> tokens minted + verified; invalid ones only logged
+#   * secret set, enforce on  -> invalid/missing tokens rejected (WS close 4401)
+TELEPHONY_WS_TOKEN_SECRET = os.getenv("TELEPHONY_WS_TOKEN_SECRET") or None
+TELEPHONY_WS_TOKEN_ENFORCE = (
+    os.getenv("TELEPHONY_WS_TOKEN_ENFORCE", "false").lower() == "true"
+)
+
 # Logging configuration
 LOG_FILE_PATH = os.getenv("LOG_FILE_PATH", None)
 LOG_LEVEL = os.getenv("LOG_LEVEL", "DEBUG").upper()

--- a/api/routes/telephony.py
+++ b/api/routes/telephony.py
@@ -38,6 +38,7 @@ from api.services.telephony.factory import (
     get_telephony_provider_by_id,
     get_telephony_provider_for_run,
 )
+from api.services.telephony import ws_auth
 from api.services.telephony.transfer_event_protocol import (
     TransferEvent,
     TransferEventType,
@@ -609,6 +610,28 @@ async def _handle_telephony_websocket(
         # Set the run context
         set_current_run_id(workflow_run_id)
 
+        # Capability-token check. The id triple in the URL is otherwise a
+        # guessable bearer capability (see the TODO above and ws_auth.py). This
+        # is a no-op until an operator sets TELEPHONY_WS_TOKEN_SECRET; once set,
+        # invalid tokens are logged, and rejected only when enforcement is on.
+        if ws_auth.token_configured():
+            token = websocket.query_params.get("token")
+            if not ws_auth.verify_ws_token(
+                workflow_id, organization_id, workflow_run_id, token
+            ):
+                if ws_auth.enforcement_enabled():
+                    logger.warning(
+                        f"[telephony ws] rejecting unauthenticated connection for "
+                        f"run {workflow_run_id} (org {organization_id})"
+                    )
+                    await websocket.close(code=4401, reason="Unauthorized")
+                    return
+                logger.warning(
+                    f"[telephony ws] UNVERIFIED media socket for run {workflow_run_id} "
+                    f"(org {organization_id}); allowed because TELEPHONY_WS_TOKEN_ENFORCE "
+                    f"is off — set it to enforce"
+                )
+
         # Get workflow run to determine provider type
         workflow_run = await db_client.get_workflow_run(
             workflow_run_id, organization_id=organization_id
@@ -881,9 +904,8 @@ async def handle_inbound_run(request: Request):
                 )
 
             backend_endpoint, wss_backend_endpoint = await get_backend_endpoints()
-            websocket_url = (
-                f"{wss_backend_endpoint}/api/v1/telephony/ws/"
-                f"{workflow_id}/{config.organization_id}/{workflow_run_id}"
+            websocket_url = ws_auth.build_media_ws_url(
+                wss_backend_endpoint, workflow_id, config.organization_id, workflow_run_id
             )
 
             return await provider_instance.start_inbound_stream(
@@ -1055,9 +1077,8 @@ async def handle_inbound_telephony(
 
             # Generate response URLs
             backend_endpoint, wss_backend_endpoint = await get_backend_endpoints()
-            websocket_url = (
-                f"{wss_backend_endpoint}/api/v1/telephony/ws/"
-                f"{workflow_id}/{organization_id}/{workflow_run_id}"
+            websocket_url = ws_auth.build_media_ws_url(
+                wss_backend_endpoint, workflow_id, organization_id, workflow_run_id
             )
 
             response = await provider_instance.start_inbound_stream(

--- a/api/services/telephony/ari_manager.py
+++ b/api/services/telephony/ari_manager.py
@@ -505,11 +505,22 @@ class ARIConnection:
         """
         # v() appends URI query params to the websocket_client.conf URL
         # e.g. wss://api.dograh.com/ws/ari?workflow_id=1&organization_id=2&workflow_run_id=3
-        transport_data = (
-            f"v(workflow_id={workflow_id},"
+        from api.services.telephony import ws_auth
+
+        vparams = (
+            f"workflow_id={workflow_id},"
             f"organization_id={self.organization_id},"
-            f"workflow_run_id={workflow_run_id})"
+            f"workflow_run_id={workflow_run_id}"
         )
+        # Mint the same capability token the carrier providers use, so ARI media
+        # survives TELEPHONY_WS_TOKEN_ENFORCE (the shared handler verifies every
+        # /ws connection, including /ws/ari). No-op unless a secret is configured.
+        ws_token = ws_auth.mint_ws_token(
+            workflow_id, self.organization_id, workflow_run_id
+        )
+        if ws_token:
+            vparams += f",token={ws_token}"
+        transport_data = f"v({vparams})"
 
         params = {
             "app": self.app_name,

--- a/api/services/telephony/providers/cloudonix/provider.py
+++ b/api/services/telephony/providers/cloudonix/provider.py
@@ -126,13 +126,18 @@ class CloudonixProvider(TelephonyProvider):
 
         # Prepare call data using Cloudonix callObject schema
         # Note: 'caller-id' is REQUIRED by Cloudonix API
+        from api.services.telephony import ws_auth
+
         backend_endpoint, wss_backend_endpoint = await get_backend_endpoints()
+        ws_url = ws_auth.build_media_ws_url(
+            wss_backend_endpoint, workflow_id, organization_id, workflow_run_id
+        )
         data: Dict[str, Any] = {
             "destination": to_number,
             "cxml": f"""<?xml version="1.0" encoding="UTF-8"?>
 <Response>
     <Connect>
-        <Stream url="{wss_backend_endpoint}/api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}"></Stream>
+        <Stream url="{ws_url}"></Stream>
     </Connect>
     <Pause length="40"/>
 </Response>""",

--- a/api/services/telephony/providers/plivo/provider.py
+++ b/api/services/telephony/providers/plivo/provider.py
@@ -239,11 +239,16 @@ class PlivoProvider(TelephonyProvider):
     async def get_webhook_response(
         self, workflow_id: int, organization_id: int, workflow_run_id: int
     ) -> str:
+        from api.services.telephony import ws_auth
+
         _, wss_backend_endpoint = await get_backend_endpoints()
+        ws_url = ws_auth.build_media_ws_url(
+            wss_backend_endpoint, workflow_id, organization_id, workflow_run_id
+        )
 
         return f"""<?xml version="1.0" encoding="UTF-8"?>
 <Response>
-    <Stream bidirectional="true" keepCallAlive="true" contentType="audio/x-mulaw;rate=8000">{wss_backend_endpoint}/api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}</Stream>
+    <Stream bidirectional="true" keepCallAlive="true" contentType="audio/x-mulaw;rate=8000">{ws_url}</Stream>
 </Response>"""
 
     async def get_call_cost(self, call_id: str) -> Dict[str, Any]:

--- a/api/services/telephony/providers/telnyx/provider.py
+++ b/api/services/telephony/providers/telnyx/provider.py
@@ -99,11 +99,12 @@ class TelnyxProvider(TelephonyProvider):
         backend_endpoint, wss_backend_endpoint = await get_backend_endpoints()
 
         # Build the WebSocket stream URL for inline audio streaming
+        from api.services.telephony import ws_auth
+
         workflow_id = kwargs.get("workflow_id")
         organization_id = kwargs.get("organization_id")
-        stream_url = (
-            f"{wss_backend_endpoint}/api/v1/telephony/ws"
-            f"/{workflow_id}/{organization_id}/{workflow_run_id}"
+        stream_url = ws_auth.build_media_ws_url(
+            wss_backend_endpoint, workflow_id, organization_id, workflow_run_id
         )
 
         # Build the webhook URL for status callbacks

--- a/api/services/telephony/providers/twilio/provider.py
+++ b/api/services/telephony/providers/twilio/provider.py
@@ -169,12 +169,17 @@ class TwilioProvider(TelephonyProvider):
         """
         Generate TwiML response for starting a call session.
         """
+        from api.services.telephony import ws_auth
+
         _, wss_backend_endpoint = await get_backend_endpoints()
+        ws_url = ws_auth.build_media_ws_url(
+            wss_backend_endpoint, workflow_id, organization_id, workflow_run_id
+        )
 
         twiml_content = f"""<?xml version="1.0" encoding="UTF-8"?>
 <Response>
     <Connect>
-        <Stream url="{wss_backend_endpoint}/api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}"></Stream>
+        <Stream url="{ws_url}"></Stream>
     </Connect>
     <Pause length="40"/>
 </Response>"""

--- a/api/services/telephony/providers/vobiz/provider.py
+++ b/api/services/telephony/providers/vobiz/provider.py
@@ -263,11 +263,16 @@ class VobizProvider(TelephonyProvider):
         - audioTrack: Which audio to stream (inbound, outbound, both)
         - contentType: audio/x-mulaw;rate=8000
         """
+        from api.services.telephony import ws_auth
+
         _, wss_backend_endpoint = await get_backend_endpoints()
+        ws_url = ws_auth.build_media_ws_url(
+            wss_backend_endpoint, workflow_id, organization_id, workflow_run_id
+        )
 
         vobiz_xml = f"""<?xml version="1.0" encoding="UTF-8"?>
 <Response>
-    <Stream bidirectional="true" keepCallAlive="true" contentType="audio/x-mulaw;rate=8000">{wss_backend_endpoint}/api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}</Stream>
+    <Stream bidirectional="true" keepCallAlive="true" contentType="audio/x-mulaw;rate=8000">{ws_url}</Stream>
 </Response>"""
         return vobiz_xml
 

--- a/api/services/telephony/providers/vonage/provider.py
+++ b/api/services/telephony/providers/vonage/provider.py
@@ -211,7 +211,12 @@ class VonageProvider(TelephonyProvider):
         Generate NCCO response for starting a call session.
         NCCO (Nexmo Call Control Objects) is JSON-based, unlike TwiML which is XML.
         """
+        from api.services.telephony import ws_auth
+
         _, wss_backend_endpoint = await get_backend_endpoints()
+        ws_url = ws_auth.build_media_ws_url(
+            wss_backend_endpoint, workflow_id, organization_id, workflow_run_id
+        )
 
         # NCCO for WebSocket connection
         ncco = [
@@ -220,7 +225,7 @@ class VonageProvider(TelephonyProvider):
                 "endpoint": [
                     {
                         "type": "websocket",
-                        "uri": f"{wss_backend_endpoint}/api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}",
+                        "uri": ws_url,
                         "content-type": "audio/l16;rate=16000",  # 16kHz Linear PCM
                         "headers": {},
                     }

--- a/api/services/telephony/ws_auth.py
+++ b/api/services/telephony/ws_auth.py
@@ -59,7 +59,13 @@ def verify_ws_token(workflow_id, organization_id, workflow_run_id, token) -> boo
     expected = mint_ws_token(workflow_id, organization_id, workflow_run_id)
     if not expected or not token:
         return False
-    return hmac.compare_digest(expected, token)
+    try:
+        # Compare as bytes: hmac.compare_digest rejects non-ASCII *str* args with
+        # TypeError, and ``token`` is attacker-controlled from the query string.
+        # Anything that can't be compared is simply an invalid token, not a 500.
+        return hmac.compare_digest(expected.encode("utf-8"), token.encode("utf-8"))
+    except (TypeError, UnicodeError):
+        return False
 
 
 def build_media_ws_url(wss_base, workflow_id, organization_id, workflow_run_id) -> str:

--- a/api/services/telephony/ws_auth.py
+++ b/api/services/telephony/ws_auth.py
@@ -1,0 +1,78 @@
+"""Capability-token authentication for the telephony media WebSocket.
+
+The media socket ``/api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}``
+is dialed back by the carrier/connector, so its URL is caller-visible and the id
+triple alone is a *guessable bearer capability*: anyone who supplies a valid
+triple can open the socket and drive the run.
+
+When ``TELEPHONY_WS_TOKEN_SECRET`` is configured, the URL is minted with an HMAC
+``?token=`` that the handler verifies. An attacker can then no longer connect by
+guessing ids — only by holding the server secret. This is a stateless capability
+token (HMAC over the id triple); it deliberately does *not* attempt the one-shot
+redemption / state-race hardening the handler's ``TODO(security)`` sketches, which
+needs a run-creation schema change and is left to a follow-up.
+
+Backward-compatible by construction: with no secret set, :func:`build_media_ws_url`
+returns exactly the legacy URL and :func:`verify_ws_token` is never consulted, so
+adopting the builder in a provider is a no-op until an operator opts in.
+"""
+
+import hashlib
+import hmac
+from urllib.parse import urlencode
+
+from api import constants
+
+_WS_PATH = "/api/v1/telephony/ws"
+
+
+def token_configured() -> bool:
+    """True when a secret is set, i.e. the feature is enabled."""
+    return bool(constants.TELEPHONY_WS_TOKEN_SECRET)
+
+
+def enforcement_enabled() -> bool:
+    """True when an invalid/missing token should reject the connection."""
+    return bool(constants.TELEPHONY_WS_TOKEN_ENFORCE)
+
+
+def _canonical(workflow_id, organization_id, workflow_run_id) -> str:
+    return f"{workflow_id}:{organization_id}:{workflow_run_id}"
+
+
+def mint_ws_token(workflow_id, organization_id, workflow_run_id):
+    """Return the HMAC-SHA256 capability token, or ``None`` when no secret is set."""
+    secret = constants.TELEPHONY_WS_TOKEN_SECRET
+    if not secret:
+        return None
+    msg = _canonical(workflow_id, organization_id, workflow_run_id).encode()
+    return hmac.new(secret.encode(), msg, hashlib.sha256).hexdigest()
+
+
+def verify_ws_token(workflow_id, organization_id, workflow_run_id, token) -> bool:
+    """Constant-time compare of a presented token against the expected one.
+
+    Returns ``False`` when no secret is configured or no token was presented, so
+    callers should gate on :func:`token_configured` before treating ``False`` as
+    a rejection.
+    """
+    expected = mint_ws_token(workflow_id, organization_id, workflow_run_id)
+    if not expected or not token:
+        return False
+    return hmac.compare_digest(expected, token)
+
+
+def build_media_ws_url(wss_base, workflow_id, organization_id, workflow_run_id) -> str:
+    """Canonical media-WS URL, with ``?token=`` appended when a secret is set.
+
+    With no secret configured this returns the exact legacy URL, so switching a
+    provider over to this helper changes nothing until an operator opts in.
+    """
+    url = (
+        f"{wss_base.rstrip('/')}{_WS_PATH}"
+        f"/{workflow_id}/{organization_id}/{workflow_run_id}"
+    )
+    token = mint_ws_token(workflow_id, organization_id, workflow_run_id)
+    if token:
+        url = f"{url}?{urlencode({'token': token})}"
+    return url

--- a/api/tests/telephony/test_ws_auth.py
+++ b/api/tests/telephony/test_ws_auth.py
@@ -50,6 +50,27 @@ def test_verify_roundtrip_and_tamper(secret):
     assert ws_auth.verify_ws_token(7, 3, 42, "") is False
 
 
+def test_non_ascii_token_is_invalid_not_error(secret):
+    # `token` is attacker-controlled from the query string; a non-ASCII value
+    # must return False, not raise (which would 500 the socket and skip the
+    # audit/enforcement path). Regression for cubic P2 on #599.
+    tok = ws_auth.mint_ws_token(7, 3, 42)
+    assert ws_auth.verify_ws_token(7, 3, 42, "café☕") is False
+    assert ws_auth.verify_ws_token(7, 3, 42, "🔑" * 10) is False
+    # A genuine token still verifies after the byte-compare change.
+    assert ws_auth.verify_ws_token(7, 3, 42, tok) is True
+
+
+def test_str_and_int_ids_produce_same_token(secret):
+    # The ARI path mints with string ids (v() dial params) while the shared
+    # handler verifies with int path/query params. f-string rendering makes them
+    # identical, so the ARI token must verify under the int triple. Regression
+    # for cubic P1 on #599 (ARI enforcement outage).
+    ari_token = ws_auth.mint_ws_token("7", 3, "42")   # ARI: workflow_id/run are str
+    assert ari_token == ws_auth.mint_ws_token(7, 3, 42)
+    assert ws_auth.verify_ws_token(7, 3, 42, ari_token) is True
+
+
 def test_token_bound_to_secret(monkeypatch):
     monkeypatch.setattr(constants, "TELEPHONY_WS_TOKEN_SECRET", "secret-a")
     a = ws_auth.mint_ws_token(7, 3, 42)

--- a/api/tests/telephony/test_ws_auth.py
+++ b/api/tests/telephony/test_ws_auth.py
@@ -1,0 +1,67 @@
+"""Capability-token auth for the telephony media WebSocket (issue #598).
+
+The media socket's id triple is otherwise a guessable bearer capability; when a
+secret is configured, the URL carries an HMAC ?token= the handler verifies.
+These cover the stateless crypto/URL logic — the security-critical surface.
+"""
+import pytest
+
+from api import constants
+from api.services.telephony import ws_auth
+
+
+@pytest.fixture
+def secret(monkeypatch):
+    monkeypatch.setattr(constants, "TELEPHONY_WS_TOKEN_SECRET", "unit-test-secret")
+    monkeypatch.setattr(constants, "TELEPHONY_WS_TOKEN_ENFORCE", False)
+
+
+@pytest.fixture
+def no_secret(monkeypatch):
+    monkeypatch.setattr(constants, "TELEPHONY_WS_TOKEN_SECRET", None)
+
+
+def test_disabled_when_no_secret(no_secret):
+    assert ws_auth.token_configured() is False
+    assert ws_auth.mint_ws_token(7, 3, 42) is None
+    # Byte-for-byte the legacy URL -> adopting the builder is a no-op until opt-in.
+    assert (ws_auth.build_media_ws_url("wss://x", 7, 3, 42)
+            == "wss://x/api/v1/telephony/ws/7/3/42")
+    # verify() is always False when disabled; callers gate on token_configured().
+    assert ws_auth.verify_ws_token(7, 3, 42, "anything") is False
+
+
+def test_url_carries_token_when_secret_set(secret):
+    assert ws_auth.token_configured() is True
+    url = ws_auth.build_media_ws_url("wss://x/", 7, 3, 42)  # trailing slash trimmed
+    assert url.startswith("wss://x/api/v1/telephony/ws/7/3/42?token=")
+
+
+def test_verify_roundtrip_and_tamper(secret):
+    tok = ws_auth.mint_ws_token(7, 3, 42)
+    assert ws_auth.verify_ws_token(7, 3, 42, tok) is True
+    # Any id in the triple changing invalidates the token.
+    assert ws_auth.verify_ws_token(7, 3, 43, tok) is False
+    assert ws_auth.verify_ws_token(8, 3, 42, tok) is False
+    assert ws_auth.verify_ws_token(7, 9, 42, tok) is False
+    # Wrong / missing token.
+    assert ws_auth.verify_ws_token(7, 3, 42, "deadbeef") is False
+    assert ws_auth.verify_ws_token(7, 3, 42, None) is False
+    assert ws_auth.verify_ws_token(7, 3, 42, "") is False
+
+
+def test_token_bound_to_secret(monkeypatch):
+    monkeypatch.setattr(constants, "TELEPHONY_WS_TOKEN_SECRET", "secret-a")
+    a = ws_auth.mint_ws_token(7, 3, 42)
+    monkeypatch.setattr(constants, "TELEPHONY_WS_TOKEN_SECRET", "secret-b")
+    b = ws_auth.mint_ws_token(7, 3, 42)
+    assert a != b
+    # A token minted under secret-a must not verify once the secret rotates.
+    assert ws_auth.verify_ws_token(7, 3, 42, a) is False
+
+
+def test_enforcement_flag(monkeypatch):
+    monkeypatch.setattr(constants, "TELEPHONY_WS_TOKEN_ENFORCE", True)
+    assert ws_auth.enforcement_enabled() is True
+    monkeypatch.setattr(constants, "TELEPHONY_WS_TOKEN_ENFORCE", False)
+    assert ws_auth.enforcement_enabled() is False


### PR DESCRIPTION
## What & why

Closes the media-WebSocket trust-boundary gap tracked in #598 (surfaced during the VoxPro provider review, #595). The socket

```
/api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}
```

is dialed back by the carrier/connector, so the id triple in its URL is a **guessable bearer capability** — `_handle_telephony_websocket`'s own `TODO(security)` calls this out. It affects **every** WebSocket-media provider, so the fix lives in the shared handler + a shared URL builder, not in any one provider.

## Approach — stateless HMAC capability token, opt-in, backward-compatible

- **`ws_auth.build_media_ws_url()`** mints the URL with `?token=HMAC-SHA256(secret, "{wid}:{oid}:{rid}")` when `TELEPHONY_WS_TOKEN_SECRET` is set. **With no secret it returns the exact legacy URL**, so switching a provider onto the helper is a no-op until an operator opts in.
- All **9 mint sites** — telnyx, twilio, vonage, cloudonix, plivo, vobiz, and the two inbound routes in `routes/telephony.py` — now build the URL through the helper.
- **`_handle_telephony_websocket`** verifies the token, with a two-phase zero-downtime rollout:

| `TELEPHONY_WS_TOKEN_SECRET` | `TELEPHONY_WS_TOKEN_ENFORCE` | Behavior |
|---|---|---|
| unset (default) | — | feature off, URLs unchanged |
| set | off (default) | tokens minted + verified; invalid ones **logged**, connection allowed |
| set | on | invalid/missing token **rejected** (WS close `4401`) |

So an operator sets the secret first (everything gets a valid token, spoofs get logged), confirms the logs are clean, then flips enforcement.

## Scope / non-goals

This closes **forgeability** — a peer can no longer connect by guessing ids, only by holding the server secret. It intentionally does **not** implement the one-shot-redemption + `initialized -> running` compare-and-swap the `TODO(security)` sketches: that needs a run-creation schema change and also closes a separate state-race, so it's better as its own PR. Happy to follow up with it if you'd like it in the same effort.

Note: **VoxPro (#595)** builds the same URL and will adopt `build_media_ws_url` on rebase once both land — kept out of this diff so this PR stands alone against `main`.

## Tests

`api/tests/telephony/test_ws_auth.py` — 5 cases: mint/verify roundtrip, tamper across each id, secret rotation invalidation, no-secret no-op URL, enforcement flag. The handler gate itself is a small verified branch in the diff (an integration test would want your DB/websocket fixtures).

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add HMAC capability-token auth to the telephony media WebSocket and cover the ARI path to prevent guessable URL access. Opt-in and backward-compatible with staged enforcement. Closes #598.

- **New Features**
  - Added `ws_auth.build_media_ws_url` that appends `?token=HMAC-SHA256(secret, "{workflow_id}:{organization_id}:{workflow_run_id}")`; with no `TELEPHONY_WS_TOKEN_SECRET`, it returns the legacy URL.
  - `_handle_telephony_websocket` verifies tokens; logs invalid when `TELEPHONY_WS_TOKEN_ENFORCE` is off, rejects with 4401 when on; non-ASCII tokens are treated as invalid (no 500).
  - All mint sites now use the helper (telnyx, twilio, vonage, cloudonix, plivo, vobiz, and inbound routes); ARI external-media now mints/forwards the token in `v()` params so `/ws/ari` authenticates under enforcement.
  - Tests cover mint/verify, tamper cases, secret rotation, no-secret no-op URL, enforcement flag, non-ASCII token invalidation, and ARI str/int id equivalence.

- **Migration**
  - Set `TELEPHONY_WS_TOKEN_SECRET` to start minting and verifying tokens (connections still allowed).
  - Monitor logs for unverifiable connections.
  - Enable `TELEPHONY_WS_TOKEN_ENFORCE=true` to reject invalid or missing tokens.

<sup>Written for commit deeb1e20aee27a6d09b5ac2fbc8b7b333e235bcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional HMAC capability-token authentication for telephony media WebSockets. Carrier provider URLs, inbound media URLs, and ARI external-media callbacks now include a token when configured, while installations without a token secret retain the existing URLs.

The focused execution checks exercised token generation and identifier binding, ARI string/integer identifier compatibility, enforced rejection of missing, malformed, non-ASCII, and mismatched tokens, and all changed URL emitters. The predecessor's non-ASCII token path raised a `TypeError`; the current implementation safely rejects that input and closes an enforced connection as unauthorized. No defects were found in the exercised behavior.

Merge safety: safe to merge.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The review-authored WebSocket token contract harness was run against the current repository, exiting with code 0 and exercising token minting, verification, provider URL construction, no-secret compatibility, the shared WebSocket handler under valid, missing, malformed, non-ASCII, and identifier-mismatched inputs, ARI external-media transport data, and all changed emitters, while also revalidating the predecessor verifier at commit 6874d68 where a non-ASCII token raised TypeError and confirming the current code rejects that token with a 4401 Unauthorized response.
- A before-and-after assessment shows the prior non-ASCII failure path at commit 6874d68 is fixed, and the harness run demonstrates all capability-token contracts pass with exit code 0 after the PR.
- Artifacts created to support the review include the standalone PR 599 WebSocket token contract validation script and the baseline and post-PR validation outputs captured by the harness runs.

<a href="https://app.greptile.com/trex/runs/16596644/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(telephony): ARI token minting + non-..."](https://github.com/dograh-hq/dograh/commit/deeb1e20aee27a6d09b5ac2fbc8b7b333e235bcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48706302)</sub>

<!-- /greptile_comment -->