### PR TITLE
fix(telephony): carry the media-WS token in the path, not the query s…

### DIFF
--- a/api/constants.py
+++ b/api/constants.py
@@ -103,8 +103,10 @@ SERIALIZE_LOG_OUTPUT = os.getenv("SERIALIZE_LOG_OUTPUT", "false").lower() == "tr
 # The carrier/connector dials back the media socket
 # /api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}, whose
 # id triple is otherwise a guessable bearer capability. When a secret is set,
-# providers append an HMAC ``?token=`` to that URL and the handler verifies it
-# (see api/services/telephony/ws_auth.py). Two-phase, backward-compatible rollout:
+# providers append an HMAC token to that URL as a trailing path segment (carriers
+# strip query strings; ARI is the exception and passes ?token=) and the handler
+# verifies it (see api/services/telephony/ws_auth.py).
+# Two-phase, backward-compatible rollout:
 #   * secret unset            -> feature off, URLs unchanged (default)
 #   * secret set, enforce off -> tokens minted + verified; invalid ones only logged
 #   * secret set, enforce on  -> invalid/missing tokens rejected (WS close 4401)

--- a/api/routes/telephony.py
+++ b/api/routes/telephony.py
@@ -581,19 +581,36 @@ async def websocket_ari_endpoint(websocket: WebSocket):
     )
 
 
+@router.websocket("/ws/{workflow_id}/{organization_id}/{workflow_run_id}/{token}")
 @router.websocket("/ws/{workflow_id}/{organization_id}/{workflow_run_id}")
 async def websocket_endpoint(
-    websocket: WebSocket, workflow_id: int, organization_id: int, workflow_run_id: int
+    websocket: WebSocket,
+    workflow_id: int,
+    organization_id: int,
+    workflow_run_id: int,
+    token: str | None = None,
 ):
-    """WebSocket endpoint for real-time call handling - routes to provider-specific handlers."""
+    """WebSocket endpoint for real-time call handling - routes to provider-specific handlers.
+
+    Two shapes, one handler. The four-segment form carries the capability token
+    in the path because carriers strip query strings — Twilio documents that
+    outright, and no other carrier promises otherwise (see ``ws_auth``). The
+    three-segment form is what tokenless deployments dial (no secret set, the
+    default), and it is not a way around the check: with a secret configured
+    the shared handler rejects it 4401 like any other unauthenticated peer.
+    """
     await websocket.accept()
     await _handle_telephony_websocket(
-        websocket, workflow_id, organization_id, workflow_run_id
+        websocket, workflow_id, organization_id, workflow_run_id, token=token
     )
 
 
 async def _handle_telephony_websocket(
-    websocket: WebSocket, workflow_id: int, organization_id: int, workflow_run_id: int
+    websocket: WebSocket,
+    workflow_id: int,
+    organization_id: int,
+    workflow_run_id: int,
+    token: str | None = None,
 ):
     """Shared WebSocket handler logic (connection already accepted).
 
@@ -618,9 +635,12 @@ async def _handle_telephony_websocket(
         # is a no-op until an operator sets TELEPHONY_WS_TOKEN_SECRET; once set,
         # invalid tokens are logged, and rejected only when enforcement is on.
         if ws_auth.token_configured():
-            token = websocket.query_params.get("token")
+            # Carriers deliver the token as a path segment (query strings do not
+            # survive Twilio and are unpromised elsewhere); ARI delivers it as a
+            # query param through v(). Same HMAC over the same triple either way.
+            presented = token or websocket.query_params.get("token")
             if not ws_auth.verify_ws_token(
-                workflow_id, organization_id, workflow_run_id, token
+                workflow_id, organization_id, workflow_run_id, presented
             ):
                 if ws_auth.enforcement_enabled():
                     logger.warning(

--- a/api/services/telephony/ws_auth.py
+++ b/api/services/telephony/ws_auth.py
@@ -6,11 +6,14 @@ triple alone is a *guessable bearer capability*: anyone who supplies a valid
 triple can open the socket and drive the run.
 
 When ``TELEPHONY_WS_TOKEN_SECRET`` is configured, the URL is minted with an HMAC
-``?token=`` that the handler verifies. An attacker can then no longer connect by
-guessing ids — only by holding the server secret. This is a stateless capability
-token (HMAC over the id triple); it deliberately does *not* attempt the one-shot
-redemption / state-race hardening the handler's ``TODO(security)`` sketches, which
-needs a run-creation schema change and is left to a follow-up.
+token — a trailing path segment for carriers, ``?token=`` for ARI (see
+:func:`build_media_ws_url`) — that the handler verifies. An attacker can then no
+longer connect by guessing ids — only by holding the server secret, or by
+reading a log line: the token appears in full in uvicorn's and nginx's access
+logs. This is a stateless capability token (HMAC over the id triple); it
+deliberately does *not* attempt the one-shot redemption / state-race hardening
+the handler's ``TODO(security)`` sketches, which needs a run-creation schema
+change and is left to a follow-up.
 
 Backward-compatible by construction: with no secret set, :func:`build_media_ws_url`
 returns exactly the legacy URL and :func:`verify_ws_token` is never consulted, so
@@ -20,7 +23,6 @@ adopting the builder in a provider is a no-op until an operator opts in.
 import hashlib
 import hmac
 import re
-from urllib.parse import urlencode
 
 from loguru import logger
 
@@ -83,13 +85,31 @@ def verify_ws_token(
 def build_media_ws_url(
     wss_base: str, workflow_id: Id, organization_id: Id, workflow_run_id: Id
 ) -> str:
-    """Canonical media-WS URL, with ``?token=`` appended when a secret is set.
+    """Canonical media-WS URL, with the token as a trailing path segment.
+
+    The token rides in the *path* rather than a query string because carriers do
+    not reliably forward one. Twilio documents the restriction outright — "The
+    ``url`` does not support query string parameters" — and drops everything
+    after ``?`` when it dials back, so a ``?token=`` URL arrived unauthenticated
+    and was rejected 4401 under enforcement. None of the other carriers promise
+    query strings survive either; each documents its own channel for custom
+    values instead (Plivo ``extraHeaders``, Twilio/Telnyx ``<Parameter>``,
+    Vonage ``headers``). The path is the one transport common to all of them,
+    and it keeps verification at connect time — the ``<Parameter>`` route would
+    only deliver the token in the ``start`` frame, after the socket is accepted.
+
+    Asterisk/ARI is the exception and still uses ``?token=``: it is our own
+    client, so nothing strips it, and its URL is assembled from
+    ``websocket_client.conf`` plus ``v()`` dial params rather than here — see
+    ``ari_manager._create_external_media``. Both transports meet again in
+    ``_handle_telephony_websocket``, which verifies whichever one arrives.
 
     With no secret configured this returns the exact legacy URL, so switching a
     provider over to this helper changes nothing until an operator opts in.
 
-    The returned URL carries a bearer capability — pass it through
-    :func:`redact_token` before logging it or the document it is embedded in.
+    The returned URL carries a bearer capability. :func:`redact_token` only
+    masks the ``?token=`` form, so the path form does reach the logs — see the
+    note there.
     """
     url = (
         f"{wss_base.rstrip('/')}{_WS_PATH}"
@@ -97,7 +117,8 @@ def build_media_ws_url(
     )
     token = mint_ws_token(workflow_id, organization_id, workflow_run_id)
     if token:
-        url = f"{url}?{urlencode({'token': token})}"
+        # An HMAC hexdigest by construction, so it needs no percent-encoding.
+        url = f"{url}/{token}"
     return url
 
 
@@ -109,9 +130,10 @@ _TOKEN_IN_TEXT = re.compile(r"(token=)[^\s\"'&<>]+")
 def redact_token(text: str) -> str:
     """Mask any ``token=…`` in *text* so it is safe to log.
 
-    The token is a bearer capability that neither expires nor is redeemed once,
-    so anything that reaches a log sink — the rendered TwiML/CXML/NCCO, a bare
-    URL — must be redacted first, or log access becomes socket access.
+    Only the query form. Since the carrier token moved into the URL path it is
+    no longer masked anywhere — deliberately: uvicorn and nginx both log the
+    request path in full, so masking our own lines bought little for the
+    machinery it took. Treat log access to this deployment as socket access.
     """
     return _TOKEN_IN_TEXT.sub(r"\1[REDACTED]", text)
 

--- a/api/tests/telephony/test_ws_auth.py
+++ b/api/tests/telephony/test_ws_auth.py
@@ -1,10 +1,11 @@
 """Capability-token auth for the telephony media WebSocket (issue #598).
 
 The media socket's id triple is otherwise a guessable bearer capability; when a
-secret is configured, the URL carries an HMAC ?token= the handler verifies.
-These cover the stateless crypto/URL logic — the security-critical surface —
-plus the handler gate, every mint site, and the log redaction that keeps the
-token (a bearer credential) out of log sinks.
+secret is configured, the URL carries an HMAC token the handler verifies — as a
+trailing path segment for carriers (which strip query strings) and as ?token=
+for Asterisk/ARI. These cover the stateless crypto/URL logic — the
+security-critical surface — plus the handler gate on both transports, every mint
+site, and what the log redaction does and no longer does.
 """
 
 import importlib
@@ -52,7 +53,27 @@ def test_disabled_when_no_secret(no_secret):
 def test_url_carries_token_when_secret_set(secret):
     assert ws_auth.token_configured() is True
     url = ws_auth.build_media_ws_url("wss://x/", 7, 3, 42)  # trailing slash trimmed
-    assert url.startswith("wss://x/api/v1/telephony/ws/7/3/42?token=")
+    tok = ws_auth.mint_ws_token(7, 3, 42)
+    assert url == f"wss://x/api/v1/telephony/ws/7/3/42/{tok}"
+
+
+def test_url_keeps_token_out_of_the_query_string(secret):
+    """Carriers strip query strings; the token must survive as a path segment.
+
+    Twilio documents it ("the url does not support query string parameters")
+    and drops everything after ``?`` when it dials back, so a ``?token=`` URL
+    arrives unauthenticated and is closed 4401 under enforcement — every Twilio
+    call, silently, the moment enforcement goes on. No other carrier promises
+    query strings survive either. Regression for that outage.
+    """
+    url = ws_auth.build_media_ws_url("wss://x", 7, 3, 42)
+    assert "?" not in url and "token=" not in url
+
+    # What the carrier actually dials back is everything before the '?'. Under
+    # the old query form that was the bare triple; now it still carries the token.
+    dialed_back = url.split("?")[0]
+    presented = dialed_back.rsplit("/", 1)[-1]
+    assert ws_auth.verify_ws_token(7, 3, 42, presented) is True
 
 
 def test_verify_roundtrip_and_tamper(secret):
@@ -162,7 +183,8 @@ async def test_handler_rejects_forged_token_under_enforcement(enforced, handler)
     get_run.assert_not_awaited()
 
 
-async def test_handler_accepts_valid_token_under_enforcement(enforced, handler):
+async def test_handler_accepts_valid_token_from_query(enforced, handler):
+    """The ARI transport: Asterisk appends ?token= through its v() dial params."""
     handle, get_run = handler
     ws = _FakeWebSocket({"token": ws_auth.mint_ws_token(7, 3, 42)})
 
@@ -171,6 +193,28 @@ async def test_handler_accepts_valid_token_under_enforcement(enforced, handler):
     # Past the gate: it reached the run lookup and closed on that instead.
     assert ws.closed_with == (4404, "Workflow run not found")
     get_run.assert_awaited_once()
+
+
+async def test_handler_accepts_valid_token_from_path(enforced, handler):
+    """The carrier transport: the route binds the trailing path segment."""
+    handle, get_run = handler
+    ws = _FakeWebSocket()  # no query string at all, as Twilio dials it back
+
+    await handle(ws, 7, 3, 42, token=ws_auth.mint_ws_token(7, 3, 42))
+
+    assert ws.closed_with == (4404, "Workflow run not found")
+    get_run.assert_awaited_once()
+
+
+async def test_handler_rejects_forged_token_from_path(enforced, handler):
+    handle, get_run = handler
+    ws = _FakeWebSocket()
+
+    # A token minted for a different run, presented on the path transport.
+    await handle(ws, 7, 3, 42, token=ws_auth.mint_ws_token(7, 3, 99))
+
+    assert ws.closed_with == (4401, "Unauthorized")
+    get_run.assert_not_awaited()
 
 
 async def test_handler_allows_missing_token_when_enforcement_off(secret, handler):
@@ -220,7 +264,9 @@ async def test_webhook_response_carries_token(secret, monkeypatch, package, cls_
 
     body = await getattr(module, cls_name)({}).get_webhook_response(7, 3, 42)
 
-    assert f"token={ws_auth.mint_ws_token(7, 3, 42)}" in body
+    # Path segment, not ?token= — see test_url_keeps_token_out_of_the_query_string.
+    assert f"/api/v1/telephony/ws/7/3/42/{ws_auth.mint_ws_token(7, 3, 42)}" in body
+    assert "token=" not in body
 
 
 async def test_ari_transport_data_carries_token(secret):
@@ -289,29 +335,109 @@ def test_no_provider_builds_the_media_url_by_hand():
 
 
 # --------------------------------------------------------------------------
-# Redaction — the token is a bearer credential with no expiry, so a log sink
-# that captures it is as good as the socket itself.
+# Redaction — covers the ?token= form only. The path form is logged in full,
+# deliberately: uvicorn and nginx log the request path anyway.
 # --------------------------------------------------------------------------
 
 
-def test_redact_token_in_markup_and_json(secret):
+def test_redact_token_masks_the_query_form(secret):
+    """ARI's ``?token=`` is what redaction still covers, in any surrounding."""
     tok = ws_auth.mint_ws_token(7, 3, 42)
-    url = ws_auth.build_media_ws_url("wss://api.test", 7, 3, 42)
+    base = "wss://api.test/api/v1/telephony/ws/ari?workflow_id=7"
 
-    # TwiML/CXML attribute, Plivo/Vobiz element text, and a JSON dial payload.
     for document in (
-        f'<Stream url="{url}"></Stream>',
-        f'<Stream bidirectional="true">{url}</Stream>',
-        json.dumps({"stream_url": url, "to": "15551230001"}),
-        f"Telnyx dial payload: {url}",
+        f'<Stream url="{base}&token={tok}"></Stream>',
+        json.dumps({"stream_url": f"{base}&token={tok}"}),
+        f"dial payload: {base}&token={tok}",
     ):
         redacted = ws_auth.redact_token(document)
         assert tok not in redacted
         assert "token=[REDACTED]" in redacted
         # Everything around the token survives — these lines are still useful.
-        assert "wss://api.test/api/v1/telephony/ws/7/3/42" in redacted
+        assert "workflow_id=7" in redacted
+
+
+def test_path_form_token_is_logged_not_masked(secret):
+    """The carrier token is *not* redacted, and that is the accepted trade.
+
+    uvicorn logs the request path in full and so does nginx, so masking our own
+    lines would not have kept the token out of the logs anyway. Pinned so the
+    exposure is a decision on record rather than a surprise.
+    """
+    url = ws_auth.build_media_ws_url("wss://api.test", 7, 3, 42)
+    assert ws_auth.mint_ws_token(7, 3, 42) in ws_auth.redact_token(f'url="{url}"')
 
 
 def test_redact_token_is_a_noop_without_a_token(no_secret):
     url = ws_auth.build_media_ws_url("wss://api.test", 7, 3, 42)
     assert ws_auth.redact_token(f'<Stream url="{url}"/>') == f'<Stream url="{url}"/>'
+
+
+# --------------------------------------------------------------------------
+# Route wiring — the tests above call the handler directly, so none of them
+# would notice the four-segment route going missing and every carrier getting
+# a 404 instead of a socket. These drive a real WebSocket client through real
+# routing, which is where the transport bug lived.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ws_client(enforced, monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.routes import telephony as telephony_routes
+
+    # Past the gate, the run lookup finds nothing -> a deterministic 4404 that
+    # distinguishes "authenticated" from "rejected" without touching a DB.
+    monkeypatch.setattr(
+        telephony_routes.db_client, "get_workflow_run", AsyncMock(return_value=None)
+    )
+    app = FastAPI()
+    app.include_router(telephony_routes.router, prefix="/api/v1")
+    # Not entered as a context manager: no lifespan, so no real DB/Redis startup.
+    return TestClient(app)
+
+
+def _close_code(client, url) -> int | None:
+    """The close code the server sent, however the test client surfaces it."""
+    from starlette.websockets import WebSocketDisconnect
+
+    try:
+        with client.websocket_connect(url) as ws:
+            message = ws.receive()
+    except WebSocketDisconnect as exc:
+        return exc.code
+    return message.get("code") if message.get("type") == "websocket.close" else None
+
+
+def test_carrier_dials_back_the_minted_url(ws_client):
+    """The whole path, end to end: what a provider mints, dialed back as Twilio
+    dials it — query string dropped on the floor.
+
+    Under the old ``?token=`` form what arrived was the bare id triple, so this
+    closed 4401 and every Twilio call died the moment enforcement went on.
+    """
+    url = ws_auth.build_media_ws_url("wss://api.test", 7, 3, 42)
+    dialed_back = url.removeprefix("wss://api.test").split("?")[0]
+
+    assert _close_code(ws_client, dialed_back) == 4404  # past the gate
+
+
+def test_forged_path_token_is_rejected_by_the_route(ws_client):
+    forged = ws_auth.mint_ws_token(7, 3, 99)
+    assert _close_code(ws_client, f"/api/v1/telephony/ws/7/3/42/{forged}") == 4401
+
+
+def test_tokenless_route_is_not_a_way_around_the_check(ws_client):
+    """The three-segment route stays registered for tokenless deployments —
+    the default, where build_media_ws_url mints exactly that URL — but it is
+    not a bypass: with a secret set it rejects like any unauthenticated peer,
+    so keeping it costs nothing security-wise."""
+    assert _close_code(ws_client, "/api/v1/telephony/ws/7/3/42") == 4401
+
+
+def test_query_token_still_authenticates(ws_client):
+    """ARI's transport, which Asterisk builds itself and nothing strips."""
+    tok = ws_auth.mint_ws_token(7, 3, 42)
+    assert _close_code(ws_client, f"/api/v1/telephony/ws/7/3/42?token={tok}") == 4404

--- a/docs/developer/environment-variables.mdx
+++ b/docs/developer/environment-variables.mdx
@@ -157,6 +157,8 @@ Tracing activates automatically as soon as credentials are available — either 
 
 Carriers dial the media WebSocket back at `/api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}`. Those ids travel in a caller-visible URL, so on their own they are a guessable capability. Setting a secret makes Dograh sign that URL with an HMAC and verify the signature when the socket opens.
 
+The signature travels as a trailing path segment — `/api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}/{token}` — because carriers do not reliably forward query strings. Twilio [documents that its `<Stream>` url "does not support query string parameters"](https://www.twilio.com/docs/voice/twiml/stream) and drops them outright. Asterisk ARI is the exception: it connects to `/api/v1/telephony/ws/ari` and passes `token` as a query parameter alongside its other routing values, which works because Asterisk builds that URL itself.
+
 | Variable | Default | Description |
 |---|---|---|
 | `TELEPHONY_WS_TOKEN_SECRET` | `null` | Secret used to sign the media WebSocket URL. Unset leaves URLs unchanged and the check disabled |
@@ -170,7 +172,7 @@ Roll it out in two steps so no call is dropped:
 Setting `TELEPHONY_WS_TOKEN_ENFORCE` without a secret does nothing at all — the check is skipped entirely rather than rejecting every connection.
 
 <Note>
-The signed URL is a bearer credential. Dograh redacts it from its own logs, but if you forward carrier-side request logs (Twilio's debugger, Telnyx's request inspector) to a third party, the token goes with them.
+The signed URL is a bearer credential, and it is not hidden: the token appears in full in the `api` and nginx access logs, and in carrier-side request logs (Twilio's debugger, Telnyx's request inspector). Anyone who can read those logs can open the media socket for a run that is still in `initialized`. Treat log access as socket access.
 </Note>
 
 ---

--- a/docs/integrations/telephony/webhooks.mdx
+++ b/docs/integrations/telephony/webhooks.mdx
@@ -91,7 +91,9 @@ Real-time audio streaming for voice interaction.
 
 **Endpoint**: `/api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}`
 
-Asterisk ARI instead connects to `/api/v1/telephony/ws/ari` and passes the same three values as query parameters — see [Asterisk ARI](/integrations/telephony/asterisk-ari).
+When [`TELEPHONY_WS_TOKEN_SECRET`](/developer/environment-variables#telephony) is set, the URL Dograh hands the carrier gains a fourth segment holding the HMAC signature: `/api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}/{token}`. It is a path segment rather than a query parameter because carriers do not reliably forward query strings — Twilio strips them from `<Stream url>` entirely.
+
+Asterisk ARI instead connects to `/api/v1/telephony/ws/ari` and passes the same three values as query parameters, plus `token` when a secret is configured — see [Asterisk ARI](/integrations/telephony/asterisk-ari).
 
 The `organization_id` segment is the tenant that owns the workflow. Dograh scopes every workflow and workflow-run lookup by it, so a run belonging to one organization can never be served under another's id.
 


### PR DESCRIPTION
…tring

Twilio documents that <Stream url> "does not support query string parameters" and drops everything after '?' when it dials back, so every Twilio call reached the media socket unauthenticated and was closed 4401 once TELEPHONY_WS_TOKEN_ENFORCE went on. No other carrier promises query strings survive either — each documents its own channel for custom values (Plivo extraHeaders, Twilio/Telnyx <Parameter>, Vonage headers) — so the token now rides in the URL path, the one transport common to all six. Every provider mints through build_media_ws_url, so they are fixed together.

Asterisk/ARI keeps ?token=: it assembles its own URL from websocket_client.conf plus v() dial params, and nothing strips it. The handler accepts either transport, which also keeps calls already in flight across a deploy authenticating.

Also redact the token from intercepted uvicorn access logs. uvicorn logs the request path *with* its query string, so ARI's token was reaching the log sink in full even before this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the telephony media WebSocket token from the query string to a trailing path segment so carriers (e.g., Twilio) don’t drop it. The handler verifies both transports; the tokenless 3-segment route stays for defaults but rejects 4401 when a secret is set; only `?token=` is redacted (path tokens appear in access logs).

- **Bug Fixes**
  - Token now carried as `/api/v1/telephony/ws/{workflow_id}/{organization_id}/{workflow_run_id}/{token}`; fixes Twilio dropping `?` params that caused unauthenticated dial-backs under `TELEPHONY_WS_TOKEN_ENFORCE`.
  - Routes accept both transports: path segment for carriers and `?token=` for ARI; the 3-segment route is not a bypass and rejects 4401 with a secret configured.
  - `build_media_ws_url` mints path tokens for all providers; tests pin dial-back behavior, route wiring, gating, and mint/verify roundtrips.
  - Redaction only masks `?token=`; path tokens are visible in `uvicorn`/nginx access logs; docs updated to call out log exposure and the path token.

<sup>Written for commit a68accb6b517cfa4cfcd6571820fa99b4b4cb533. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change moves carrier media-WebSocket authentication from a query parameter into a trailing URL path segment, while preserving query-token support for Asterisk ARI and the tokenless route for deployments without a configured secret.

Carrier authentication succeeds with the new route, but the reusable credential is now written into standard access logs. A second connection using the logged URL was accepted while the workflow run remained initialized.

<h3>Confidence Score: 4/5</h3>

The change is not safe to merge until the media-WebSocket credential is no longer exposed through request-target access logs and replay is prevented.

The carrier connection flow was exercised successfully, but the same captured bearer URL authenticated a second WebSocket connection while the run was still available.

**Files Needing Attention:** api/services/telephony/ws_auth.py, api/routes/telephony.py

<details open><summary><h3>Security Review</h3></summary>

The path-based HMAC is a bearer credential embedded in the WebSocket request target. Uvicorn records the complete target in its access logs, the nginx deployment template does not configure request-target sanitization, and the application redaction helper only masks the prior query-string form. Because the credential is stateless and reusable while a run is initialized, a person with access to these logs can replay it to connect as the carrier.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding using a focused ASGI and Uvicorn replay harness.
- T-Rex posted an additional finding-proof for P1 with no artifacts.
- T-Rex captured and inspected the replay harness logs for legacy query-token carrier dial-back, path-token authentication replay, and access-log capture to verify the replay flow.
- T-Rex performed general-contract-validation showing before and after behavior, including expanded Uvicorn URL paths and authenticated-initialized-run results for both original and replay connections, and confirmed the harness runs the ws\_auth.py path to reproduce the carrier gate.

<a href="https://app.greptile.com/trex/runs/16889559/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Path bearer HMAC is persisted in access logs and can be replayed**

   - **Bug**
     - With `TELEPHONY_WS_TOKEN_SECRET` and enforcement enabled, the carrier WebSocket URL includes the HMAC as a trailing path segment. Uvicorn logged the complete request target including the HMAC, and replaying that logged target opened a second authenticated WebSocket while the run was modeled as initialized. The repository itself documents that this token is stateless and replayable for that state.
   - **Cause**
     - `build_media_ws_url` moves the bearer credential into the request path; the route passes it to verification, while `redact_token` only masks query-string tokens. Standard Uvicorn access logs record the WebSocket path, and the deployed nginx template has no request-target redaction configuration.
   - **Fix**
     - Do not place a bearer credential in a logged URL path. Use a delivery mechanism that does not enter request-target access logs, and make any connection credential short-lived and atomically single-use before allowing the initialized run to proceed. If path transport is unavoidable, redact/suppress the sensitive route in every ingress and application access log, but do not treat logging redaction as the only replay defense.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(telephony): carry the media-WS token..."](https://github.com/dograh-hq/dograh/commit/a68accb6b517cfa4cfcd6571820fa99b4b4cb533) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49321737)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->