### PR TITLE
fix(ui): prevent /embed prefix from exempting sibling routes from auth

### DIFF
--- a/ui/src/middleware.ts
+++ b/ui/src/middleware.ts
@@ -53,8 +53,12 @@ export async function middleware(request: NextRequest) {
   const token = request.cookies.get(OSS_TOKEN_COOKIE)?.value;
   const { pathname } = request.nextUrl;
 
-  // Allow public paths without auth
-  if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+  // Allow public paths without auth. Match on a path-segment boundary (exact
+  // match or a `/`-delimited subpath) rather than a bare prefix, so a public
+  // entry like `/embed` exempts `/embed` and `/embed/...` but NOT sibling
+  // routes such as `/embed-admin` — a bare startsWith would let those bypass
+  // authentication.
+  if (PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`))) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Problem
Follow-up to #591. Greptile flagged a **P1 security** issue on that (now merged) PR: the OSS auth middleware checks `PUBLIC_PATHS` with a bare `pathname.startsWith(p)`. Adding `/embed` therefore exempts **any** route sharing that prefix — e.g. `/embed-admin`, `/embedxyz` — from authentication, not just the intended `/embed/…` widget assets. The same loose match applies to `/auth/login` and `/auth/signup`.

There are no such sibling routes today, but it's a latent auth-bypass footgun the moment one is added.

## Fix
Match on a **path-segment boundary** — exact match or a `/`-delimited subpath:

```ts
PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`))
```

So `/embed` exempts only `/embed` and `/embed/...`; `/embed-admin` is once again guarded. Tightens the auth paths the same way.

## Test
- `/embed/dograh-widget.js` → still public (200), as fixed in #591.
- `/embed` → public. `/embed-admin` → now redirected to `/auth/login` (previously bypassed).
- `/auth/login`, `/auth/signup` → unchanged.

Refs #591, #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the auth middleware to match public paths on path-segment boundaries, so `/embed` only exempts `/embed` and `/embed/...` from auth. Sibling routes like `/embed-admin` are now protected; `/auth/login` and `/auth/signup` are matched the same way.

<sup>Written for commit 100feaee005e17a65dcba93cdfb9e956b78ef0b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change restricts OSS public-route matching to complete path segments. Executed middleware checks confirmed that `/embed` and `/embed/dograh-widget.js` remain available without a session, while `/embed-admin`, `/embedxyz`, `/auth/login-extra`, and `/auth/signup-extra` redirect unauthenticated users to login. An authenticated request to `/embed-admin` continues normally.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the Vitest middleware harness by running it from the UI repo with real NextRequest objects and a local health endpoint, and confirmed the health mock received one request, proving local authentication was selected and cached.
- Observed redirect and protection behavior: /embed and /embed/dograh-widget.js loaded without redirects; /embed-admin, /embedxyz, /auth/login-extra, and /auth/signup-extra issued 307 redirects to /auth/login, while an authenticated /embed-admin request proceeded normally.
- No production files were changed; the exact executable validation source and its two observed outputs are preserved in the uploaded artifact references.

<a href="https://app.greptile.com/trex/runs/16803960/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): match public paths on segment b..."](https://github.com/dograh-hq/dograh/commit/100feaee005e17a65dcba93cdfb9e956b78ef0b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49143593)</sub>

<!-- /greptile_comment -->