### PR TITLE
fix (middleware): added '/embed' to PUBLIC_PATHS, also strict slash boundary so sibling routes stay protected

### DIFF
--- a/ui/src/middleware.ts
+++ b/ui/src/middleware.ts
@@ -6,7 +6,7 @@ import { getServerBackendUrl } from '@/lib/apiClient';
 const OSS_TOKEN_COOKIE = 'dograh_auth_token';
 
 // Paths that don't require authentication in OSS mode
-const PUBLIC_PATHS = ['/auth/login', '/auth/signup'];
+const PUBLIC_PATHS = ['/auth/login', '/auth/signup', '/embed'];
 
 let cachedAuthProvider: string | null = null;
 
@@ -50,8 +50,9 @@ export async function middleware(request: NextRequest) {
   const token = request.cookies.get(OSS_TOKEN_COOKIE)?.value;
   const { pathname } = request.nextUrl;
 
-  // Allow public paths without auth
-  if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+  // Allow public paths without auth, (exact match or subpaths like '/embed or /embed/*, 
+  // slash boundary to block sibling protected paths like /embedded)
+  if (PUBLIC_PATHS.some((p) => pathname === p ||  pathname.startsWith(`${p}/`))) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Description
Fixes an issue in OSS middleware where `pathname.startsWith(p)` incorrectly matched sibling paths (e.g., `/embedded` or `/embeddable` matching public path `/embed`). 

Updated the matching logic to require an exact match or a trailing slash boundary (`pathname === p || pathname.startsWith(`${p}/`)`).

Fixes #585 

## Changes Made
- Updated `PUBLIC_PATHS` check in `middleware.ts` to include `/embed` public directory.
- Prevents sibling path bypasses while preserving exact route matching (`/embed`) and subpath matching (`/embed/123`).

## Testing
- Tested exact match (`/embed`) -> Allowed
- Tested subpath match (`/embed/123`) -> Allowed
- Tested sibling match (`/embedded`) -> Blocked (redirects to `/auth/login`)
- Tested exact match (`/auth/login`) -> Allowed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes public route matching in OSS middleware so `/embed` and its subpaths work without auth while sibling routes stay protected (fixes #583). Adds `/embed` to `PUBLIC_PATHS` and uses exact-or-slash-boundary matching to prevent false positives like `/embedded`.

<sup>Written for commit fb95ea65098ae2a4ba071a3a9677dd06dfe585fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes `/embed` and its subpaths available without authentication in local OSS mode, while requiring an exact path or slash-delimited subpath match so similarly named protected routes remain gated. Runtime requests confirmed that `/embed` and `/embed/123` pass through without a login cookie, while `/embedded`, `/auth/loginfoo`, and `/auth/signup-extra` redirect to `/auth/login`.

The UI cannot currently produce a production build because trailing whitespace in `ui/src/middleware.ts` fails the repository lint rule. Remove the whitespace and rerun the production build before merging.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until T-Rex findings are addressed.

Runtime checks confirmed the intended public-route and protected-sibling behavior, but the changed middleware source prevents the production UI build from completing.

T-Rex reproduced 2 failing behaviors at runtime in ui/src/middleware.ts; the change needs fixes before it is safe to merge.

**Files Needing Attention:** `ui/src/middleware.ts` needs its trailing whitespace removed on line 53.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I started a local health endpoint with auth\_provider: local, launched Next UI with BACKEND\_URL pointing to it, and exercised unauthenticated requests to /embed, /embed/123, /embedded, /auth/login, /auth/loginfoo, and /auth/signup-extra to verify the updated middleware behavior.
- I captured the exact runtime harness and the before and after routing outputs to validate the route changes introduced by PR #600.
- I produced a P1 finding proof for the posted finding and linked it to the corresponding review comment.
- I produced a second P1 finding proof for another review finding and linked it to its review comment.
- I documented production UI build and lint outcomes showing a trailing whitespace issue blocked production build and introduced lint failures in the PR.

<a href="https://app.greptile.com/trex/runs/16624362/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Trailing space in middleware comment blocks the production UI build**

   - **Bug**
     - `npm run build` from `ui/` compiles the application but then fails during "Linting and checking validity of types" with `./src/middleware.ts 53:89 Error: Trailing spaces not allowed. no-trailing-spaces`, exiting 1.
   - **Cause**
     - PR #600 changed the public-path comment and left a trailing space after the comma on line 53. The production Next.js build enforces the repository ESLint `no-trailing-spaces` rule.
   - **Fix**
     - Remove the trailing whitespace on `ui/src/middleware.ts` line 53 (and keep the comment text properly quoted if desired), then rerun `npm run build`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix (middleware): added &#39;/embed&#39; to PUBL..."](https://github.com/dograh-hq/dograh/commit/fb95ea65098ae2a4ba071a3a9677dd06dfe585fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48775185)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->