### PR TITLE
fix: combine OSS run authorization requests

### DIFF
--- a/api/services/mps_service_key_client.py
+++ b/api/services/mps_service_key_client.py
@@ -478,6 +478,47 @@ class MPSServiceKeyClient:
                 response=response,
             )
 
+    async def authorize_service_key_run_start(
+        self,
+        *,
+        service_key: str,
+        workflow_run_id: int | None = None,
+        require_correlation_id: bool = False,
+        minimum_credits: float | None = None,
+        metadata: Optional[dict] = None,
+    ) -> dict:
+        """Authorize an OSS run using the configured service key as identity."""
+        payload = {
+            "workflow_run_id": workflow_run_id,
+            "require_correlation_id": require_correlation_id,
+            "metadata": metadata or {},
+        }
+        if minimum_credits is not None:
+            payload["minimum_credits"] = minimum_credits
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(
+                f"{self.base_url}/api/v1/service-keys/run-authorization/self",
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {service_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+
+            if response.status_code == 200:
+                return response.json()
+
+            logger.warning(
+                "Failed to authorize MPS service-key workflow run start: "
+                f"{response.status_code} - {response.text}"
+            )
+            raise httpx.HTTPStatusError(
+                f"Failed to authorize MPS service-key workflow run start: {response.text}",
+                request=response.request,
+                response=response,
+            )
+
     async def create_correlation_id(
         self,
         *,

--- a/api/services/quota_service.py
+++ b/api/services/quota_service.py
@@ -361,6 +361,102 @@ async def _authorize_oss_managed_v2_correlation(
     return QuotaCheckResult(has_quota=True)
 
 
+async def _authorize_oss_managed_v2_run(
+    *,
+    workflow_id: int,
+    workflow_run_id: int,
+    service_key: str,
+    user_config: Any,
+) -> QuotaCheckResult:
+    try:
+        authorization = await mps_service_key_client.authorize_service_key_run_start(
+            service_key=service_key,
+            workflow_run_id=workflow_run_id,
+            require_correlation_id=True,
+            minimum_credits=MINIMUM_DOGRAH_CREDITS_FOR_CALL,
+            metadata={"workflow_id": workflow_id},
+        )
+    except httpx.HTTPStatusError as e:
+        status_code = getattr(e.response, "status_code", None)
+        if status_code not in {404, 405}:
+            logger.error(
+                "Failed to authorize OSS managed v2 workflow start for workflow {} run {}: {}",
+                workflow_id,
+                workflow_run_id,
+                e,
+            )
+            return QuotaCheckResult(
+                has_quota=False,
+                error_code="quota_check_failed",
+                error_message="Could not verify Dograh credits. Please try again.",
+            )
+
+        logger.info(
+            "MPS service-key run authorization is unavailable; using legacy "
+            "quota and correlation endpoints"
+        )
+        legacy_quota = await _authorize_oss_dograh_keys(
+            dograh_api_keys={service_key},
+        )
+        if not legacy_quota.has_quota:
+            return legacy_quota
+        return await _authorize_oss_managed_v2_correlation(
+            workflow_id=workflow_id,
+            workflow_run_id=workflow_run_id,
+            user_config=user_config,
+        )
+    except _MPS_UNREACHABLE_ERRORS as e:
+        return _mps_unreachable_result("OSS run authorization", e)
+    except Exception as e:
+        logger.error(
+            "Failed to authorize OSS managed v2 workflow start for workflow {} run {}: {}",
+            workflow_id,
+            workflow_run_id,
+            e,
+        )
+        return QuotaCheckResult(
+            has_quota=False,
+            error_code="quota_check_failed",
+            error_message="Could not verify Dograh credits. Please try again.",
+        )
+
+    remaining = _safe_float(authorization.get("remaining_credits"))
+    if (
+        not authorization.get("allowed", False)
+        or remaining < MINIMUM_DOGRAH_CREDITS_FOR_CALL
+    ):
+        logger.warning(
+            "Insufficient Dograh credits for key ...{}: {:.2f} credits remaining",
+            service_key[-8:],
+            remaining,
+        )
+        return _insufficient_oss_quota_result()
+
+    try:
+        await _store_run_correlation_id(
+            workflow_run_id,
+            authorization.get("correlation_id"),
+        )
+    except Exception as e:
+        logger.error(
+            "Failed to store MPS correlation id for workflow_run_id {}: {}",
+            workflow_run_id,
+            e,
+        )
+        return QuotaCheckResult(
+            has_quota=False,
+            error_code="quota_check_failed",
+            error_message="Could not verify Dograh credits. Please try again.",
+        )
+
+    logger.info(
+        "Dograh run authorization passed for key ...{}: {:.2f} credits remaining",
+        service_key[-8:],
+        remaining,
+    )
+    return QuotaCheckResult(has_quota=True)
+
+
 async def authorize_workflow_run_start(
     *,
     workflow_id: int,
@@ -518,16 +614,36 @@ async def authorize_workflow_run_start(
             )
 
         dograh_api_keys = _dograh_api_keys(user_config)
-        if dograh_api_keys:
+        if workflow_run_id is None or not uses_managed_model_services_v2(user_config):
+            if dograh_api_keys:
+                return await _authorize_oss_dograh_keys(
+                    dograh_api_keys=dograh_api_keys,
+                )
+            return QuotaCheckResult(has_quota=True)
+
+        correlation_service_key = get_dograh_service_api_key(user_config)
+        if not correlation_service_key:
+            return QuotaCheckResult(
+                has_quota=False,
+                error_code="invalid_service_key",
+                error_message=(
+                    "You have invalid keys in your model configuration. "
+                    "Please validate the service keys."
+                ),
+            )
+
+        keys_requiring_legacy_check = dograh_api_keys - {correlation_service_key}
+        if keys_requiring_legacy_check:
             oss_result = await _authorize_oss_dograh_keys(
-                dograh_api_keys=dograh_api_keys,
+                dograh_api_keys=keys_requiring_legacy_check,
             )
             if not oss_result.has_quota:
                 return oss_result
 
-        return await _authorize_oss_managed_v2_correlation(
+        return await _authorize_oss_managed_v2_run(
             workflow_id=workflow.id,
             workflow_run_id=workflow_run_id,
+            service_key=correlation_service_key,
             user_config=user_config,
         )
 

--- a/api/services/quota_service.py
+++ b/api/services/quota_service.py
@@ -45,6 +45,11 @@ HOSTED_QUOTA_EXCEEDED_MESSAGE = (
     "or change providers in Models configurations."
 )
 
+OSS_HOSTED_KEY_QUOTA_EXCEEDED_MESSAGE = (
+    "The organization linked to this Dograh service key has insufficient credits. "
+    "Please add credits at app.dograh.com or change providers in Models configurations."
+)
+
 SERVICE_TOKEN_ORG_MISMATCH_MESSAGE = (
     "The Dograh service token being used is created from another account. "
     "Please create a new service token from the Developers tab and use it in "
@@ -95,6 +100,39 @@ def _mps_unreachable_result(
         error,
     )
     return QuotaCheckResult(has_quota=True)
+
+
+def _managed_v2_authorization_failed_result() -> QuotaCheckResult:
+    return QuotaCheckResult(
+        has_quota=False,
+        error_code="quota_check_failed",
+        error_message="Could not verify Dograh credits. Please try again.",
+    )
+
+
+def _required_correlation_id(authorization: dict[str, Any]) -> str | None:
+    correlation_id = authorization.get("correlation_id")
+    if not isinstance(correlation_id, str):
+        return None
+    correlation_id = correlation_id.strip()
+    return correlation_id or None
+
+
+def _oss_run_authorization_denied_result(
+    authorization: dict[str, Any],
+) -> QuotaCheckResult:
+    if authorization.get("error") == "insufficient_credits":
+        message = authorization.get("message")
+        return QuotaCheckResult(
+            has_quota=False,
+            error_code="insufficient_credits",
+            error_message=(
+                message
+                if isinstance(message, str) and message.strip()
+                else OSS_HOSTED_KEY_QUOTA_EXCEEDED_MESSAGE
+            ),
+        )
+    return _insufficient_oss_quota_result()
 
 
 def _service_uses_dograh(service: Any) -> bool:
@@ -217,6 +255,13 @@ async def _authorize_hosted_workflow_run_start(
             },
         )
     except _MPS_UNREACHABLE_ERRORS as e:
+        if requires_correlation:
+            logger.warning(
+                "MPS unreachable during hosted managed-v2 run authorization; "
+                "denying workflow run because a correlation id is required: {}",
+                e,
+            )
+            return _managed_v2_authorization_failed_result()
         return _mps_unreachable_result("hosted run authorization", e)
     except Exception as e:
         logger.warning(
@@ -248,10 +293,18 @@ async def _authorize_hosted_workflow_run_start(
         )
         return _insufficient_hosted_quota_result()
 
+    correlation_id = _required_correlation_id(authorization)
+    if requires_correlation and not correlation_id:
+        logger.error(
+            "MPS authorized hosted managed-v2 workflow run {} without a correlation id",
+            workflow_run_id,
+        )
+        return _managed_v2_authorization_failed_result()
+
     try:
         await _store_run_correlation_id(
             workflow_run_id,
-            authorization.get("correlation_id"),
+            correlation_id,
         )
     except Exception as e:
         logger.error(
@@ -339,12 +392,26 @@ async def _authorize_oss_managed_v2_correlation(
             service_key=service_key,
             workflow_run_id=workflow_run_id,
         )
+        correlation_id = _required_correlation_id(response)
+        if not correlation_id:
+            logger.error(
+                "MPS correlation endpoint returned no correlation id for OSS "
+                "managed-v2 workflow {} run {}",
+                workflow_id,
+                workflow_run_id,
+            )
+            return _managed_v2_authorization_failed_result()
         await _store_run_correlation_id(
             workflow_run_id,
-            response.get("correlation_id"),
+            correlation_id,
         )
     except _MPS_UNREACHABLE_ERRORS as e:
-        return _mps_unreachable_result("OSS correlation creation", e)
+        logger.warning(
+            "MPS unreachable during OSS managed-v2 correlation creation; "
+            "denying workflow run because a correlation id is required: {}",
+            e,
+        )
+        return _managed_v2_authorization_failed_result()
     except Exception as e:
         logger.error(
             "Failed to authorize OSS managed v2 workflow start for workflow {} run {}: {}",
@@ -406,7 +473,12 @@ async def _authorize_oss_managed_v2_run(
             user_config=user_config,
         )
     except _MPS_UNREACHABLE_ERRORS as e:
-        return _mps_unreachable_result("OSS run authorization", e)
+        logger.warning(
+            "MPS unreachable during OSS managed-v2 run authorization; "
+            "denying workflow run because a correlation id is required: {}",
+            e,
+        )
+        return _managed_v2_authorization_failed_result()
     except Exception as e:
         logger.error(
             "Failed to authorize OSS managed v2 workflow start for workflow {} run {}: {}",
@@ -430,12 +502,21 @@ async def _authorize_oss_managed_v2_run(
             service_key[-8:],
             remaining,
         )
-        return _insufficient_oss_quota_result()
+        return _oss_run_authorization_denied_result(authorization)
+
+    correlation_id = _required_correlation_id(authorization)
+    if not correlation_id:
+        logger.error(
+            "MPS authorized OSS managed-v2 workflow {} run {} without a correlation id",
+            workflow_id,
+            workflow_run_id,
+        )
+        return _managed_v2_authorization_failed_result()
 
     try:
         await _store_run_correlation_id(
             workflow_run_id,
-            authorization.get("correlation_id"),
+            correlation_id,
         )
     except Exception as e:
         logger.error(

--- a/api/tests/test_mps_service_key_client.py
+++ b/api/tests/test_mps_service_key_client.py
@@ -201,6 +201,66 @@ async def test_authorize_workflow_run_start_uses_hosted_org_auth(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_authorize_service_key_run_start_uses_bearer_auth(monkeypatch):
+    calls = []
+
+    class FakeAsyncClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, json, headers):
+            calls.append(("POST", url, json, headers))
+            return _Response(
+                200,
+                {
+                    "allowed": True,
+                    "remaining_credits": "25.0000",
+                    "correlation_id": "mps-corr-123",
+                },
+            )
+
+    monkeypatch.setattr(
+        "api.services.mps_service_key_client.httpx.AsyncClient", FakeAsyncClient
+    )
+
+    client = MPSServiceKeyClient()
+
+    assert await client.authorize_service_key_run_start(
+        service_key="mps_sk_paid",
+        workflow_run_id=88,
+        require_correlation_id=True,
+        minimum_credits=0.1,
+        metadata={"workflow_id": 7},
+    ) == {
+        "allowed": True,
+        "remaining_credits": "25.0000",
+        "correlation_id": "mps-corr-123",
+    }
+    assert calls == [
+        (
+            "POST",
+            f"{client.base_url}/api/v1/service-keys/run-authorization/self",
+            {
+                "workflow_run_id": 88,
+                "require_correlation_id": True,
+                "minimum_credits": 0.1,
+                "metadata": {"workflow_id": 7},
+            },
+            {
+                "Authorization": "Bearer mps_sk_paid",
+                "Content-Type": "application/json",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_ensure_billing_account_v2_uses_balance_endpoint(monkeypatch):
     calls = []
 

--- a/api/tests/test_quota_service.py
+++ b/api/tests/test_quota_service.py
@@ -313,6 +313,34 @@ async def test_authorize_workflow_run_managed_v2_stores_hosted_correlation(
 
 
 @pytest.mark.asyncio
+async def test_hosted_managed_v2_authorization_rejects_missing_correlation(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        quota_service.mps_service_key_client,
+        "authorize_workflow_run_start",
+        AsyncMock(
+            return_value={
+                "allowed": True,
+                "billing_mode": "v2",
+                "remaining_credits": "25.0",
+            }
+        ),
+    )
+
+    result = await quota_service._authorize_hosted_workflow_run_start(
+        workflow_owner=_workflow_owner(),
+        organization_id=42,
+        workflow_id=7,
+        workflow_run_id=88,
+        user_config=_dograh_config(managed_service_version=2),
+    )
+
+    assert result.has_quota is False
+    assert result.error_code == "quota_check_failed"
+
+
+@pytest.mark.asyncio
 async def test_authorize_workflow_run_service_token_from_wrong_org_prompts_new_token(
     monkeypatch,
 ):
@@ -469,6 +497,66 @@ async def test_authorize_workflow_run_oss_uses_key_paths_not_workflow_org(
 
 
 @pytest.mark.asyncio
+async def test_oss_run_authorization_rejects_missing_correlation(monkeypatch):
+    authorize = AsyncMock(
+        return_value={
+            "allowed": True,
+            "remaining_credits": "25.0",
+            "correlation_id": None,
+        }
+    )
+    get_workflow_run = AsyncMock()
+    monkeypatch.setattr(
+        quota_service.mps_service_key_client,
+        "authorize_service_key_run_start",
+        authorize,
+    )
+    monkeypatch.setattr(
+        quota_service.db_client,
+        "get_workflow_run_by_id",
+        get_workflow_run,
+    )
+
+    result = await quota_service._authorize_oss_managed_v2_run(
+        workflow_id=7,
+        workflow_run_id=88,
+        service_key="mps_sk_12345678",
+        user_config=_dograh_config(managed_service_version=2),
+    )
+
+    assert result.has_quota is False
+    assert result.error_code == "quota_check_failed"
+    get_workflow_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_oss_run_authorization_preserves_hosted_key_credit_denial(monkeypatch):
+    monkeypatch.setattr(
+        quota_service.mps_service_key_client,
+        "authorize_service_key_run_start",
+        AsyncMock(
+            return_value={
+                "allowed": False,
+                "remaining_credits": "0",
+                "error": "insufficient_credits",
+                "message": "Organization has insufficient billing credits.",
+            }
+        ),
+    )
+
+    result = await quota_service._authorize_oss_managed_v2_run(
+        workflow_id=7,
+        workflow_run_id=88,
+        service_key="mps_sk_12345678",
+        user_config=_dograh_config(managed_service_version=2),
+    )
+
+    assert result.has_quota is False
+    assert result.error_code == "insufficient_credits"
+    assert result.error_message == "Organization has insufficient billing credits."
+
+
+@pytest.mark.asyncio
 async def test_oss_run_authorization_falls_back_for_older_mps(monkeypatch):
     api_key = "mps_sk_12345678"
     request = httpx.Request(
@@ -532,6 +620,24 @@ async def test_oss_run_authorization_falls_back_for_older_mps(monkeypatch):
         88,
         initial_context={MPS_CORRELATION_ID_CONTEXT_KEY: "legacy-corr-123"},
     )
+
+
+@pytest.mark.asyncio
+async def test_legacy_oss_correlation_rejects_missing_id(monkeypatch):
+    monkeypatch.setattr(
+        quota_service.mps_service_key_client,
+        "create_correlation_id",
+        AsyncMock(return_value={}),
+    )
+
+    result = await quota_service._authorize_oss_managed_v2_correlation(
+        workflow_id=7,
+        workflow_run_id=88,
+        user_config=_dograh_config(managed_service_version=2),
+    )
+
+    assert result.has_quota is False
+    assert result.error_code == "quota_check_failed"
 
 
 @pytest.mark.asyncio
@@ -1057,7 +1163,7 @@ async def test_authorize_workflow_run_fails_closed_on_oss_quota_mps_http_error(
 
 
 @pytest.mark.asyncio
-async def test_authorize_workflow_run_opens_when_oss_run_authorization_is_unreachable(
+async def test_authorize_workflow_run_denies_when_oss_run_authorization_is_unreachable(
     monkeypatch,
 ):
     request = httpx.Request(
@@ -1091,7 +1197,8 @@ async def test_authorize_workflow_run_opens_when_oss_run_authorization_is_unreac
         workflow_run_id=88,
     )
 
-    assert result.has_quota is True
+    assert result.has_quota is False
+    assert result.error_code == "quota_check_failed"
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_quota_service.py
+++ b/api/tests/test_quota_service.py
@@ -391,10 +391,15 @@ async def test_authorize_workflow_run_oss_uses_key_paths_not_workflow_org(
         return_value=_dograh_config(api_key, managed_service_version=2)
     )
     hosted_authorize = AsyncMock()
-    check_usage = AsyncMock(
-        return_value={"total_credits_used": 1.0, "remaining_credits": 499.0}
+    service_key_authorize = AsyncMock(
+        return_value={
+            "allowed": True,
+            "remaining_credits": "499.0",
+            "correlation_id": "oss-corr-123",
+        }
     )
-    create_correlation = AsyncMock(return_value={"correlation_id": "oss-corr-123"})
+    check_usage = AsyncMock()
+    create_correlation = AsyncMock()
     update_workflow_run = AsyncMock()
 
     monkeypatch.setattr(quota_service, "DEPLOYMENT_MODE", "oss")
@@ -426,6 +431,11 @@ async def test_authorize_workflow_run_oss_uses_key_paths_not_workflow_org(
     )
     monkeypatch.setattr(
         quota_service.mps_service_key_client,
+        "authorize_service_key_run_start",
+        service_key_authorize,
+    )
+    monkeypatch.setattr(
+        quota_service.mps_service_key_client,
         "check_service_key_usage",
         check_usage,
     )
@@ -443,6 +453,76 @@ async def test_authorize_workflow_run_oss_uses_key_paths_not_workflow_org(
 
     assert result.has_quota is True
     hosted_authorize.assert_not_awaited()
+    service_key_authorize.assert_awaited_once_with(
+        service_key=api_key,
+        workflow_run_id=88,
+        require_correlation_id=True,
+        minimum_credits=quota_service.MINIMUM_DOGRAH_CREDITS_FOR_CALL,
+        metadata={"workflow_id": 7},
+    )
+    check_usage.assert_not_awaited()
+    create_correlation.assert_not_awaited()
+    update_workflow_run.assert_awaited_once_with(
+        88,
+        initial_context={MPS_CORRELATION_ID_CONTEXT_KEY: "oss-corr-123"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_oss_run_authorization_falls_back_for_older_mps(monkeypatch):
+    api_key = "mps_sk_12345678"
+    request = httpx.Request(
+        "POST",
+        "https://services.dograh.com/api/v1/service-keys/run-authorization/self",
+    )
+    response = httpx.Response(404, request=request)
+    combined_authorize = AsyncMock(
+        side_effect=httpx.HTTPStatusError(
+            "Not found",
+            request=request,
+            response=response,
+        )
+    )
+    check_usage = AsyncMock(return_value={"remaining_credits": 25.0})
+    create_correlation = AsyncMock(return_value={"correlation_id": "legacy-corr-123"})
+    workflow_run = SimpleNamespace(initial_context={})
+    update_workflow_run = AsyncMock()
+
+    monkeypatch.setattr(
+        quota_service.mps_service_key_client,
+        "authorize_service_key_run_start",
+        combined_authorize,
+    )
+    monkeypatch.setattr(
+        quota_service.mps_service_key_client,
+        "check_service_key_usage",
+        check_usage,
+    )
+    monkeypatch.setattr(
+        quota_service.mps_service_key_client,
+        "create_correlation_id",
+        create_correlation,
+    )
+    monkeypatch.setattr(
+        quota_service.db_client,
+        "get_workflow_run_by_id",
+        AsyncMock(return_value=workflow_run),
+    )
+    monkeypatch.setattr(
+        quota_service.db_client,
+        "update_workflow_run",
+        update_workflow_run,
+    )
+
+    result = await quota_service._authorize_oss_managed_v2_run(
+        workflow_id=7,
+        workflow_run_id=88,
+        service_key=api_key,
+        user_config=_dograh_config(api_key, managed_service_version=2),
+    )
+
+    assert result.has_quota is True
+    combined_authorize.assert_awaited_once()
     check_usage.assert_awaited_once_with(api_key)
     create_correlation.assert_awaited_once_with(
         service_key=api_key,
@@ -450,7 +530,7 @@ async def test_authorize_workflow_run_oss_uses_key_paths_not_workflow_org(
     )
     update_workflow_run.assert_awaited_once_with(
         88,
-        initial_context={MPS_CORRELATION_ID_CONTEXT_KEY: "oss-corr-123"},
+        initial_context={MPS_CORRELATION_ID_CONTEXT_KEY: "legacy-corr-123"},
     )
 
 
@@ -977,12 +1057,12 @@ async def test_authorize_workflow_run_fails_closed_on_oss_quota_mps_http_error(
 
 
 @pytest.mark.asyncio
-async def test_authorize_workflow_run_opens_when_oss_correlation_mps_is_unreachable(
+async def test_authorize_workflow_run_opens_when_oss_run_authorization_is_unreachable(
     monkeypatch,
 ):
     request = httpx.Request(
         "POST",
-        "https://services.dograh.com/api/v1/service-keys/correlation-id/self",
+        "https://services.dograh.com/api/v1/service-keys/run-authorization/self",
     )
 
     monkeypatch.setattr(quota_service, "DEPLOYMENT_MODE", "oss")
@@ -999,12 +1079,7 @@ async def test_authorize_workflow_run_opens_when_oss_correlation_mps_is_unreacha
     )
     monkeypatch.setattr(
         quota_service.mps_service_key_client,
-        "check_service_key_usage",
-        AsyncMock(return_value={"remaining_credits": 25.0}),
-    )
-    monkeypatch.setattr(
-        quota_service.mps_service_key_client,
-        "create_correlation_id",
+        "authorize_service_key_run_start",
         AsyncMock(
             side_effect=httpx.ConnectError("connection refused", request=request)
         ),
@@ -1042,13 +1117,14 @@ async def test_authorize_workflow_run_fails_closed_when_storing_oss_correlation(
     )
     monkeypatch.setattr(
         quota_service.mps_service_key_client,
-        "check_service_key_usage",
-        AsyncMock(return_value={"remaining_credits": 25.0}),
-    )
-    monkeypatch.setattr(
-        quota_service.mps_service_key_client,
-        "create_correlation_id",
-        AsyncMock(return_value={"correlation_id": "oss-corr-123"}),
+        "authorize_service_key_run_start",
+        AsyncMock(
+            return_value={
+                "allowed": True,
+                "remaining_credits": 25.0,
+                "correlation_id": "oss-corr-123",
+            }
+        ),
     )
 
     result = await quota_service.authorize_workflow_run_start(


### PR DESCRIPTION
## Summary

- replace the sequential OSS managed-v2 usage and correlation calls with one service-key run-authorization request
- retain per-key quota checks for any additional distinct Dograh service keys
- fall back to the legacy `/usage/self` and `/correlation-id/self` flow when MPS returns 404 or 405
- keep hosted organization authorization unchanged

## MPS dependency

- dograh-hq/model_services#8

Deploy the MPS PR first for the single-round-trip path. This PR remains compatible with an older MPS through the legacy fallback.

## Testing

- `api/tests/test_mps_service_key_client.py`
- `api/tests/test_quota_service.py`
- `api/tests/test_telephony_routes.py`

43 focused tests pass, including inbound telephony coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Combine OSS managed‑v2 run authorization into a single `POST /api/v1/service-keys/run-authorization/self` call and require a persisted MPS correlation ID for all managed‑v2 runs; deny when the ID is missing or when MPS is unreachable. Hosted org flow remains, but managed‑v2 now also fails closed without a correlation ID.

- **Refactors**
  - Replaced sequential `/usage/self` + `/correlation-id/self` with `authorize_service_key_run_start` in the MPS client (passes `require_correlation_id` and `minimum_credits`) and stores the returned `correlation_id`.
  - Enforced correlation IDs for managed‑v2 (hosted and OSS): reject on missing IDs and when MPS is unreachable; preserve MPS `insufficient_credits` errors; clarified OSS hosted‑key credit message.
  - Kept per-key quota checks for additional Dograh service keys; use the combined authorization for the correlation service key.
  - Fallback to legacy endpoints on 404/405; legacy correlation now also requires an ID and denies if missing.

- **Dependencies**
  - Requires updated `dograh-hq/model_services` exposing `POST /api/v1/service-keys/run-authorization/self`; fallback keeps compatibility with older versions.

<sup>Written for commit ad6b1c4c726e221fda170daedaad32b8bed15fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change combines OSS managed-v2 credit authorization and correlation-ID creation into one service-key request while preserving the legacy quota and correlation flow for older MPS deployments.

The managed-v2 authorization paths were exercised directly. A whitespace-only correlation ID was rejected without updating the workflow run, and both HTTP 404 and 405 from the combined endpoint used the legacy balance check and correlation creation flow, persisting the returned correlation ID. The focused MPS client and quota-service tests also passed: 40 tests passed.

No review comments were raised. The exercised failure hypotheses were disproved by the observed behavior: missing or blank correlation IDs do not authorize a run, while legacy-compatible MPS responses continue to authorize and store a valid correlation ID.

<h3>Confidence Score: 5/5</h3>

The PR is safe to merge; no blocking failure remains in the exercised managed-v2 authorization paths.

Runtime checks confirmed that blank correlation IDs are denied before persistence and that 404/405 compatibility responses use the legacy balance and correlation flow. The focused test suite passed.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the focused pytest suite for api/tests/test\_mps\_service\_key\_client.py and api/tests/test\_quota\_service.py, and the tests reported 40 passed in 0.53 seconds.
- I executed the OSS managed-v2 correlation repro against the current HEAD, which showed has\_quota=False and error\_code='quota\_check\_failed' with db\_reads=0 for a whitespace correlation ID, and it persisted legacy correlations for both 404 and 405 paths.
- I ran the focused pytest suite again and observed 40 passed in 0.36 seconds.
- Artifacts capturing the reproduction script and related logs were created to aid review.

<a href="https://app.greptile.com/trex/runs/16884112/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: require managed v2 correlation ids"](https://github.com/dograh-hq/dograh/commit/ad6b1c4c726e221fda170daedaad32b8bed15fe8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49308248)</sub>

<!-- /greptile_comment -->