### PR TITLE
fix(telephony): validate number ownership before assignment

### DIFF
--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -81,10 +81,12 @@ from api.services.organization_preferences import (
 )
 from api.services.posthog_client import capture_event
 from api.services.telephony import registry as telephony_registry
+from api.services.telephony.base import ProviderPhoneNumberLookupError
 from api.services.telephony.factory import get_telephony_provider_by_id
 from api.services.worker_sync.manager import get_worker_sync_manager
 from api.services.worker_sync.protocol import WorkerSyncEventType
 from api.utils.common import get_backend_endpoints
+from api.utils.telephony_address import normalize_telephony_address
 
 router = APIRouter(prefix="/organizations", tags=["organizations"])
 
@@ -590,6 +592,41 @@ def _phone_number_to_response(
     return response
 
 
+async def _ensure_provider_owns_phone_number(
+    config_id: int,
+    organization_id: int,
+    address: str,
+    country_hint: str | None = None,
+) -> None:
+    """Reject an address unless the provider can confirm account ownership.
+
+    Provider implementations use read-only inventory lookups. PBX-managed
+    providers that cannot prove carrier ownership explicitly opt out through
+    their ``validate_phone_number`` implementation.
+    """
+    try:
+        canonical_address = normalize_telephony_address(
+            address, country_hint=country_hint
+        ).canonical
+        provider = await get_telephony_provider_by_id(config_id, organization_id)
+        result = await provider.validate_phone_number(canonical_address)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except ProviderPhoneNumberLookupError as e:
+        logger.error(
+            f"Provider phone-number lookup failed for config {config_id} "
+            f"address {address}: {e}"
+        )
+        raise HTTPException(status_code=502, detail=str(e)) from e
+
+    if not result.ok:
+        raise HTTPException(
+            status_code=400,
+            detail=result.message
+            or "Phone number is not owned by this provider account",
+        )
+
+
 async def _sync_inbound_for_phone_number(
     config_id: int, organization_id: int, address: str, *, attach: bool = True
 ) -> ProviderSyncStatus:
@@ -862,6 +899,13 @@ async def create_phone_number(
             request.inbound_workflow_id, user.selected_organization_id
         )
 
+    await _ensure_provider_owns_phone_number(
+        config_id,
+        user.selected_organization_id,
+        request.address,
+        request.country_code,
+    )
+
     # Inbound dispatch (find_inbound_route_by_account) keys on (provider,
     # credentials[account_id_field], address_normalized) without the org, so
     # that tuple has to be globally unique. Reject up front if another config —
@@ -1126,6 +1170,11 @@ async def save_telephony_configuration(
     existing_numbers = await db_client.list_phone_numbers_for_config(row.id)
     existing_by_address = {n.address: n for n in existing_numbers}
     incoming_set = set(new_addresses)
+    for addr in new_addresses:
+        if addr not in existing_by_address:
+            await _ensure_provider_owns_phone_number(
+                row.id, user.selected_organization_id, addr
+            )
     for addr in new_addresses:
         if addr in existing_by_address:
             continue

--- a/api/services/telephony/base.py
+++ b/api/services/telephony/base.py
@@ -41,6 +41,17 @@ class ProviderSyncResult:
     message: Optional[str] = None  # human-readable detail when ok=False
 
 
+class ProviderPhoneNumberLookupError(Exception):
+    """The provider could not determine whether it owns a phone number.
+
+    This is distinct from a successful lookup that reports ``ok=False``. The
+    latter means the address is definitely absent from the provider account;
+    this exception means credentials, transport, or the upstream API failed,
+    so callers should surface a provider error instead of treating the number
+    as unowned.
+    """
+
+
 @dataclass
 class NormalizedInboundData:
     """Standardized inbound call data across all providers."""
@@ -413,6 +424,17 @@ class TelephonyProvider(ABC):
         don't support programmatic webhook configuration (e.g. ARI).
         """
         return ProviderSyncResult(ok=True)
+
+    @abstractmethod
+    async def validate_phone_number(self, address: str) -> ProviderSyncResult:
+        """Check that ``address`` belongs to this provider configuration.
+
+        Carrier-backed providers implement a read-only account-inventory
+        lookup. PBX-managed providers without a carrier ownership resource
+        must explicitly opt out so a newly registered provider cannot silently
+        bypass validation.
+        """
+        raise NotImplementedError
 
     @staticmethod
     @abstractmethod

--- a/api/services/telephony/providers/ari/provider.py
+++ b/api/services/telephony/providers/ari/provider.py
@@ -18,6 +18,7 @@ from api.enums import TelephonyCallStatus, WorkflowRunMode
 from api.services.telephony.base import (
     CallInitiationResult,
     NormalizedInboundData,
+    ProviderSyncResult,
     TelephonyProvider,
 )
 from api.services.telephony.providers.ari.external_pbx import create_adapter
@@ -176,6 +177,15 @@ class ARIProvider(TelephonyProvider):
     def validate_config(self) -> bool:
         """Validate ARI configuration."""
         return bool(self.ari_endpoint and self.app_name and self.app_password)
+
+    async def validate_phone_number(self, address: str) -> ProviderSyncResult:
+        """Accept PBX-managed caller IDs and extensions.
+
+        ARI exposes channel endpoints and accepts ``callerId`` during channel
+        origination, but it has no carrier-number ownership resource. The PBX
+        dialplan and outbound trunk remain authoritative for these addresses.
+        """
+        return ProviderSyncResult(ok=True)
 
     async def verify_webhook_signature(
         self, url: str, params: Dict[str, Any], signature: str

--- a/api/services/telephony/providers/cloudonix/provider.py
+++ b/api/services/telephony/providers/cloudonix/provider.py
@@ -5,6 +5,7 @@ Cloudonix implementation of the TelephonyProvider interface.
 import asyncio
 import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from urllib.parse import quote
 
 import aiohttp
 from fastapi import HTTPException
@@ -15,10 +16,12 @@ from api.enums import TelephonyCallStatus, WorkflowRunMode
 from api.services.telephony.base import (
     CallInitiationResult,
     NormalizedInboundData,
+    ProviderPhoneNumberLookupError,
     ProviderSyncResult,
     TelephonyProvider,
 )
 from api.utils.common import get_backend_endpoints
+from api.utils.telephony_address import normalize_telephony_address
 
 if TYPE_CHECKING:
     from fastapi import WebSocket
@@ -967,6 +970,64 @@ class CloudonixProvider(TelephonyProvider):
             f"(domain={self.domain_id}, triggered by address {address})"
         )
         return ProviderSyncResult(ok=True)
+
+    async def validate_phone_number(self, address: str) -> ProviderSyncResult:
+        """Verify that the address exists as a DNID in this Cloudonix domain."""
+        if not (self.bearer_token and self.domain_id):
+            raise ProviderPhoneNumberLookupError(
+                "Cloudonix bearer token and domain are required to validate "
+                "phone-number ownership"
+            )
+
+        normalized = normalize_telephony_address(address)
+        expected = normalized.canonical
+        encoded_address = quote(expected, safe="")
+        endpoint = (
+            f"{self.base_url}/customers/self/domains/{self.domain_id}/dnids/"
+            f"{encoded_address}"
+        )
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    endpoint, headers=self._get_auth_headers()
+                ) as response:
+                    if response.status == 404:
+                        return ProviderSyncResult(
+                            ok=False,
+                            message=(
+                                f"Address {expected} is not configured as a DNID "
+                                f"in Cloudonix domain {self.domain_id}. Add it in "
+                                "the Cloudonix Cockpit first."
+                            ),
+                        )
+                    if response.status != 200:
+                        body = await response.text()
+                        raise ProviderPhoneNumberLookupError(
+                            f"Cloudonix API {response.status}: {body}"
+                        )
+                    data = await response.json()
+        except ProviderPhoneNumberLookupError:
+            raise
+        except Exception as e:
+            raise ProviderPhoneNumberLookupError(
+                f"Cloudonix DNID lookup failed: {e}"
+            ) from e
+
+        source = data.get("source")
+        if source is not None:
+            try:
+                source = normalize_telephony_address(str(source)).canonical
+            except ValueError:
+                source = str(source).strip()
+        if source == expected:
+            return ProviderSyncResult(ok=True)
+        return ProviderSyncResult(
+            ok=False,
+            message=(
+                f"Address {expected} is not configured as a DNID in Cloudonix "
+                f"domain {self.domain_id}. Add it in the Cloudonix Cockpit first."
+            ),
+        )
 
     async def start_inbound_stream(
         self,

--- a/api/services/telephony/providers/plivo/provider.py
+++ b/api/services/telephony/providers/plivo/provider.py
@@ -7,7 +7,7 @@ import hashlib
 import hmac
 import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from urllib.parse import parse_qs, urlparse, urlunparse
+from urllib.parse import parse_qs, quote, urlparse, urlunparse
 
 import aiohttp
 from fastapi import HTTPException
@@ -18,6 +18,7 @@ from api.enums import TelephonyCallStatus, WorkflowRunMode
 from api.services.telephony.base import (
     CallInitiationResult,
     NormalizedInboundData,
+    ProviderPhoneNumberLookupError,
     ProviderSyncResult,
     TelephonyProvider,
 )
@@ -483,6 +484,45 @@ class PlivoProvider(TelephonyProvider):
             f"(triggered by address {address})"
         )
         return ProviderSyncResult(ok=True)
+
+    async def validate_phone_number(self, address: str) -> ProviderSyncResult:
+        """Verify PSTN ownership through Plivo's Account Number resource."""
+        normalized = normalize_telephony_address(address)
+        if normalized.address_type != "pstn":
+            return ProviderSyncResult(ok=True)
+        if not (self.auth_id and self.auth_token):
+            raise ProviderPhoneNumberLookupError(
+                "Plivo auth ID and auth token are required to validate "
+                "phone-number ownership"
+            )
+
+        number = quote(normalized.canonical.lstrip("+"), safe="")
+        endpoint = f"{self.base_url}/Number/{number}/"
+        auth = aiohttp.BasicAuth(self.auth_id, self.auth_token)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(endpoint, auth=auth) as response:
+                    if response.status == 200:
+                        return ProviderSyncResult(ok=True)
+                    if response.status == 404:
+                        return ProviderSyncResult(
+                            ok=False,
+                            message=(
+                                f"Phone number {normalized.canonical} is not owned "
+                                f"by this Plivo account ({self.auth_id}). Add it "
+                                "in the Plivo console first."
+                            ),
+                        )
+                    body = await response.text()
+                    raise ProviderPhoneNumberLookupError(
+                        f"Plivo API {response.status}: {body}"
+                    )
+        except ProviderPhoneNumberLookupError:
+            raise
+        except Exception as e:
+            raise ProviderPhoneNumberLookupError(
+                f"Plivo phone-number lookup failed: {e}"
+            ) from e
 
     async def start_inbound_stream(
         self,

--- a/api/services/telephony/providers/telnyx/provider.py
+++ b/api/services/telephony/providers/telnyx/provider.py
@@ -28,6 +28,7 @@ from api.enums import TelephonyCallStatus, WorkflowRunMode
 from api.services.telephony.base import (
     CallInitiationResult,
     NormalizedInboundData,
+    ProviderPhoneNumberLookupError,
     ProviderSyncResult,
     TelephonyProvider,
 )
@@ -649,6 +650,54 @@ class TelnyxProvider(TelephonyProvider):
             f"{self.connection_id} (triggered by address {address})"
         )
         return ProviderSyncResult(ok=True)
+
+    async def validate_phone_number(self, address: str) -> ProviderSyncResult:
+        """Verify PSTN ownership through Telnyx's phone-number inventory."""
+        normalized = normalize_telephony_address(address)
+        if normalized.address_type != "pstn":
+            return ProviderSyncResult(ok=True)
+        if not self.api_key:
+            raise ProviderPhoneNumberLookupError(
+                "Telnyx API key is required to validate phone-number ownership"
+            )
+
+        endpoint = f"{self.TELNYX_API_BASE}/phone_numbers"
+        params = {
+            "filter[phone_number]": normalized.canonical,
+            "page[size]": 100,
+        }
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    endpoint, params=params, headers=self._headers()
+                ) as response:
+                    if response.status != 200:
+                        body = await response.text()
+                        raise ProviderPhoneNumberLookupError(
+                            f"Telnyx API {response.status}: {body}"
+                        )
+                    data = await response.json()
+        except ProviderPhoneNumberLookupError:
+            raise
+        except Exception as e:
+            raise ProviderPhoneNumberLookupError(
+                f"Telnyx phone-number lookup failed: {e}"
+            ) from e
+
+        owned = any(
+            item.get("phone_number") == normalized.canonical
+            for item in (data.get("data") or [])
+        )
+        if owned:
+            return ProviderSyncResult(ok=True)
+        return ProviderSyncResult(
+            ok=False,
+            message=(
+                f"Phone number {normalized.canonical} is not owned by this "
+                "Telnyx account. Add it in the Telnyx Mission Control "
+                "Portal first."
+            ),
+        )
 
     async def start_inbound_stream(
         self,

--- a/api/services/telephony/providers/twilio/provider.py
+++ b/api/services/telephony/providers/twilio/provider.py
@@ -15,6 +15,7 @@ from api.services.telephony.base import (
     AnsweringMachineDetectionResult,
     CallInitiationResult,
     NormalizedInboundData,
+    ProviderPhoneNumberLookupError,
     ProviderSyncResult,
     TelephonyProvider,
 )
@@ -435,7 +436,7 @@ class TwilioProvider(TelephonyProvider):
         addresses (SIP URIs, extensions) are skipped — Twilio's
         IncomingPhoneNumbers resource only covers PSTN numbers.
         """
-        if not self.validate_config():
+        if not (self.account_sid and self.auth_token):
             return ProviderSyncResult(
                 ok=False, message="Twilio provider not properly configured"
             )
@@ -451,6 +452,13 @@ class TwilioProvider(TelephonyProvider):
         except Exception as e:
             logger.error(f"Failed to look up Twilio number {e164}: {e}")
             return ProviderSyncResult(ok=False, message=f"Twilio lookup failed: {e}")
+
+        if not sid and webhook_url is None:
+            logger.info(
+                f"Twilio number {e164} is already detached or absent from "
+                f"account {self.account_sid}"
+            )
+            return ProviderSyncResult(ok=True)
 
         if not sid:
             return ProviderSyncResult(
@@ -495,6 +503,35 @@ class TwilioProvider(TelephonyProvider):
         logger.info(f"Twilio VoiceUrl {action} for {e164} (sid={sid})")
         return ProviderSyncResult(ok=True)
 
+    async def validate_phone_number(self, address: str) -> ProviderSyncResult:
+        """Verify PSTN ownership through Twilio's IncomingPhoneNumbers list."""
+        normalized = normalize_telephony_address(address)
+        if normalized.address_type != "pstn":
+            return ProviderSyncResult(ok=True)
+        if not (self.account_sid and self.auth_token):
+            raise ProviderPhoneNumberLookupError(
+                "Twilio account SID and auth token are required to validate "
+                "phone-number ownership"
+            )
+
+        try:
+            sid = await self._lookup_incoming_number_sid(normalized.canonical)
+        except Exception as e:
+            raise ProviderPhoneNumberLookupError(
+                f"Twilio phone-number lookup failed: {e}"
+            ) from e
+
+        if sid:
+            return ProviderSyncResult(ok=True)
+        return ProviderSyncResult(
+            ok=False,
+            message=(
+                f"Phone number {normalized.canonical} is not owned by this "
+                f"Twilio account ({self.account_sid}). Add it in the Twilio "
+                "console first."
+            ),
+        )
+
     async def _lookup_incoming_number_sid(self, e164: str) -> Optional[str]:
         """Return the Twilio SID of the IncomingPhoneNumber matching ``e164``."""
         endpoint = f"{self.base_url}/IncomingPhoneNumbers.json"
@@ -507,9 +544,10 @@ class TwilioProvider(TelephonyProvider):
                     raise Exception(f"Twilio API {response.status}: {body}")
                 data = await response.json()
         numbers = data.get("incoming_phone_numbers") or []
-        if not numbers:
-            return None
-        return numbers[0].get("sid")
+        for number in numbers:
+            if number.get("phone_number") == e164:
+                return number.get("sid")
+        return None
 
     async def start_inbound_stream(
         self,

--- a/api/services/telephony/providers/vobiz/provider.py
+++ b/api/services/telephony/providers/vobiz/provider.py
@@ -17,6 +17,7 @@ from api.enums import TelephonyCallStatus, WorkflowRunMode
 from api.services.telephony.base import (
     CallInitiationResult,
     NormalizedInboundData,
+    ProviderPhoneNumberLookupError,
     ProviderSyncResult,
     TelephonyProvider,
 )
@@ -513,7 +514,7 @@ class VobizProvider(TelephonyProvider):
         - Attach: https://vobiz.ai/docs/applications/attach-number
         - Detach: https://vobiz.ai/docs/applications/detach-number
         """
-        if not self.validate_config():
+        if not (self.auth_id and self.auth_token):
             return ProviderSyncResult(
                 ok=False, message="Vobiz provider not properly configured"
             )
@@ -659,6 +660,70 @@ class VobizProvider(TelephonyProvider):
             f"{self.application_id}; answer_url set to {webhook_url}"
         )
         return ProviderSyncResult(ok=True)
+
+    async def validate_phone_number(self, address: str) -> ProviderSyncResult:
+        """Verify PSTN ownership through Vobiz's account number inventory."""
+        normalized = normalize_telephony_address(address)
+        if normalized.address_type != "pstn":
+            return ProviderSyncResult(ok=True)
+        if not (self.auth_id and self.auth_token):
+            raise ProviderPhoneNumberLookupError(
+                "Vobiz auth ID and auth token are required to validate "
+                "phone-number ownership"
+            )
+
+        endpoint = f"{self.base_url}/v1/Account/{self.auth_id}/numbers"
+        headers = {
+            "X-Auth-ID": self.auth_id,
+            "X-Auth-Token": self.auth_token,
+            "Content-Type": "application/json",
+        }
+        page = 1
+        per_page = 100
+        try:
+            async with aiohttp.ClientSession() as session:
+                while True:
+                    params = {
+                        "page": page,
+                        "per_page": per_page,
+                        "search": normalized.canonical,
+                    }
+                    async with session.get(
+                        endpoint, params=params, headers=headers
+                    ) as response:
+                        if response.status != 200:
+                            body = await response.text()
+                            raise ProviderPhoneNumberLookupError(
+                                f"Vobiz API {response.status}: {body}"
+                            )
+                        data = await response.json()
+
+                    items = data.get("items") or []
+                    for item in items:
+                        if item.get("e164") == normalized.canonical:
+                            return ProviderSyncResult(ok=True)
+
+                    total = int(data.get("total") or len(items))
+                    response_page = int(data.get("page") or page)
+                    response_per_page = int(data.get("per_page") or per_page)
+                    if not items or response_page * response_per_page >= total:
+                        break
+                    page = response_page + 1
+        except ProviderPhoneNumberLookupError:
+            raise
+        except Exception as e:
+            raise ProviderPhoneNumberLookupError(
+                f"Vobiz phone-number lookup failed: {e}"
+            ) from e
+
+        return ProviderSyncResult(
+            ok=False,
+            message=(
+                f"Phone number {normalized.canonical} is not owned by this "
+                f"Vobiz account ({self.auth_id}). Add it in the Vobiz "
+                "console first."
+            ),
+        )
 
     async def start_inbound_stream(
         self,

--- a/api/services/telephony/providers/vonage/provider.py
+++ b/api/services/telephony/providers/vonage/provider.py
@@ -16,10 +16,12 @@ from api.enums import TelephonyCallStatus, WorkflowRunMode
 from api.services.telephony.base import (
     CallInitiationResult,
     NormalizedInboundData,
+    ProviderPhoneNumberLookupError,
     ProviderSyncResult,
     TelephonyProvider,
 )
 from api.utils.common import get_backend_endpoints
+from api.utils.telephony_address import normalize_telephony_address
 
 if TYPE_CHECKING:
     from fastapi import WebSocket
@@ -676,6 +678,56 @@ class VonageProvider(TelephonyProvider):
             f"(triggered by address {address})"
         )
         return ProviderSyncResult(ok=True)
+
+    async def validate_phone_number(self, address: str) -> ProviderSyncResult:
+        """Verify PSTN ownership through Vonage's owned-numbers endpoint."""
+        normalized = normalize_telephony_address(address)
+        if normalized.address_type != "pstn":
+            return ProviderSyncResult(ok=True)
+        if not (self.api_key and self.api_secret):
+            raise ProviderPhoneNumberLookupError(
+                "Vonage API key and secret are required to validate "
+                "phone-number ownership"
+            )
+
+        expected = normalized.canonical.lstrip("+")
+        endpoint = "https://rest.nexmo.com/account/numbers"
+        params = {
+            "pattern": expected,
+            "search_pattern": 0,
+            "size": 100,
+        }
+        auth = aiohttp.BasicAuth(self.api_key, self.api_secret)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(endpoint, params=params, auth=auth) as response:
+                    if response.status != 200:
+                        body = await response.text()
+                        raise ProviderPhoneNumberLookupError(
+                            f"Vonage API {response.status}: {body}"
+                        )
+                    data = await response.json()
+        except ProviderPhoneNumberLookupError:
+            raise
+        except Exception as e:
+            raise ProviderPhoneNumberLookupError(
+                f"Vonage phone-number lookup failed: {e}"
+            ) from e
+
+        owned = any(
+            str(item.get("msisdn") or item.get("number") or "").lstrip("+") == expected
+            for item in (data.get("numbers") or [])
+        )
+        if owned:
+            return ProviderSyncResult(ok=True)
+        return ProviderSyncResult(
+            ok=False,
+            message=(
+                f"Phone number {normalized.canonical} is not owned by this "
+                f"Vonage account ({self.api_key}). Add it in the Vonage "
+                "dashboard first."
+            ),
+        )
 
     async def start_inbound_stream(
         self,

--- a/api/tests/telephony/test_phone_number_validation.py
+++ b/api/tests/telephony/test_phone_number_validation.py
@@ -1,0 +1,436 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.organization import create_phone_number
+from api.schemas.telephony_phone_number import PhoneNumberCreateRequest
+from api.services.telephony.base import (
+    ProviderPhoneNumberLookupError,
+    ProviderSyncResult,
+)
+from api.services.telephony.providers.ari.provider import ARIProvider
+from api.services.telephony.providers.cloudonix.provider import CloudonixProvider
+from api.services.telephony.providers.plivo.provider import PlivoProvider
+from api.services.telephony.providers.telnyx.provider import TelnyxProvider
+from api.services.telephony.providers.twilio.provider import TwilioProvider
+from api.services.telephony.providers.vobiz.provider import VobizProvider
+from api.services.telephony.providers.vonage.provider import VonageProvider
+
+
+class _StubResponse:
+    def __init__(self, status: int, *, data=None, body: str = ""):
+        self.status = status
+        self._data = data
+        self._body = body
+
+    async def json(self):
+        return self._data
+
+    async def text(self) -> str:
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _StubSession:
+    def __init__(self, responses: list[_StubResponse]):
+        self.responses = responses
+        self.requests: list[tuple[str, dict]] = []
+
+    def get(self, url: str, **kwargs):
+        self.requests.append((url, kwargs))
+        return self.responses.pop(0)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_twilio_validation_requires_an_exact_owned_number():
+    provider = TwilioProvider(
+        {
+            "account_sid": "AC123",
+            "auth_token": "token",
+            "from_numbers": [],
+        }
+    )
+    session = _StubSession(
+        [
+            _StubResponse(
+                200,
+                data={
+                    "incoming_phone_numbers": [
+                        {"sid": "PN_PARTIAL", "phone_number": "+155512300020"},
+                        {"sid": "PN_EXACT", "phone_number": "+15551230002"},
+                    ]
+                },
+            )
+        ]
+    )
+
+    with patch(
+        "api.services.telephony.providers.twilio.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.validate_phone_number("+15551230002")
+
+    assert result.ok
+    assert session.requests[0][1]["params"] == {"PhoneNumber": "+15551230002"}
+
+
+@pytest.mark.asyncio
+async def test_twilio_validation_rejects_unowned_number():
+    provider = TwilioProvider(
+        {
+            "account_sid": "AC123",
+            "auth_token": "token",
+            "from_numbers": [],
+        }
+    )
+    provider._lookup_incoming_number_sid = AsyncMock(return_value=None)
+
+    result = await provider.validate_phone_number("+15551230002")
+
+    assert not result.ok
+    assert "not owned by this Twilio account" in result.message
+
+
+@pytest.mark.asyncio
+async def test_twilio_missing_number_is_an_idempotent_detach():
+    provider = TwilioProvider(
+        {
+            "account_sid": "AC123",
+            "auth_token": "token",
+            "from_numbers": [],
+        }
+    )
+    provider._lookup_incoming_number_sid = AsyncMock(return_value=None)
+
+    result = await provider.configure_inbound("+15551230002", None)
+
+    assert result.ok
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status, expected_ok", [(200, True), (404, False)])
+async def test_plivo_validation_uses_account_number_resource(status, expected_ok):
+    provider = PlivoProvider(
+        {"auth_id": "MA123", "auth_token": "token", "from_numbers": []}
+    )
+    session = _StubSession([_StubResponse(status)])
+
+    with patch(
+        "api.services.telephony.providers.plivo.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.validate_phone_number("+15551230002")
+
+    assert result.ok is expected_ok
+    assert session.requests[0][0].endswith("/Account/MA123/Number/15551230002/")
+
+
+@pytest.mark.asyncio
+async def test_vonage_validation_exact_matches_owned_number():
+    provider = VonageProvider(
+        {
+            "api_key": "key",
+            "api_secret": "secret",
+            "application_id": "app-id",
+            "private_key": "unused",
+            "from_numbers": [],
+        }
+    )
+    session = _StubSession(
+        [_StubResponse(200, data={"numbers": [{"msisdn": "15551230002"}]})]
+    )
+
+    with patch(
+        "api.services.telephony.providers.vonage.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.validate_phone_number("+15551230002")
+
+    assert result.ok
+    assert session.requests[0][0] == "https://rest.nexmo.com/account/numbers"
+    assert session.requests[0][1]["params"] == {
+        "pattern": "15551230002",
+        "search_pattern": 0,
+        "size": 100,
+    }
+
+
+@pytest.mark.asyncio
+async def test_vonage_validation_rejects_nonexact_search_result():
+    provider = VonageProvider(
+        {
+            "api_key": "key",
+            "api_secret": "secret",
+            "application_id": "app-id",
+            "private_key": "unused",
+            "from_numbers": [],
+        }
+    )
+    session = _StubSession(
+        [_StubResponse(200, data={"numbers": [{"msisdn": "155512300020"}]})]
+    )
+
+    with patch(
+        "api.services.telephony.providers.vonage.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.validate_phone_number("+15551230002")
+
+    assert not result.ok
+
+
+@pytest.mark.asyncio
+async def test_telnyx_validation_rejects_filter_results_without_exact_number():
+    provider = TelnyxProvider(
+        {
+            "api_key": "key",
+            "connection_id": "connection-id",
+            "from_numbers": [],
+        }
+    )
+    session = _StubSession(
+        [
+            _StubResponse(
+                200,
+                data={"data": [{"phone_number": "+155512300020"}]},
+            )
+        ]
+    )
+
+    with patch(
+        "api.services.telephony.providers.telnyx.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.validate_phone_number("+15551230002")
+
+    assert not result.ok
+    assert session.requests[0][1]["params"]["filter[phone_number]"] == ("+15551230002")
+
+
+@pytest.mark.asyncio
+async def test_vobiz_validation_paginates_account_inventory():
+    provider = VobizProvider(
+        {"auth_id": "MA123", "auth_token": "token", "from_numbers": []}
+    )
+    session = _StubSession(
+        [
+            _StubResponse(
+                200,
+                data={
+                    "items": [{"auth_id": "MA123", "e164": "+15551230001"}],
+                    "page": 1,
+                    "per_page": 1,
+                    "total": 2,
+                },
+            ),
+            _StubResponse(
+                200,
+                data={
+                    "items": [{"auth_id": "MA123", "e164": "+15551230002"}],
+                    "page": 2,
+                    "per_page": 1,
+                    "total": 2,
+                },
+            ),
+        ]
+    )
+
+    with patch(
+        "api.services.telephony.providers.vobiz.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.validate_phone_number("+15551230002")
+
+    assert result.ok
+    assert [request[1]["params"]["page"] for request in session.requests] == [1, 2]
+    assert all(
+        request[1]["params"]["search"] == "+15551230002" for request in session.requests
+    )
+
+
+@pytest.mark.asyncio
+async def test_vobiz_validation_rejects_number_missing_from_account_inventory():
+    provider = VobizProvider(
+        {"auth_id": "MA123", "auth_token": "token", "from_numbers": []}
+    )
+    session = _StubSession(
+        [
+            _StubResponse(
+                200,
+                data={"items": [], "page": 1, "per_page": 25, "total": 0},
+            )
+        ]
+    )
+
+    with patch(
+        "api.services.telephony.providers.vobiz.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.validate_phone_number("+15551230002")
+
+    assert not result.ok
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status, data, expected_ok",
+    [
+        (200, {"source": "+15551230002"}, True),
+        (404, None, False),
+    ],
+)
+async def test_cloudonix_validation_uses_domain_dnid(status, data, expected_ok):
+    provider = CloudonixProvider(
+        {
+            "bearer_token": "token",
+            "domain_id": "example.cloudonix.net",
+            "from_numbers": [],
+        }
+    )
+    session = _StubSession([_StubResponse(status, data=data)])
+
+    with patch(
+        "api.services.telephony.providers.cloudonix.provider.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await provider.validate_phone_number("+15551230002")
+
+    assert result.ok is expected_ok
+    assert session.requests[0][0].endswith(
+        "/domains/example.cloudonix.net/dnids/%2B15551230002"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ari_validation_explicitly_accepts_pbx_managed_address():
+    provider = ARIProvider(
+        {
+            "ari_endpoint": "http://asterisk:8088",
+            "app_name": "dograh",
+            "app_password": "secret",
+            "from_numbers": [],
+        }
+    )
+
+    result = await provider.validate_phone_number("PJSIP/office-trunk")
+
+    assert result.ok
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_unowned_number_before_database_insert():
+    config = SimpleNamespace(provider="twilio", credentials={"account_sid": "AC123"})
+    provider = SimpleNamespace(
+        validate_phone_number=AsyncMock(
+            return_value=ProviderSyncResult(ok=False, message="not owned")
+        )
+    )
+    create_local = AsyncMock()
+    find_conflict = AsyncMock()
+
+    with (
+        patch(
+            "api.routes.organization._ensure_config_belongs_to_org",
+            new_callable=AsyncMock,
+            return_value=config,
+        ),
+        patch(
+            "api.routes.organization.get_telephony_provider_by_id",
+            new_callable=AsyncMock,
+            return_value=provider,
+        ),
+        patch(
+            "api.routes.organization.db_client.find_inbound_routing_conflict",
+            find_conflict,
+        ),
+        patch("api.routes.organization.db_client.create_phone_number", create_local),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await create_phone_number(
+            config_id=7,
+            request=PhoneNumberCreateRequest(address="+15551230002"),
+            user=SimpleNamespace(selected_organization_id=11),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "not owned"
+    find_conflict.assert_not_awaited()
+    create_local.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_surfaces_provider_lookup_failure_as_bad_gateway():
+    config = SimpleNamespace(provider="twilio", credentials={"account_sid": "AC123"})
+    provider = SimpleNamespace(
+        validate_phone_number=AsyncMock(
+            side_effect=ProviderPhoneNumberLookupError("Twilio API 401")
+        )
+    )
+
+    with (
+        patch(
+            "api.routes.organization._ensure_config_belongs_to_org",
+            new_callable=AsyncMock,
+            return_value=config,
+        ),
+        patch(
+            "api.routes.organization.get_telephony_provider_by_id",
+            new_callable=AsyncMock,
+            return_value=provider,
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await create_phone_number(
+            config_id=7,
+            request=PhoneNumberCreateRequest(address="+15551230002"),
+            user=SimpleNamespace(selected_organization_id=11),
+        )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == "Twilio API 401"
+
+
+@pytest.mark.asyncio
+async def test_create_validates_country_hinted_number_in_canonical_form():
+    config = SimpleNamespace(provider="twilio", credentials={"account_sid": "AC123"})
+    provider = SimpleNamespace(
+        validate_phone_number=AsyncMock(
+            return_value=ProviderSyncResult(ok=False, message="not owned")
+        )
+    )
+
+    with (
+        patch(
+            "api.routes.organization._ensure_config_belongs_to_org",
+            new_callable=AsyncMock,
+            return_value=config,
+        ),
+        patch(
+            "api.routes.organization.get_telephony_provider_by_id",
+            new_callable=AsyncMock,
+            return_value=provider,
+        ),
+        pytest.raises(HTTPException),
+    ):
+        await create_phone_number(
+            config_id=7,
+            request=PhoneNumberCreateRequest(
+                address="080 4307 1383", country_code="IN"
+            ),
+            user=SimpleNamespace(selected_organization_id=11),
+        )
+
+    provider.validate_phone_number.assert_awaited_once_with("+918043071383")


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validates phone-number ownership with the configured telephony provider before assignment to prevent misrouted calls and bad configs. Applies during number creation and when saving telephony configurations.

- **Bug Fixes**
  - Added `validate_phone_number` to `TelephonyProvider`; implemented for Twilio, Telnyx, Plivo, Vonage, Vobiz, and Cloudonix; `ARI` explicitly allows PBX-managed addresses.
  - Enforced ownership checks in `create_phone_number` and config save; normalizes numbers (supports country hints).
  - Returns 400 when not owned and 502 on provider lookup failures; Twilio inbound config is idempotent if the number is already detached.
  - Added comprehensive tests for provider inventory checks and error handling.

<sup>Written for commit adbb2fe2ce86ac1ae52d75181de11fee61a2e5bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds provider-backed phone-number ownership checks before assigning numbers through supported telephony providers.

Two configuration-integrity failures remain in the legacy telephony save flow. Retaining a phone number while changing provider credentials does not verify that the replacement account owns that number; the reproduced request succeeds and preserves the number under the new account. Separately, configuration changes are saved before a newly submitted number is validated, so a rejected number can leave credentials or the default provider changed without the requested number set.

### T-Rex validation blocked
- **Package:** the installed `pipecat-ai==1.6.0` package does not provide `pipecat.audio.mixers.silence_mixer`, which prevents importing `api.routes.organization` to execute the partial-save failure path. [Configure VMs](https://app.greptile.com/-/settings/trex#environments)

<h3>Confidence Score: 2/5</h3>





<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and attached artifacts showing the focused AST-only legacy credential-change harness source and related outputs.
- T-Rex ran the requested verification for proof 1, but the local artifact references were not uploaded.
- T-Rex produced a proof for a posted P1 finding (proof 2).
- In the general contract validation for proof 3, T-Rex compared the before and after Telephony configuration state and observed that an existing number is exempted by existing\_by\_address, with credentials saved and the number remaining assigned.

<a href="https://app.greptile.com/trex/runs/16767640/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Legacy credential changes bypass ownership validation for retained phone numbers**

   - **Bug**
     - When POST `/organizations/telephony-config` updates credentials but retains a phone number already assigned to the default configuration, the request succeeds with HTTP 200 even if the new provider account does not own that number. The number remains assigned under the new credentials.
   - **Cause**
     - `existing_by_address` is computed from the existing configuration and lines 1174-1177 call `_ensure_provider_owns_phone_number` only for addresses not already in that mapping. The condition does not account for changed provider credentials/account identity.
   - **Fix**
     - Detect credential/account changes before updating the configuration and revalidate every retained inline phone number against the updated credentials, or unconditionally validate every incoming legacy `from_numbers` address before retaining/assigning it.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(telephony): validate number ownershi..."](https://github.com/dograh-hq/dograh/commit/adbb2fe2ce86ac1ae52d75181de11fee61a2e5bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49046969)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->