### PR TITLE
feat: hydrate error events at error source and seam

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -27,11 +27,13 @@ if SENTRY_DSN and (
 
 from contextlib import asynccontextmanager
 
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from loguru import logger
 
 from api.constants import REDIS_URL
+from api.errors.mps import MPS_UNAVAILABLE_PUBLIC_MESSAGE, MPSUnavailableError
 from api.mcp_server import mcp
 from api.routes.main import router as main_router
 from api.services.pipecat.tracing_config import (
@@ -93,6 +95,19 @@ app = FastAPI(
         {"url": "http://localhost:8000", "description": "Local development"},
     ],
 )
+
+
+@app.exception_handler(MPSUnavailableError)
+async def handle_mps_unavailable_error(
+    _request: Request,
+    _exc: MPSUnavailableError,
+) -> JSONResponse:
+    """Tell callers this is a Dograh outage, not invalid customer config."""
+
+    return JSONResponse(
+        status_code=503,
+        content={"detail": MPS_UNAVAILABLE_PUBLIC_MESSAGE},
+    )
 
 
 # Configure CORS.

--- a/api/errors/failure.py
+++ b/api/errors/failure.py
@@ -1,0 +1,596 @@
+"""Stable failure classification for customer-owned and platform dependencies.
+
+This module is intentionally independent of persistence and notification policy.  It
+classifies a failure at the boundary where it is observed and emits a shadow-mode log
+record that later phases can consume without changing runtime behaviour.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import httpx
+from loguru import logger
+from pipecat.utils.run_context import get_current_org_id
+
+
+class ErrorSource(str, Enum):
+    LLM = "llm"
+    TTS = "tts"
+    STT = "stt"
+    TELEPHONY = "telephony"
+    TRANSPORT = "transport"
+    WEBHOOK = "webhook"
+    INTEGRATION = "integration"
+    TOOL = "tool"
+    KNOWLEDGE_BASE = "knowledge_base"
+    PLATFORM = "platform"
+
+
+class ErrorType(str, Enum):
+    CONFIG_ERROR = "config_error"
+    QUOTA_ERROR = "quota_error"
+    PROVIDER_ERROR = "provider_error"
+    SYSTEM_ERROR = "system_error"
+
+
+class ErrorOwner(str, Enum):
+    USER = "user"
+    OPERATOR = "operator"
+
+
+_SECRET_QUERY_RE = re.compile(
+    r"(?i)([?&](?:api[_-]?key|access[_-]?token|auth[_-]?token|token|signature|secret|password|key)=)([^&#\s]+)"
+)
+_SECRET_NAME_PATTERN = (
+    r"(?:x[-_])?(?:api[-_]?key|access[-_]?token|auth[-_]?token|authorization|"
+    r"token|signature|secret|password|private[-_]?key|client[-_]?secret|"
+    r"aws[-_]?access[-_]?key(?:[-_]?id)?|aws[-_]?secret[-_]?access[-_]?key)"
+)
+_QUOTED_SECRET_ASSIGNMENT_RE = re.compile(
+    rf"(?i)([\"']?{_SECRET_NAME_PATTERN}[\"']?\s*[:=]\s*)([\"'])(.*?)(\2)"
+)
+_SECRET_ASSIGNMENT_RE = re.compile(
+    rf"(?i)([\"']?{_SECRET_NAME_PATTERN}[\"']?\s*[:=]\s*)([^\s,;\"'}}]+)"
+)
+_AUTH_HEADER_RE = re.compile(r"(?i)(\b(?:basic|bearer)\s+)[A-Za-z0-9._~+/=-]+")
+_URL_USERINFO_RE = re.compile(r"(?i)(\b(?:https?|wss?)://)([^/@\s]+)@")
+_HTTP_STATUS_IN_MESSAGE_RE = re.compile(
+    r"(?i)\b(?:http(?:\s+status)?|status(?:_code)?)\s*[:=]?\s*(\d{3})\b"
+)
+_MAX_MESSAGE_LENGTH = 4000
+_FAILURE_METADATA_ATTR = "_dograh_failure_metadata"
+
+
+def redact_failure_message(message: object) -> str:
+    """Remove common credentials from exception text before it reaches a log sink."""
+
+    try:
+        value = str(message)
+    except Exception:
+        value = f"<{type(message).__name__}>"
+
+    value = _URL_USERINFO_RE.sub(r"\1[REDACTED]@", value)
+    value = _SECRET_QUERY_RE.sub(r"\1[REDACTED]", value)
+    value = _AUTH_HEADER_RE.sub(r"\1[REDACTED]", value)
+    value = _QUOTED_SECRET_ASSIGNMENT_RE.sub(r"\1\2[REDACTED]\4", value)
+    value = _SECRET_ASSIGNMENT_RE.sub(r"\1[REDACTED]", value)
+    if len(value) > _MAX_MESSAGE_LENGTH:
+        value = f"{value[:_MAX_MESSAGE_LENGTH]}…"
+    return value
+
+
+def _enum_value(value: object) -> str:
+    enum_value = getattr(value, "value", value)
+    return str(enum_value)
+
+
+def _normalize_provider(provider: object | None) -> str | None:
+    if provider is None:
+        return None
+    normalized = re.sub(r"[^a-z0-9]+", "-", _enum_value(provider).strip().lower())
+    return normalized.strip("-") or None
+
+
+def _normalize_code(code: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", code.strip().lower()).strip("-")
+    return normalized or "platform-unknown"
+
+
+def _resolve_error_owner(
+    error_type: ErrorType, error_owner: ErrorOwner | str | None
+) -> ErrorOwner:
+    """Route responsibility without treating an external provider as an owner."""
+
+    if error_type in (ErrorType.CONFIG_ERROR, ErrorType.QUOTA_ERROR):
+        return ErrorOwner.USER
+    if error_type == ErrorType.SYSTEM_ERROR or error_owner is None:
+        return ErrorOwner.OPERATOR
+    if isinstance(error_owner, ErrorOwner):
+        return error_owner
+    return ErrorOwner(error_owner)
+
+
+@dataclass
+class DograhFailure:
+    source: ErrorSource
+    type: ErrorType
+    code: str
+    internal_message: str
+    external_message: str
+    error_owner: ErrorOwner | str | None = None
+    provider: str | None = None
+    provider_error_code: str | None = None
+    retryable: bool | None = None
+    context: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source, ErrorSource):
+            self.source = ErrorSource(self.source)
+        if not isinstance(self.type, ErrorType):
+            self.type = ErrorType(self.type)
+        self.error_owner = _resolve_error_owner(self.type, self.error_owner)
+        self.provider = _normalize_provider(self.provider)
+        self.provider_error_code = _normalize_provider(self.provider_error_code)
+        self.code = _normalize_code(self.code)
+        self.internal_message = redact_failure_message(self.internal_message)
+        self.external_message = redact_failure_message(self.external_message)
+
+
+@dataclass(frozen=True)
+class ServiceFailureMetadata:
+    """Authoritative source/ownership attached by the service factory."""
+
+    source: ErrorSource
+    provider: str | None
+    error_owner: ErrorOwner
+
+
+def _external_message(source: ErrorSource, error_type: ErrorType) -> str:
+    label = source.value.replace("_", " ")
+    if error_type == ErrorType.CONFIG_ERROR:
+        return f"Check your {label} configuration and credentials."
+    if error_type == ErrorType.QUOTA_ERROR:
+        return f"The {label} account has insufficient quota or credits."
+    if error_type == ErrorType.PROVIDER_ERROR:
+        return f"The external {label} service is temporarily unavailable."
+    return f"Dograh encountered an internal error while processing {label}."
+
+
+def _valid_http_status(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if 100 <= value <= 599 else None
+
+
+def extract_http_status(exc: BaseException) -> int | None:
+    """Extract an HTTP status without confusing vendor error codes for statuses."""
+
+    for attr in ("status_code", "code", "status"):
+        try:
+            status = _valid_http_status(getattr(exc, attr, None))
+        except Exception:
+            status = None
+        if status is not None:
+            return status
+
+    try:
+        response = getattr(exc, "response", None)
+        status = _valid_http_status(getattr(response, "status_code", None))
+    except Exception:
+        status = None
+    return status
+
+
+def extract_provider_error_code(
+    exc: BaseException, *, http_status: int | None = None
+) -> str | None:
+    """Read an optional structured vendor code without interpreting its meaning.
+
+    The code may make a failure easier to correlate with provider documentation,
+    but it never influences ``error_type``. Unstructured exception text is not
+    inspected here, so provider wording changes cannot change fault attribution.
+    """
+
+    for attr in ("error_code", "code"):
+        try:
+            value = getattr(exc, attr, None)
+        except Exception:
+            continue
+        if value is None or isinstance(value, bool) or callable(value):
+            continue
+        value = getattr(value, "value", value)
+        if not isinstance(value, str | int):
+            continue
+
+        raw_code = str(value).strip()
+        if not raw_code or len(raw_code) > 128:
+            continue
+        if raw_code.isdigit() and http_status == int(raw_code):
+            continue
+
+        normalized = re.sub(r"[^a-z0-9]+", "-", raw_code.lower()).strip("-")
+        if normalized:
+            return normalized
+    return None
+
+
+def _type_for_http_status(status_code: int) -> tuple[ErrorType, bool | None]:
+    if status_code in (401, 403):
+        return ErrorType.CONFIG_ERROR, False
+    if status_code in (402, 429):
+        return ErrorType.QUOTA_ERROR, False
+    if status_code == 408 or 500 <= status_code <= 599:
+        return ErrorType.PROVIDER_ERROR, True
+    if 400 <= status_code <= 499:
+        return ErrorType.CONFIG_ERROR, False
+    return ErrorType.SYSTEM_ERROR, None
+
+
+def classify_http_response(
+    status_code: int,
+    message: object,
+    *,
+    source: ErrorSource,
+    provider: object | None = None,
+    provider_error_code: object | None = None,
+    error_owner: ErrorOwner | str | None = None,
+    context: dict[str, Any] | None = None,
+) -> DograhFailure:
+    """Classify an HTTP response at a known external boundary."""
+
+    normalized_provider = _normalize_provider(provider)
+    internal_message = redact_failure_message(message)
+
+    if normalized_provider == "dograh":
+        if status_code == 402:
+            error_type, detail, retryable = (
+                ErrorType.QUOTA_ERROR,
+                "insufficient-credits",
+                False,
+            )
+        else:
+            error_type, detail, retryable = (
+                ErrorType.SYSTEM_ERROR,
+                str(status_code),
+                500 <= status_code <= 599,
+            )
+        error_owner = (
+            ErrorOwner.USER
+            if error_type == ErrorType.QUOTA_ERROR
+            else ErrorOwner.OPERATOR
+        )
+    else:
+        error_type, retryable = _type_for_http_status(status_code)
+        detail = str(status_code)
+
+    code_provider = normalized_provider or source.value.replace("_", "-")
+    return DograhFailure(
+        source=source,
+        type=error_type,
+        code=f"{code_provider}-{detail}",
+        internal_message=internal_message,
+        external_message=_external_message(source, error_type),
+        provider=normalized_provider,
+        provider_error_code=_normalize_provider(provider_error_code),
+        error_owner=error_owner,
+        retryable=retryable,
+        context=dict(context or {}),
+    )
+
+
+def classify_message(
+    message: object,
+    *,
+    source: ErrorSource,
+    provider: object | None = None,
+    error_owner: ErrorOwner | str | None = None,
+    context: dict[str, Any] | None = None,
+) -> DograhFailure:
+    """Classify string-only errors using protocol signals or the safe default."""
+
+    internal_message = redact_failure_message(message)
+    normalized_provider = _normalize_provider(provider)
+    if normalized_provider == "dograh":
+        error_type, detail, retryable = (
+            ErrorType.SYSTEM_ERROR,
+            "unknown",
+            None,
+        )
+        error_owner = ErrorOwner.OPERATOR
+    else:
+        status_match = _HTTP_STATUS_IN_MESSAGE_RE.search(internal_message)
+        if status_match:
+            return classify_http_response(
+                int(status_match.group(1)),
+                internal_message,
+                source=source,
+                provider=normalized_provider,
+                error_owner=error_owner,
+                context=context,
+            )
+        error_type, detail, retryable = ErrorType.SYSTEM_ERROR, "unknown", None
+
+    code_provider = normalized_provider or source.value.replace("_", "-")
+    return DograhFailure(
+        source=source,
+        type=error_type,
+        code=f"{code_provider}-{detail}",
+        internal_message=internal_message,
+        external_message=_external_message(source, error_type),
+        provider=normalized_provider,
+        error_owner=error_owner,
+        retryable=retryable,
+        context=dict(context or {}),
+    )
+
+
+def classify_exception(
+    exc: BaseException,
+    *,
+    source: ErrorSource,
+    provider: object | None = None,
+    error_owner: ErrorOwner | str | None = None,
+    context: dict[str, Any] | None = None,
+) -> DograhFailure:
+    """Pure exception classifier used by all execution seams."""
+
+    failure_context = dict(context or {})
+    failure_context.setdefault("exception_type", type(exc).__name__)
+    traceback_frames: list[str] = []
+    traceback_cursor = exc.__traceback__
+    while traceback_cursor is not None:
+        code = traceback_cursor.tb_frame.f_code
+        traceback_frames.append(
+            f"{code.co_filename}:{traceback_cursor.tb_lineno} in {code.co_name}"
+        )
+        traceback_cursor = traceback_cursor.tb_next
+    if traceback_frames:
+        failure_context.setdefault(
+            "exception_traceback", "\n".join(traceback_frames[-20:])
+        )
+
+    try:
+        detail = str(exc)
+    except Exception:
+        detail = ""
+    internal_message = redact_failure_message(
+        f"{type(exc).__name__}: {detail}" if detail else type(exc).__name__
+    )
+    status_code = extract_http_status(exc)
+    provider_error_code = extract_provider_error_code(exc, http_status=status_code)
+    if status_code is not None:
+        return classify_http_response(
+            status_code,
+            internal_message,
+            source=source,
+            provider=provider,
+            provider_error_code=provider_error_code,
+            error_owner=error_owner,
+            context=failure_context,
+        )
+
+    normalized_provider = _normalize_provider(provider)
+    if normalized_provider == "dograh":
+        exception_identity = f"{type(exc).__module__}.{type(exc).__name__}".lower()
+        transient = isinstance(
+            exc,
+            (
+                httpx.TimeoutException,
+                httpx.ConnectError,
+                ConnectionError,
+                OSError,
+            ),
+        ) or ("websocket" in exception_identity and "closed" in exception_identity)
+        detail_code = (
+            "timeout"
+            if isinstance(exc, httpx.TimeoutException | TimeoutError)
+            else ("connection" if transient else "unknown")
+        )
+        return DograhFailure(
+            source=source,
+            type=ErrorType.SYSTEM_ERROR,
+            code=f"dograh-{detail_code}",
+            internal_message=internal_message,
+            external_message=_external_message(source, ErrorType.SYSTEM_ERROR),
+            provider="dograh",
+            provider_error_code=provider_error_code,
+            error_owner=ErrorOwner.OPERATOR,
+            retryable=True if transient else None,
+            context=failure_context,
+        )
+
+    status_match = _HTTP_STATUS_IN_MESSAGE_RE.search(internal_message)
+    if status_match:
+        return classify_http_response(
+            int(status_match.group(1)),
+            internal_message,
+            source=source,
+            provider=normalized_provider,
+            error_owner=error_owner,
+            context=failure_context,
+        )
+
+    exception_identity = f"{type(exc).__module__}.{type(exc).__name__}".lower()
+    websocket_closed = "websocket" in exception_identity and any(
+        marker in exception_identity for marker in ("closed", "connection")
+    )
+    transient_exception = websocket_closed or isinstance(
+        exc,
+        (
+            httpx.TimeoutException,
+            httpx.ConnectError,
+            ConnectionError,
+            OSError,
+        ),
+    )
+    error_type = (
+        ErrorType.PROVIDER_ERROR if transient_exception else ErrorType.SYSTEM_ERROR
+    )
+    code_provider = normalized_provider or source.value.replace("_", "-")
+    detail_code = "connection" if transient_exception else "unknown"
+    if isinstance(exc, httpx.TimeoutException | TimeoutError):
+        detail_code = "timeout"
+    return DograhFailure(
+        source=source,
+        type=error_type,
+        code=f"{code_provider}-{detail_code}",
+        internal_message=internal_message,
+        external_message=_external_message(source, error_type),
+        provider=normalized_provider,
+        provider_error_code=provider_error_code,
+        error_owner=error_owner,
+        retryable=True if transient_exception else None,
+        context=failure_context,
+    )
+
+
+def annotate_failure_metadata(
+    service: object,
+    *,
+    source: ErrorSource,
+    provider: object | None,
+    error_owner: ErrorOwner | str,
+) -> object:
+    """Attach authoritative provider metadata to a constructed Pipecat service."""
+
+    try:
+        setattr(
+            service,
+            _FAILURE_METADATA_ATTR,
+            ServiceFailureMetadata(
+                source=source,
+                provider=_normalize_provider(provider),
+                error_owner=(
+                    error_owner
+                    if isinstance(error_owner, ErrorOwner)
+                    else ErrorOwner(error_owner)
+                ),
+            ),
+        )
+    except Exception:
+        # Some third-party services may use slots or prohibit attributes.  Error
+        # reporting must never make an otherwise-valid service unusable.
+        pass
+    return service
+
+
+def failure_metadata_for_processor(processor: object | None) -> ServiceFailureMetadata:
+    """Resolve source/provider, preferring factory metadata over registry hints."""
+
+    if processor is None:
+        return ServiceFailureMetadata(ErrorSource.PLATFORM, None, ErrorOwner.OPERATOR)
+    metadata = getattr(processor, _FAILURE_METADATA_ATTR, None)
+    if isinstance(metadata, ServiceFailureMetadata):
+        return metadata
+
+    source = ErrorSource.PLATFORM
+    try:
+        from pipecat.services.llm_service import LLMService
+        from pipecat.services.stt_service import STTService
+        from pipecat.services.tts_service import TTSService
+
+        if isinstance(processor, STTService):
+            source = ErrorSource.STT
+        elif isinstance(processor, TTSService):
+            source = ErrorSource.TTS
+        elif isinstance(processor, LLMService):
+            source = ErrorSource.LLM
+    except Exception:
+        pass
+
+    class_name = type(processor).__name__.lower()
+    if source == ErrorSource.PLATFORM:
+        if "stt" in class_name:
+            source = ErrorSource.STT
+        elif "tts" in class_name:
+            source = ErrorSource.TTS
+        elif "llm" in class_name or "realtime" in class_name:
+            source = ErrorSource.LLM
+
+    provider = None
+    try:
+        from api.services.configuration.registry import (
+            ServiceType,
+            match_registered_provider,
+        )
+
+        service_types = {
+            ErrorSource.STT: (ServiceType.STT,),
+            ErrorSource.TTS: (ServiceType.TTS,),
+            ErrorSource.LLM: (ServiceType.LLM, ServiceType.REALTIME),
+        }.get(source)
+        provider = _normalize_provider(
+            match_registered_provider(class_name, service_types=service_types)
+        )
+    except Exception:
+        # Failure reporting is best effort and must not interfere with an error
+        # path if the configuration registry is unavailable during startup.
+        pass
+
+    # A Dograh-prefixed wrapper is not sufficient evidence that the dependency is
+    # operator-owned; several BYOK adapters use that prefix. Only factory metadata
+    # is authoritative for ownership.
+    return ServiceFailureMetadata(source, provider, ErrorOwner.OPERATOR)
+
+
+def _safe_log_context(context: dict[str, Any]) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    for key, value in context.items():
+        normalized_key = str(key)
+        if any(
+            secret in normalized_key.lower()
+            for secret in ("key", "token", "secret", "password", "authorization", "url")
+        ):
+            continue
+        if value is None or isinstance(value, str | int | float | bool):
+            safe[normalized_key] = (
+                redact_failure_message(value) if isinstance(value, str) else value
+            )
+    return safe
+
+
+def log_failure(
+    failure: DograhFailure,
+    *,
+    level: str = "ERROR",
+    **extra_context: Any,
+) -> None:
+    """Emit one structured and greppable shadow-mode record; never raise."""
+
+    try:
+        context = _safe_log_context({**failure.context, **extra_context})
+        if "org_id" in context and "organization_id" not in context:
+            context["organization_id"] = context.pop("org_id")
+        context.setdefault("organization_id", get_current_org_id())
+        context = {key: value for key, value in context.items() if value is not None}
+
+        bound = logger.bind(
+            error_source=failure.source.value,
+            error_type=failure.type.value,
+            error_owner=failure.error_owner.value,
+            error_code=failure.code,
+            provider=failure.provider,
+            provider_error_code=failure.provider_error_code,
+            retryable=failure.retryable,
+            external_message=failure.external_message,
+            classified=True,
+            classification_mode="explicit",
+            **context,
+        )
+        bound.opt(depth=1).log(
+            level.upper(),
+            "DOGRAH_FAILURE [src={} type={} code={}] [owner={}] {}",
+            failure.source.value,
+            failure.type.value,
+            failure.code,
+            failure.error_owner.value,
+            failure.internal_message,
+        )
+    except Exception:
+        # Deliberately do not attempt a fallback log: the logger itself may be what
+        # failed, and classification must never mask the original error path.
+        return

--- a/api/errors/failure.py
+++ b/api/errors/failure.py
@@ -50,8 +50,12 @@ _SECRET_NAME_PATTERN = (
     r"token|signature|secret|password|private[-_]?key|client[-_]?secret|"
     r"aws[-_]?access[-_]?key(?:[-_]?id)?|aws[-_]?secret[-_]?access[-_]?key)"
 )
+# Consume backslash escapes as a unit and allow literal newlines inside either
+# quote style, so only an unescaped matching quote can terminate the value.
 _QUOTED_SECRET_ASSIGNMENT_RE = re.compile(
-    rf"(?i)([\"']?{_SECRET_NAME_PATTERN}[\"']?\s*[:=]\s*)([\"'])(.*?)(\2)"
+    rf"(?P<prefix>[\"']?{_SECRET_NAME_PATTERN}[\"']?\s*[:=]\s*)"
+    r"(?P<quoted>\"(?:\\[\s\S]|[^\"\\])*\"|'(?:\\[\s\S]|[^'\\])*')",
+    re.IGNORECASE,
 )
 _SECRET_ASSIGNMENT_RE = re.compile(
     rf"(?i)([\"']?{_SECRET_NAME_PATTERN}[\"']?\s*[:=]\s*)([^\s,;\"'}}]+)"
@@ -65,6 +69,12 @@ _MAX_MESSAGE_LENGTH = 4000
 _FAILURE_METADATA_ATTR = "_dograh_failure_metadata"
 
 
+def _redact_quoted_secret_assignment(match: re.Match[str]) -> str:
+    quoted_value = match.group("quoted")
+    quote = quoted_value[0]
+    return f"{match.group('prefix')}{quote}[REDACTED]{quote}"
+
+
 def redact_failure_message(message: object) -> str:
     """Remove common credentials from exception text before it reaches a log sink."""
 
@@ -76,7 +86,7 @@ def redact_failure_message(message: object) -> str:
     value = _URL_USERINFO_RE.sub(r"\1[REDACTED]@", value)
     value = _SECRET_QUERY_RE.sub(r"\1[REDACTED]", value)
     value = _AUTH_HEADER_RE.sub(r"\1[REDACTED]", value)
-    value = _QUOTED_SECRET_ASSIGNMENT_RE.sub(r"\1\2[REDACTED]\4", value)
+    value = _QUOTED_SECRET_ASSIGNMENT_RE.sub(_redact_quoted_secret_assignment, value)
     value = _SECRET_ASSIGNMENT_RE.sub(r"\1[REDACTED]", value)
     if len(value) > _MAX_MESSAGE_LENGTH:
         value = f"{value[:_MAX_MESSAGE_LENGTH]}…"

--- a/api/errors/mps.py
+++ b/api/errors/mps.py
@@ -1,0 +1,21 @@
+"""Errors raised at the Model Proxy Service boundary."""
+
+MPS_UNAVAILABLE_PUBLIC_MESSAGE = (
+    "A Dograh service is temporarily unavailable. Please try again later."
+)
+
+
+class MPSUnavailableError(ConnectionError):
+    """MPS could not complete an operation for a Dograh-owned reason.
+
+    ``status_code`` is retained as structured classifier input. Response bodies are
+    deliberately excluded because upstream payloads may contain sensitive details.
+    """
+
+    def __init__(self, operation: str, *, status_code: int | None = None) -> None:
+        self.operation = operation
+        self.status_code = status_code
+        detail = f"MPS could not complete {operation}"
+        if status_code is not None:
+            detail = f"{detail} (HTTP {status_code})"
+        super().__init__(detail)

--- a/api/errors/telephony_errors.py
+++ b/api/errors/telephony_errors.py
@@ -5,6 +5,8 @@ Centralizes error handling across all telephony providers.
 
 from enum import Enum
 
+from api.errors.failure import DograhFailure, ErrorSource, ErrorType, log_failure
+
 
 class TelephonyError(Enum):
     """Telephony validation error types"""
@@ -31,3 +33,75 @@ TELEPHONY_ERROR_MESSAGES = {
     TelephonyError.QUOTA_EXCEEDED: "Service temporarily unavailable: Your account has exceeded usage limits. Please contact your administrator or upgrade your plan to continue receiving calls.",
     TelephonyError.GENERAL_AUTH_FAILED: "Authentication failed: Please check your webhook URL configuration and ensure your telephony provider settings match your dashboard configuration.",
 }
+
+
+_QUOTA_ERRORS = {
+    TelephonyError.CONCURRENT_CALL_LIMIT,
+    TelephonyError.QUOTA_EXCEEDED,
+}
+
+
+def failure_from_telephony_error(
+    error: TelephonyError,
+    *,
+    provider: str | None = None,
+) -> DograhFailure | None:
+    """Map an inbound validation result onto the stable failure taxonomy."""
+
+    if not isinstance(error, TelephonyError):
+        try:
+            error = TelephonyError(error)
+        except (TypeError, ValueError):
+            provider_code = (provider or "telephony").replace("_", "-")
+            return DograhFailure(
+                source=ErrorSource.TELEPHONY,
+                type=ErrorType.SYSTEM_ERROR,
+                code=f"{provider_code}-unknown-validation-error",
+                internal_message=f"Unknown inbound telephony validation result: {error}",
+                external_message="Dograh could not process the inbound telephony validation result.",
+                provider=provider,
+                retryable=None,
+                context={
+                    "notification_eligible": False,
+                    "tenant_attribution_trusted": False,
+                },
+            )
+    if error == TelephonyError.VALID:
+        return None
+
+    error_type = (
+        ErrorType.QUOTA_ERROR if error in _QUOTA_ERRORS else ErrorType.CONFIG_ERROR
+    )
+    provider_code = (provider or "telephony").replace("_", "-")
+    external_message = TELEPHONY_ERROR_MESSAGES.get(
+        error, TELEPHONY_ERROR_MESSAGES[TelephonyError.GENERAL_AUTH_FAILED]
+    )
+    return DograhFailure(
+        source=ErrorSource.TELEPHONY,
+        type=error_type,
+        code=f"{provider_code}-{error.value.lower().replace('_', '-')}",
+        internal_message=f"Inbound telephony validation failed: {error.value}",
+        external_message=external_message,
+        provider=provider,
+        error_owner="user",
+        retryable=False,
+        context={
+            # A failed signature can be sent by an attacker and must not become a
+            # tenant notification until attribution has been established.
+            "notification_eligible": error
+            != TelephonyError.SIGNATURE_VALIDATION_FAILED,
+            "tenant_attribution_trusted": error
+            != TelephonyError.SIGNATURE_VALIDATION_FAILED,
+        },
+    )
+
+
+def log_telephony_error(
+    error: TelephonyError,
+    *,
+    provider: str | None = None,
+    **context,
+) -> None:
+    failure = failure_from_telephony_error(error, provider=provider)
+    if failure is not None:
+        log_failure(failure, **context)

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -20,6 +20,13 @@ from api.utils.worker import get_worker_id, is_worker_process
 # Track if logging has been initialized
 _logging_initialized = False
 
+_FALLBACK_ERROR_CLASSIFICATION = {
+    "error_owner": "operator",
+    "error_type": "system_error",
+    "error_source": "platform",
+    "error_code": "unclassified-error",
+}
+
 
 class InterceptHandler(logging.Handler):
     """
@@ -41,9 +48,27 @@ class InterceptHandler(logging.Handler):
         ).log(level, record.getMessage())
 
 
-def inject_run_id(record):
-    """Inject run_id from context variable into log record"""
-    record["extra"]["run_id"] = run_id_var.get()
+def enrich_log_record(record):
+    """Inject run context and conservatively classify every ERROR record."""
+
+    extra = record["extra"]
+    extra["run_id"] = run_id_var.get()
+
+    if record["level"].no < logging.ERROR:
+        return
+
+    required_fields = _FALLBACK_ERROR_CLASSIFICATION.keys()
+    has_explicit_classification = all(extra.get(field) for field in required_fields)
+    if has_explicit_classification:
+        extra["classified"] = True
+        extra.setdefault("classification_mode", "explicit")
+        return
+
+    # An incomplete classification is not safe enough for customer routing. Assign
+    # the whole record to the operator so no partial user attribution leaks through.
+    extra.update(_FALLBACK_ERROR_CLASSIFICATION)
+    extra["classified"] = True
+    extra["classification_mode"] = "fallback"
 
 
 def setup_logging():
@@ -67,12 +92,13 @@ def setup_logging():
         # Handler might already be removed
         pass
 
-    # Set default extra values on the shared core so ALL logger references
-    # (including ones imported before this runs) have run_id available.
-    loguru.logger.configure(extra={"run_id": None})
-
-    # Patch loguru to inject run_id
-    patched = loguru.logger.patch(inject_run_id)
+    # Configure the shared core so ALL logger references (including ones imported
+    # before this runs) get the same run and ownership metadata.
+    loguru.logger.configure(
+        extra={"run_id": None},
+        patcher=enrich_log_record,
+    )
+    patched = loguru.logger
 
     log_format = "{time:YYYY-MM-DD HH:mm:ss.SSS} | <level>{level}</level> | [run_id={extra[run_id]}] | {file.name}:{line} | {message}"
 

--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -15,6 +15,8 @@ from api.db import db_client
 from api.db.models import UserModel
 from api.db.telephony_configuration_client import TelephonyConfigurationInUseError
 from api.enums import OrganizationConfigurationKey, PostHogEvent
+from api.errors.failure import ErrorSource, classify_exception, log_failure
+from api.errors.mps import MPSUnavailableError
 from api.schemas.ai_model_configuration import (
     DOGRAH_DEFAULT_LANGUAGE,
     DOGRAH_DEFAULT_VOICE,
@@ -387,14 +389,23 @@ async def get_model_configuration_pricing(
             user.selected_organization_id,
         )
         return ModelConfigurationPricingResponse.model_validate(pricing)
+    except MPSUnavailableError:
+        # The MPS boundary emitted the classified failure. The app-level handler
+        # converts this typed dependency failure to a customer-safe HTTP 503.
+        raise
     except Exception as exc:
-        logger.error(
-            "Failed to get MPS model-configuration pricing for organization {}: {}",
-            user.selected_organization_id,
-            exc,
+        log_failure(
+            classify_exception(
+                exc,
+                source=ErrorSource.PLATFORM,
+                provider="dograh",
+                error_owner="operator",
+            ),
+            organization_id=user.selected_organization_id,
+            operation="validate_billing_pricing_response",
         )
         raise HTTPException(
-            status_code=502,
+            status_code=500,
             detail="Failed to retrieve model configuration pricing",
         ) from exc
 

--- a/api/routes/user.py
+++ b/api/routes/user.py
@@ -2,13 +2,14 @@ from datetime import datetime, timedelta
 from typing import List, Literal, Optional, TypedDict, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from loguru import logger
 from pydantic import BaseModel, ValidationError
 
 from api.db import db_client
 from api.db.models import (
     UserModel,
 )
+from api.errors.failure import ErrorSource, classify_exception, log_failure
+from api.errors.mps import MPSUnavailableError
 from api.schemas.onboarding_state import OnboardingState, OnboardingStateUpdate
 from api.schemas.workflow_configurations import (
     WorkflowConfigurationDefaults,
@@ -474,9 +475,23 @@ async def get_voices(
             voices=[VoiceInfo(**voice) for voice in result.get("voices", [])],
             facets=result.get("facets"),
         )
+    except MPSUnavailableError:
+        # The MPS boundary emitted the classified failure. The app-level handler
+        # converts this typed dependency failure to a customer-safe HTTP 503.
+        raise
     except Exception as e:
-        logger.error(f"Failed to fetch voices for {provider}: {e}")
+        log_failure(
+            classify_exception(
+                e,
+                source=ErrorSource.PLATFORM,
+                provider="dograh",
+                error_owner="operator",
+            ),
+            organization_id=user.selected_organization_id,
+            operation="validate_voice_catalog_response",
+            requested_provider=provider,
+        )
         raise HTTPException(
             status_code=500,
             detail=f"Failed to fetch voices for {provider}",
-        )
+        ) from e

--- a/api/services/configuration/check_validity.py
+++ b/api/services/configuration/check_validity.py
@@ -34,6 +34,7 @@ class APIKeyStatusResponse(TypedDict):
 
 class UserConfigurationValidator:
     def __init__(self):
+        self._dograh_service_key_validation_cache: dict[str, bool] = {}
         self._validator_map = {
             ServiceProviders.OPENAI.value: self._check_openai_api_key,
             ServiceProviders.ATLASCLOUD.value: self._check_openai_api_key,
@@ -75,6 +76,9 @@ class UserConfigurationValidator:
         organization_id: Optional[int] = None,
         created_by: Optional[str] = None,
     ) -> APIKeyStatusResponse:
+        # A managed configuration commonly repeats one service key across LLM,
+        # STT, TTS, and embeddings. Validate that credential once per request.
+        self._dograh_service_key_validation_cache.clear()
         self._auth_context: AuthContext = {
             "organization_id": organization_id,
             "created_by": created_by,
@@ -344,11 +348,16 @@ class UserConfigurationValidator:
                 "Please use a service key (mps...)."
             )
         auth = getattr(self, "_auth_context", {})
-        return mps_service_key_client.validate_service_key(
+        if api_key in self._dograh_service_key_validation_cache:
+            return self._dograh_service_key_validation_cache[api_key]
+
+        is_valid = mps_service_key_client.validate_service_key(
             api_key,
             organization_id=auth.get("organization_id"),
             created_by=auth.get("created_by"),
         )
+        self._dograh_service_key_validation_cache[api_key] = is_valid
+        return is_valid
 
     def _check_sarvam_api_key(self, model: str, api_key: str) -> bool:
         return True

--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -1,4 +1,5 @@
 import random
+from collections.abc import Iterable
 from enum import Enum, auto
 from typing import Annotated, Dict, Literal, Type, TypeVar, Union
 
@@ -188,6 +189,50 @@ REGISTRY: Dict[ServiceType, Dict[str, Type[BaseServiceConfiguration]]] = {
 }
 
 T = TypeVar("T", bound=BaseServiceConfiguration)
+
+
+def registered_provider_names(
+    service_types: Iterable[ServiceType] | None = None,
+) -> tuple[str, ...]:
+    """Return canonical provider IDs from the live configuration registry."""
+
+    selected_types = (
+        tuple(service_types) if service_types is not None else tuple(REGISTRY)
+    )
+    providers = {
+        str(getattr(provider, "value", provider))
+        for service_type in selected_types
+        for provider in REGISTRY.get(service_type, {})
+    }
+    return tuple(sorted(provider for provider in providers if provider))
+
+
+def match_registered_provider(
+    candidate: str,
+    *,
+    service_types: Iterable[ServiceType] | None = None,
+) -> str | None:
+    """Find a registered provider ID embedded in a runtime class/name hint.
+
+    Separators and case are ignored, and the most specific (longest) provider
+    ID wins. This keeps best-effort runtime discovery tied to registrations
+    instead of maintaining another provider catalog at each consumer.
+    """
+
+    compact_candidate = "".join(
+        character for character in candidate.casefold() if character.isalnum()
+    )
+    matches: list[tuple[int, str]] = []
+    for provider in registered_provider_names(service_types):
+        compact_provider = "".join(
+            character for character in provider.casefold() if character.isalnum()
+        )
+        if compact_provider and compact_provider in compact_candidate:
+            matches.append((len(compact_provider), provider))
+
+    if not matches:
+        return None
+    return max(matches, key=lambda match: (match[0], match[1]))[1]
 
 
 def register_service(service_type: ServiceType):

--- a/api/services/integrations/registry.py
+++ b/api/services/integrations/registry.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from loguru import logger
-
+from api.errors.failure import ErrorSource, classify_exception, log_failure
 from api.services.integrations.base import (
     IntegrationCompletionContext,
     IntegrationNodeRegistration,
@@ -127,9 +126,16 @@ async def run_completion_handlers(
         try:
             package_result = await package.run_completion(nodes, context)
         except Exception as exc:
-            logger.exception(
-                f"Integration completion handler failed for package "
-                f"{package.name!r}: {exc}"
+            log_failure(
+                classify_exception(
+                    exc,
+                    source=ErrorSource.INTEGRATION,
+                    provider=package.name,
+                    error_owner="user",
+                ),
+                organization_id=context.organization_id,
+                workflow_run_id=context.workflow_run_id,
+                integration_package=package.name,
             )
             results[f"integration_{package.name}"] = {
                 "error": "completion_handler_failed"

--- a/api/services/mps_service_key_client.py
+++ b/api/services/mps_service_key_client.py
@@ -11,6 +11,32 @@ import httpx
 from loguru import logger
 
 from api.constants import DEPLOYMENT_MODE, DOGRAH_MPS_SECRET_KEY, MPS_API_URL
+from api.errors.failure import ErrorSource, classify_exception, log_failure
+from api.errors.mps import MPSUnavailableError
+
+_INVALID_SERVICE_KEY_STATUSES = frozenset({401, 403})
+
+
+def _log_mps_dependency_failure(
+    error: BaseException,
+    *,
+    operation: str,
+    organization_id: int | None = None,
+    **context: object,
+) -> None:
+    """Emit the single classified record for an MPS dependency failure."""
+
+    log_failure(
+        classify_exception(
+            error,
+            source=ErrorSource.PLATFORM,
+            provider="dograh",
+            error_owner="operator",
+        ),
+        organization_id=organization_id,
+        operation=operation,
+        **context,
+    )
 
 
 class MPSServiceKeyClient:
@@ -387,24 +413,35 @@ class MPSServiceKeyClient:
         if DEPLOYMENT_MODE == "oss":
             raise ValueError("OSS deployments do not fetch hosted billing prices")
 
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            response = await client.get(
-                f"{self.base_url}/api/v1/billing/accounts/{organization_id}/pricing",
-                headers=self._get_headers(organization_id=organization_id),
-            )
+        operation = "get_billing_pricing"
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(
+                    f"{self.base_url}/api/v1/billing/accounts/{organization_id}/pricing",
+                    headers=self._get_headers(organization_id=organization_id),
+                )
 
-            if response.status_code == 200:
-                return response.json()
+                if response.status_code == 200:
+                    return response.json()
 
-            logger.error(
-                "Failed to get MPS billing pricing: "
-                f"{response.status_code} - {response.text}"
+                raise MPSUnavailableError(
+                    operation,
+                    status_code=response.status_code,
+                )
+        except MPSUnavailableError as exc:
+            _log_mps_dependency_failure(
+                exc,
+                operation=operation,
+                organization_id=organization_id,
             )
-            raise httpx.HTTPStatusError(
-                f"Failed to get MPS billing pricing: {response.text}",
-                request=response.request,
-                response=response,
+            raise
+        except httpx.RequestError as exc:
+            _log_mps_dependency_failure(
+                exc,
+                operation=operation,
+                organization_id=organization_id,
             )
+            raise MPSUnavailableError(operation) from exc
 
     async def ensure_billing_account_v2(
         self,
@@ -696,8 +733,11 @@ class MPSServiceKeyClient:
         """
         Synchronously validate a Dograh service key by checking usage via MPS.
 
-        Returns True if the key is valid, False otherwise.
+        Returns True if the key is valid and False only when MPS authoritatively
+        rejects the credential. Dependency failures raise ``MPSUnavailableError``
+        so callers never misreport a Dograh outage as a customer configuration error.
         """
+        operation = "validate_service_key"
         try:
             with httpx.Client(timeout=self.timeout) as client:
                 response = client.get(
@@ -707,10 +747,28 @@ class MPSServiceKeyClient:
                         "Content-Type": "application/json",
                     },
                 )
-                return response.status_code == 200
-        except Exception:
-            logger.warning("Failed to validate Dograh service key via MPS")
-            return False
+                if response.status_code == 200:
+                    return True
+                if response.status_code in _INVALID_SERVICE_KEY_STATUSES:
+                    return False
+                raise MPSUnavailableError(
+                    operation,
+                    status_code=response.status_code,
+                )
+        except MPSUnavailableError as exc:
+            _log_mps_dependency_failure(
+                exc,
+                operation=operation,
+                organization_id=organization_id,
+            )
+            raise
+        except httpx.RequestError as exc:
+            _log_mps_dependency_failure(
+                exc,
+                operation=operation,
+                organization_id=organization_id,
+            )
+            raise MPSUnavailableError(operation) from exc
 
     async def get_voices(
         self,
@@ -737,37 +795,51 @@ class MPSServiceKeyClient:
             Dictionary containing provider name and list of voices
 
         Raises:
-            HTTPException: If the API call fails
+            MPSUnavailableError: If MPS cannot return the voice catalog
         """
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            params = {}
-            if model:
-                params["model"] = model
-            if language:
-                params["language"] = language
-            if q:
-                params["q"] = q
-            if gender:
-                params["gender"] = gender
-            if accent:
-                params["accent"] = accent
-            response = await client.get(
-                f"{self.base_url}/api/v1/voice-proxy/{provider}/voices",
-                headers=self._get_headers(organization_id, created_by),
-                params=params,
-            )
+        operation = "get_voices"
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                params = {}
+                if model:
+                    params["model"] = model
+                if language:
+                    params["language"] = language
+                if q:
+                    params["q"] = q
+                if gender:
+                    params["gender"] = gender
+                if accent:
+                    params["accent"] = accent
+                response = await client.get(
+                    f"{self.base_url}/api/v1/voice-proxy/{provider}/voices",
+                    headers=self._get_headers(organization_id, created_by),
+                    params=params,
+                )
 
-            if response.status_code == 200:
-                return response.json()
-            else:
-                logger.error(
-                    f"Failed to get voices for {provider}: {response.status_code} - {response.text}"
+                if response.status_code == 200:
+                    return response.json()
+
+                raise MPSUnavailableError(
+                    operation,
+                    status_code=response.status_code,
                 )
-                raise httpx.HTTPStatusError(
-                    f"Failed to get voices: {response.text}",
-                    request=response.request,
-                    response=response,
-                )
+        except MPSUnavailableError as exc:
+            _log_mps_dependency_failure(
+                exc,
+                operation=operation,
+                organization_id=organization_id,
+                requested_provider=provider,
+            )
+            raise
+        except httpx.RequestError as exc:
+            _log_mps_dependency_failure(
+                exc,
+                operation=operation,
+                organization_id=organization_id,
+                requested_provider=provider,
+            )
+            raise MPSUnavailableError(operation) from exc
 
     async def process_document(
         self,

--- a/api/services/pipecat/event_handlers.py
+++ b/api/services/pipecat/event_handlers.py
@@ -22,6 +22,7 @@ from api.services.workflow_run_artifacts import upload_workflow_run_artifacts
 from api.tasks.arq import enqueue_job
 from api.tasks.function_names import FunctionNames
 from pipecat.frames.frames import (
+    ErrorFrame,
     Frame,
 )
 from pipecat.pipeline.worker import PipelineWorker
@@ -198,7 +199,14 @@ def register_event_handlers(
 
     @task.event_handler("on_pipeline_error")
     async def on_pipeline_error(_task: PipelineWorker, frame: Frame):
-        logger.warning(f"Pipeline error for workflow run {workflow_run_id}: {frame}")
+        # Pipecat emits recoverable ErrorFrames for reconnect/retry paths.  The
+        # observer classifies them, but only fatal frames should dispose the call.
+        if isinstance(frame, ErrorFrame) and not frame.fatal:
+            return
+        if not isinstance(frame, ErrorFrame):
+            logger.warning(
+                f"Pipeline error for workflow run {workflow_run_id}: {frame}"
+            )
         try:
             workflow_run = await db_client.get_workflow_run_by_id(workflow_run_id)
             if workflow_run and workflow_run.campaign_id:

--- a/api/services/pipecat/pre_call_fetch.py
+++ b/api/services/pipecat/pre_call_fetch.py
@@ -10,6 +10,15 @@ import httpx
 from loguru import logger
 
 from api.db import db_client
+from api.errors.failure import (
+    DograhFailure,
+    ErrorSource,
+    ErrorType,
+    classify_exception,
+    classify_http_response,
+    log_failure,
+    redact_failure_message,
+)
 from api.services.workflow.initial_context import merge_external_initial_context
 from api.utils.credential_auth import build_auth_header
 
@@ -77,13 +86,33 @@ async def execute_pre_call_fetch(
             if credential:
                 headers.update(build_auth_header(credential))
             else:
-                logger.warning(
-                    f"Pre-call fetch: credential {credential_uuid} not found"
+                log_failure(
+                    DograhFailure(
+                        source=ErrorSource.INTEGRATION,
+                        type=ErrorType.CONFIG_ERROR,
+                        code="pre-call-fetch-credential-not-found",
+                        internal_message="Pre-call fetch credential was not found",
+                        external_message="The credential configured for pre-call fetch no longer exists.",
+                        provider="pre-call-fetch",
+                        error_owner="user",
+                        retryable=False,
+                    ),
+                    organization_id=organization_id,
+                    workflow_id=workflow_id,
                 )
         except Exception as e:
-            logger.error(f"Pre-call fetch: failed to resolve credential: {e}")
+            log_failure(
+                classify_exception(
+                    e,
+                    source=ErrorSource.INTEGRATION,
+                    provider="pre-call-fetch",
+                    error_owner="user",
+                ),
+                organization_id=organization_id,
+                workflow_id=workflow_id,
+            )
 
-    logger.info(f"Pre-call fetch: POST {url}")
+    logger.info(f"Pre-call fetch: POST {redact_failure_message(url)}")
 
     try:
         async with httpx.AsyncClient(timeout=PRE_CALL_FETCH_TIMEOUT_SECONDS) as client:
@@ -96,8 +125,19 @@ async def execute_pre_call_fetch(
 
             if response.is_success:
                 if not isinstance(response_data, dict):
-                    logger.warning(
-                        "Pre-call fetch: response is not a JSON object, skipping"
+                    log_failure(
+                        DograhFailure(
+                            source=ErrorSource.INTEGRATION,
+                            type=ErrorType.CONFIG_ERROR,
+                            code="pre-call-fetch-invalid-response",
+                            internal_message="Pre-call fetch response was not a JSON object",
+                            external_message="The pre-call fetch endpoint returned an invalid response.",
+                            provider="pre-call-fetch",
+                            error_owner="user",
+                            retryable=False,
+                        ),
+                        organization_id=organization_id,
+                        workflow_id=workflow_id,
                     )
                     return {}
 
@@ -112,20 +152,53 @@ async def execute_pre_call_fetch(
                 )
                 return initial_context_vars
             else:
-                logger.warning(
-                    f"Pre-call fetch: HTTP {response.status_code} - "
-                    f"{response.text[:200]}"
+                log_failure(
+                    classify_http_response(
+                        response.status_code,
+                        f"Pre-call fetch returned HTTP {response.status_code}: "
+                        f"{response.text[:200]}",
+                        source=ErrorSource.INTEGRATION,
+                        provider="pre-call-fetch",
+                        error_owner="user",
+                    ),
+                    organization_id=organization_id,
+                    workflow_id=workflow_id,
                 )
                 return {}
 
-    except httpx.TimeoutException:
-        logger.error(
-            f"Pre-call fetch: timed out after {PRE_CALL_FETCH_TIMEOUT_SECONDS}s"
+    except httpx.TimeoutException as e:
+        log_failure(
+            classify_exception(
+                e,
+                source=ErrorSource.INTEGRATION,
+                provider="pre-call-fetch",
+                error_owner="user",
+            ),
+            organization_id=organization_id,
+            workflow_id=workflow_id,
         )
         return {}
     except httpx.RequestError as e:
-        logger.error(f"Pre-call fetch: request failed: {e}")
+        log_failure(
+            classify_exception(
+                e,
+                source=ErrorSource.INTEGRATION,
+                provider="pre-call-fetch",
+                error_owner="user",
+            ),
+            organization_id=organization_id,
+            workflow_id=workflow_id,
+        )
         return {}
     except Exception as e:
-        logger.error(f"Pre-call fetch: unexpected error: {e}")
+        log_failure(
+            classify_exception(
+                e,
+                source=ErrorSource.INTEGRATION,
+                provider="pre-call-fetch",
+                error_owner="user",
+            ),
+            organization_id=organization_id,
+            workflow_id=workflow_id,
+        )
         return {}

--- a/api/services/pipecat/realtime_feedback_observer.py
+++ b/api/services/pipecat/realtime_feedback_observer.py
@@ -25,6 +25,12 @@ from typing import TYPE_CHECKING, Awaitable, Callable, Optional, Set
 
 from loguru import logger
 
+from api.errors.failure import (
+    classify_exception,
+    classify_message,
+    failure_metadata_for_processor,
+    log_failure,
+)
 from api.services.pipecat.realtime_feedback_events import (
     build_bot_text_event,
     build_function_call_end_event,
@@ -242,6 +248,26 @@ class RealtimeFeedbackObserver(BaseObserver):
             # them (e.g. google.genai APIError: code=1008, status=None,
             # message="Your project has been denied access...").
             exc = frame.exception
+            metadata = failure_metadata_for_processor(frame.processor)
+            if exc is not None:
+                failure = classify_exception(
+                    exc,
+                    source=metadata.source,
+                    provider=metadata.provider,
+                    error_owner=metadata.error_owner,
+                )
+            else:
+                failure = classify_message(
+                    frame.error,
+                    source=metadata.source,
+                    provider=metadata.provider,
+                    error_owner=metadata.error_owner,
+                )
+            log_failure(
+                failure,
+                fatal=frame.fatal,
+            )
+
             if exc is not None:
                 exc_type = type(exc).__name__
                 extra_payload["exception_type"] = exc_type

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -1077,16 +1077,16 @@ async def _run_pipeline_impl(
     engine.set_task(task)
     engine.set_transport_output(transport.output())
 
-    # Initialize the engine to set the initial context with
-    # System Prompt and Tools
-    await engine.initialize()
-
-    # Add real-time feedback observer (always logs to buffer, streams to WS if available)
+    # Add the observer before initialization so early ErrorFrames are not missed.
     feedback_observer = RealtimeFeedbackObserver(
         ws_sender=ws_sender,
         logs_buffer=in_memory_logs_buffer,
     )
     task.add_observer(feedback_observer)
+
+    # Initialize the engine to set the initial context with
+    # System Prompt and Tools
+    await engine.initialize()
 
     # Register latency observer to log user-to-bot response latency
     if task.user_bot_latency_observer:

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode, urlparse, urlunparse
 
@@ -6,6 +7,12 @@ from fastapi import HTTPException
 from loguru import logger
 
 from api.constants import MPS_API_URL
+from api.errors.failure import (
+    ErrorSource,
+    annotate_failure_metadata,
+    classify_exception,
+    log_failure,
+)
 from api.services.configuration.options import (
     DEEPGRAM_FLUX_MODELS,
     DEEPGRAM_FLUX_MULTILINGUAL_LANGUAGE_OPTIONS,
@@ -93,6 +100,57 @@ from pipecat.utils.text.xml_function_tag_filter import XMLFunctionTagFilter
 
 if TYPE_CHECKING:
     from api.services.pipecat.audio_config import AudioConfig
+
+
+def _report_service_factory_failures(
+    source: ErrorSource,
+    *,
+    config_section: str | None = None,
+    provider_argument: int | None = None,
+):
+    """Classify constructor failures and tag successful services for ErrorFrames."""
+
+    def decorator(factory):
+        @wraps(factory)
+        def wrapped(*args, **kwargs):
+            provider = None
+            if config_section:
+                user_config = args[0] if args else kwargs.get("user_config")
+                config = getattr(user_config, config_section, None)
+                provider = getattr(config, "provider", None)
+            elif provider_argument is not None:
+                if len(args) > provider_argument:
+                    provider = args[provider_argument]
+                else:
+                    provider = kwargs.get("provider")
+
+            provider_value = getattr(provider, "value", provider)
+            error_owner = (
+                "operator" if str(provider_value).lower() == "dograh" else "user"
+            )
+            try:
+                service = factory(*args, **kwargs)
+            except Exception as exc:
+                log_failure(
+                    classify_exception(
+                        exc,
+                        source=source,
+                        provider=provider,
+                        error_owner=error_owner,
+                    )
+                )
+                raise
+
+            return annotate_failure_metadata(
+                service,
+                source=source,
+                provider=provider,
+                error_owner=error_owner,
+            )
+
+        return wrapped
+
+    return decorator
 
 
 DEEPGRAM_FLUX_LANGUAGE_HINTS = {
@@ -188,6 +246,7 @@ def _validate_runtime_service_url(url: str, field_name: str) -> None:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
+@_report_service_factory_failures(ErrorSource.STT, config_section="stt")
 def create_stt_service(
     user_config,
     audio_config: "AudioConfig",
@@ -490,6 +549,7 @@ def create_stt_service(
         )
 
 
+@_report_service_factory_failures(ErrorSource.TTS, config_section="tts")
 def create_tts_service(
     user_config, audio_config: "AudioConfig", correlation_id: str | None = None
 ):
@@ -871,6 +931,7 @@ def _migrate_deprecated_google_model(model: str) -> str:
     return model
 
 
+@_report_service_factory_failures(ErrorSource.LLM, provider_argument=0)
 def create_llm_service_from_provider(
     provider: str,
     model: str,
@@ -1012,6 +1073,7 @@ def create_llm_service_from_provider(
         raise HTTPException(status_code=400, detail=f"Invalid LLM provider {provider}")
 
 
+@_report_service_factory_failures(ErrorSource.LLM, config_section="realtime")
 def create_realtime_llm_service(user_config, audio_config: "AudioConfig"):
     """Create a realtime (speech-to-speech) LLM service that handles STT+LLM+TTS.
 

--- a/api/services/quota_service.py
+++ b/api/services/quota_service.py
@@ -13,6 +13,13 @@ from loguru import logger
 from api.constants import DEPLOYMENT_MODE
 from api.db import db_client
 from api.db.models import UserModel
+from api.errors.failure import (
+    DograhFailure,
+    ErrorSource,
+    ErrorType,
+    classify_exception,
+    log_failure,
+)
 from api.services.configuration.ai_model_configuration import (
     get_effective_ai_model_configuration_for_workflow,
 )
@@ -66,6 +73,70 @@ class QuotaCheckResult:
     error_code: str = ""
 
 
+def _log_mps_exception(
+    error: BaseException,
+    *,
+    organization_id: int | None = None,
+    workflow_run_id: int | None = None,
+    operation: str | None = None,
+) -> None:
+    log_failure(
+        classify_exception(
+            error,
+            source=ErrorSource.PLATFORM,
+            provider="dograh",
+            error_owner="operator",
+        ),
+        organization_id=organization_id,
+        workflow_run_id=workflow_run_id,
+        operation=operation,
+    )
+
+
+def _log_mps_system_failure(
+    code: str,
+    message: str,
+    *,
+    organization_id: int | None = None,
+    workflow_run_id: int | None = None,
+) -> None:
+    log_failure(
+        DograhFailure(
+            source=ErrorSource.PLATFORM,
+            type=ErrorType.SYSTEM_ERROR,
+            code=f"dograh-{code}",
+            internal_message=message,
+            external_message="Dograh could not verify managed model access.",
+            provider="dograh",
+            error_owner="operator",
+            retryable=None,
+        ),
+        organization_id=organization_id,
+        workflow_run_id=workflow_run_id,
+    )
+
+
+def _log_insufficient_dograh_credits(
+    *,
+    organization_id: int | None = None,
+    workflow_run_id: int | None = None,
+) -> None:
+    log_failure(
+        DograhFailure(
+            source=ErrorSource.PLATFORM,
+            type=ErrorType.QUOTA_ERROR,
+            code="dograh-insufficient-credits",
+            internal_message="Insufficient Dograh credits",
+            external_message="Your organization has insufficient Dograh credits.",
+            provider="dograh",
+            error_owner="user",
+            retryable=False,
+        ),
+        organization_id=organization_id,
+        workflow_run_id=workflow_run_id,
+    )
+
+
 def _safe_float(value: Any, default: float = 0.0) -> float:
     try:
         return float(value)
@@ -92,12 +163,15 @@ def _insufficient_oss_quota_result() -> QuotaCheckResult:
 def _mps_unreachable_result(
     operation: str,
     error: httpx.RequestError,
+    *,
+    organization_id: int | None = None,
+    workflow_run_id: int | None = None,
 ) -> QuotaCheckResult:
-    logger.warning(
-        "MPS unreachable during {}; allowing workflow run to proceed without "
-        "quota verification: {}",
-        operation,
+    _log_mps_exception(
         error,
+        organization_id=organization_id,
+        workflow_run_id=workflow_run_id,
+        operation=operation,
     )
     return QuotaCheckResult(has_quota=True)
 
@@ -228,6 +302,12 @@ async def _authorize_hosted_workflow_run_start(
         get_dograh_service_api_key(user_config) if requires_correlation else None
     )
     if requires_correlation and not service_key:
+        _log_mps_system_failure(
+            "invalid-service-key",
+            "Managed-v2 workflow configuration has no Dograh service key",
+            organization_id=organization_id,
+            workflow_run_id=workflow_run_id,
+        )
         return QuotaCheckResult(
             has_quota=False,
             error_code="invalid_service_key",
@@ -255,19 +335,23 @@ async def _authorize_hosted_workflow_run_start(
             },
         )
     except _MPS_UNREACHABLE_ERRORS as e:
-        if requires_correlation:
-            logger.warning(
-                "MPS unreachable during hosted managed-v2 run authorization; "
-                "denying workflow run because a correlation id is required: {}",
-                e,
-            )
-            return _managed_v2_authorization_failed_result()
-        return _mps_unreachable_result("hosted run authorization", e)
-    except Exception as e:
-        logger.warning(
-            "Failed to authorize workflow start with MPS for org {}: {}",
-            organization_id,
+        _log_mps_exception(
             e,
+            organization_id=organization_id,
+            workflow_run_id=workflow_run_id,
+            operation="hosted run authorization",
+        )
+        if requires_correlation:
+            return _managed_v2_authorization_failed_result()
+        # Already emitted above because this branch needs the same record whether
+        # managed-v2 fails closed or a legacy check fails open.
+        return QuotaCheckResult(has_quota=True)
+    except Exception as e:
+        _log_mps_exception(
+            e,
+            organization_id=organization_id,
+            workflow_run_id=workflow_run_id,
+            operation="hosted run authorization",
         )
         if _is_service_key_org_mismatch_error(e):
             return QuotaCheckResult(
@@ -286,18 +370,19 @@ async def _authorize_hosted_workflow_run_start(
         not authorization.get("allowed", False)
         or remaining < MINIMUM_DOGRAH_CREDITS_FOR_CALL
     ):
-        logger.warning(
-            "Insufficient Dograh credits for org {}: {:.2f} credits remaining",
-            organization_id,
-            remaining,
+        _log_insufficient_dograh_credits(
+            organization_id=organization_id,
+            workflow_run_id=workflow_run_id,
         )
         return _insufficient_hosted_quota_result()
 
     correlation_id = _required_correlation_id(authorization)
     if requires_correlation and not correlation_id:
-        logger.error(
-            "MPS authorized hosted managed-v2 workflow run {} without a correlation id",
-            workflow_run_id,
+        _log_mps_system_failure(
+            "missing-correlation-id",
+            "MPS authorized a managed-v2 workflow run without a correlation id",
+            organization_id=organization_id,
+            workflow_run_id=workflow_run_id,
         )
         return _managed_v2_authorization_failed_result()
 
@@ -307,10 +392,11 @@ async def _authorize_hosted_workflow_run_start(
             correlation_id,
         )
     except Exception as e:
-        logger.error(
-            "Failed to store MPS correlation id for workflow_run_id {}: {}",
-            workflow_run_id,
+        _log_mps_exception(
             e,
+            organization_id=organization_id,
+            workflow_run_id=workflow_run_id,
+            operation="store run correlation id",
         )
         return QuotaCheckResult(
             has_quota=False,
@@ -337,10 +423,7 @@ async def _authorize_oss_dograh_keys(
 
             # Require at least $0.10 for a short call
             if remaining < MINIMUM_DOGRAH_CREDITS_FOR_CALL:
-                logger.warning(
-                    f"Insufficient Dograh credits for key ...{api_key[-8:]}: "
-                    f"${remaining:.2f} remaining"
-                )
+                _log_insufficient_dograh_credits()
                 return _insufficient_oss_quota_result()
 
             logger.info(
@@ -350,7 +433,7 @@ async def _authorize_oss_dograh_keys(
         except _MPS_UNREACHABLE_ERRORS as e:
             return _mps_unreachable_result("OSS service-key quota check", e)
         except Exception as e:
-            logger.error(f"Failed to check quota for Dograh key: {str(e)}")
+            _log_mps_exception(e, operation="OSS service-key quota check")
             error_str = str(e)
             if "404" in error_str or "not found" in error_str.lower():
                 return QuotaCheckResult(
@@ -378,6 +461,11 @@ async def _authorize_oss_managed_v2_correlation(
 
     service_key = get_dograh_service_api_key(user_config)
     if not service_key:
+        _log_mps_system_failure(
+            "invalid-service-key",
+            "OSS managed-v2 workflow configuration has no Dograh service key",
+            workflow_run_id=workflow_run_id,
+        )
         return QuotaCheckResult(
             has_quota=False,
             error_code="invalid_service_key",
@@ -394,11 +482,10 @@ async def _authorize_oss_managed_v2_correlation(
         )
         correlation_id = _required_correlation_id(response)
         if not correlation_id:
-            logger.error(
-                "MPS correlation endpoint returned no correlation id for OSS "
-                "managed-v2 workflow {} run {}",
-                workflow_id,
-                workflow_run_id,
+            _log_mps_system_failure(
+                "missing-correlation-id",
+                "MPS correlation endpoint returned no correlation id",
+                workflow_run_id=workflow_run_id,
             )
             return _managed_v2_authorization_failed_result()
         await _store_run_correlation_id(
@@ -406,18 +493,17 @@ async def _authorize_oss_managed_v2_correlation(
             correlation_id,
         )
     except _MPS_UNREACHABLE_ERRORS as e:
-        logger.warning(
-            "MPS unreachable during OSS managed-v2 correlation creation; "
-            "denying workflow run because a correlation id is required: {}",
+        _log_mps_exception(
             e,
+            workflow_run_id=workflow_run_id,
+            operation="OSS managed-v2 correlation creation",
         )
         return _managed_v2_authorization_failed_result()
     except Exception as e:
-        logger.error(
-            "Failed to authorize OSS managed v2 workflow start for workflow {} run {}: {}",
-            workflow_id,
-            workflow_run_id,
+        _log_mps_exception(
             e,
+            workflow_run_id=workflow_run_id,
+            operation="OSS managed-v2 correlation creation",
         )
         return QuotaCheckResult(
             has_quota=False,
@@ -446,11 +532,10 @@ async def _authorize_oss_managed_v2_run(
     except httpx.HTTPStatusError as e:
         status_code = getattr(e.response, "status_code", None)
         if status_code not in {404, 405}:
-            logger.error(
-                "Failed to authorize OSS managed v2 workflow start for workflow {} run {}: {}",
-                workflow_id,
-                workflow_run_id,
+            _log_mps_exception(
                 e,
+                workflow_run_id=workflow_run_id,
+                operation="OSS managed-v2 run authorization",
             )
             return QuotaCheckResult(
                 has_quota=False,
@@ -473,18 +558,17 @@ async def _authorize_oss_managed_v2_run(
             user_config=user_config,
         )
     except _MPS_UNREACHABLE_ERRORS as e:
-        logger.warning(
-            "MPS unreachable during OSS managed-v2 run authorization; "
-            "denying workflow run because a correlation id is required: {}",
+        _log_mps_exception(
             e,
+            workflow_run_id=workflow_run_id,
+            operation="OSS managed-v2 run authorization",
         )
         return _managed_v2_authorization_failed_result()
     except Exception as e:
-        logger.error(
-            "Failed to authorize OSS managed v2 workflow start for workflow {} run {}: {}",
-            workflow_id,
-            workflow_run_id,
+        _log_mps_exception(
             e,
+            workflow_run_id=workflow_run_id,
+            operation="OSS managed-v2 run authorization",
         )
         return QuotaCheckResult(
             has_quota=False,
@@ -497,19 +581,15 @@ async def _authorize_oss_managed_v2_run(
         not authorization.get("allowed", False)
         or remaining < MINIMUM_DOGRAH_CREDITS_FOR_CALL
     ):
-        logger.warning(
-            "Insufficient Dograh credits for key ...{}: {:.2f} credits remaining",
-            service_key[-8:],
-            remaining,
-        )
+        _log_insufficient_dograh_credits(workflow_run_id=workflow_run_id)
         return _oss_run_authorization_denied_result(authorization)
 
     correlation_id = _required_correlation_id(authorization)
     if not correlation_id:
-        logger.error(
-            "MPS authorized OSS managed-v2 workflow {} run {} without a correlation id",
-            workflow_id,
-            workflow_run_id,
+        _log_mps_system_failure(
+            "missing-correlation-id",
+            "MPS authorized an OSS managed-v2 run without a correlation id",
+            workflow_run_id=workflow_run_id,
         )
         return _managed_v2_authorization_failed_result()
 
@@ -519,10 +599,10 @@ async def _authorize_oss_managed_v2_run(
             correlation_id,
         )
     except Exception as e:
-        logger.error(
-            "Failed to store MPS correlation id for workflow_run_id {}: {}",
-            workflow_run_id,
+        _log_mps_exception(
             e,
+            workflow_run_id=workflow_run_id,
+            operation="store run correlation id",
         )
         return QuotaCheckResult(
             has_quota=False,
@@ -568,11 +648,12 @@ async def authorize_workflow_run_start(
             organization_id=organization_id,
         )
     except Exception as e:
-        logger.error(
-            "Workflow start authorization denied: failed to load workflow {} for org {}: {}",
-            workflow_id,
-            organization_id,
-            e,
+        log_failure(
+            classify_exception(e, source=ErrorSource.PLATFORM),
+            organization_id=organization_id,
+            workflow_run_id=workflow_run_id,
+            workflow_id=workflow_id,
+            operation="load workflow for quota authorization",
         )
         return QuotaCheckResult(
             has_quota=False,
@@ -613,12 +694,12 @@ async def authorize_workflow_run_start(
                     organization_id=organization_id,
                 )
             except Exception as e:
-                logger.error(
-                    "Workflow start authorization denied: failed to validate actor {} membership for workflow {} org {}: {}",
-                    actor_id,
-                    workflow_id,
-                    organization_id,
-                    e,
+                log_failure(
+                    classify_exception(e, source=ErrorSource.PLATFORM),
+                    organization_id=organization_id,
+                    workflow_run_id=workflow_run_id,
+                    workflow_id=workflow_id,
+                    operation="validate quota authorization actor",
                 )
                 return QuotaCheckResult(
                     has_quota=False,
@@ -704,6 +785,12 @@ async def authorize_workflow_run_start(
 
         correlation_service_key = get_dograh_service_api_key(user_config)
         if not correlation_service_key:
+            _log_mps_system_failure(
+                "invalid-service-key",
+                "Managed-v2 workflow configuration has no Dograh service key",
+                organization_id=organization_id,
+                workflow_run_id=workflow_run_id,
+            )
             return QuotaCheckResult(
                 has_quota=False,
                 error_code="invalid_service_key",
@@ -729,7 +816,12 @@ async def authorize_workflow_run_start(
         )
 
     except Exception as e:
-        logger.error(f"Error during quota check: {str(e)}")
+        log_failure(
+            classify_exception(e, source=ErrorSource.PLATFORM),
+            organization_id=organization_id,
+            workflow_run_id=workflow_run_id,
+            workflow_id=workflow_id,
+        )
         # Only an httpx transport failure raised while calling MPS is allowed to
         # fail open, and those failures are handled at the MPS call sites above.
         # Database, configuration, response-validation, and programming errors

--- a/api/services/telephony/ari_manager.py
+++ b/api/services/telephony/ari_manager.py
@@ -26,6 +26,14 @@ from loguru import logger
 from api.constants import REDIS_URL
 from api.db import db_client
 from api.enums import CallType, WorkflowRunMode
+from api.errors.failure import (
+    DograhFailure,
+    ErrorSource,
+    ErrorType,
+    classify_exception,
+    log_failure,
+    redact_failure_message,
+)
 from api.services.call_concurrency import (
     CallConcurrencyLimitError,
     call_concurrency,
@@ -48,6 +56,23 @@ _EXT_CHANNEL_KEY_PREFIX = "ari:ext_channel:"
 _PENDING_BRIDGE_PREFIX = "ari:pending_bridge:"
 _CHANNEL_KEY_TTL = 3600  # 1 hour safety expiry
 _PENDING_BRIDGE_TTL = 300  # 5 min safety expiry for bridge-pending state
+
+
+def _log_ari_failure(
+    failure: DograhFailure,
+    *,
+    organization_id: int,
+    telephony_configuration_id: int | None = None,
+    **context: object,
+) -> None:
+    """Emit a classified ARI failure with its organization context."""
+
+    log_failure(
+        failure,
+        organization_id=organization_id,
+        telephony_configuration_id=telephony_configuration_id,
+        **context,
+    )
 
 
 class ARIConnection:
@@ -196,7 +221,8 @@ class ARIConnection:
         self._running = True
         self._task = asyncio.create_task(self._connection_loop())
         logger.info(
-            f"[ARI org={self.organization_id}] Started connection to {self.ari_endpoint}"
+            f"[ARI org={self.organization_id}] Started connection to "
+            f"{redact_failure_message(self.ari_endpoint)}"
         )
 
     async def stop(self):
@@ -211,7 +237,8 @@ class ARIConnection:
             except asyncio.CancelledError:
                 pass
         logger.info(
-            f"[ARI org={self.organization_id}] Stopped connection to {self.ari_endpoint}"
+            f"[ARI org={self.organization_id}] Stopped connection to "
+            f"{redact_failure_message(self.ari_endpoint)}"
         )
 
     async def _connection_loop(self):
@@ -224,9 +251,17 @@ class ARIConnection:
             except Exception as e:
                 if not self._running:
                     break
-                logger.warning(
-                    f"[ARI org={self.organization_id}] Connection error: {e}. "
-                    f"Reconnecting in {self._reconnect_delay}s..."
+                _log_ari_failure(
+                    classify_exception(
+                        e,
+                        source=ErrorSource.TELEPHONY,
+                        provider="ari",
+                        error_owner="user",
+                    ),
+                    organization_id=self.organization_id,
+                    telephony_configuration_id=self.telephony_configuration_id,
+                    operation="connect ARI websocket",
+                    reconnect_delay_seconds=self._reconnect_delay,
                 )
                 await asyncio.sleep(self._reconnect_delay)
                 # Exponential backoff
@@ -238,7 +273,8 @@ class ARIConnection:
         """Establish WebSocket connection and listen for events."""
         ws_url = self.ws_url
         logger.info(
-            f"[ARI org={self.organization_id}] Connecting to {self.ari_endpoint}..."
+            f"[ARI org={self.organization_id}] Connecting to "
+            f"{redact_failure_message(self.ari_endpoint)}..."
         )
 
         async for ws in websockets.connect(
@@ -254,7 +290,8 @@ class ARIConnection:
                 self._reconnect_delay = 1
 
                 logger.info(
-                    f"[ARI org={self.organization_id}] WebSocket connected to {self.ari_endpoint}"
+                    f"[ARI org={self.organization_id}] WebSocket connected to "
+                    f"{redact_failure_message(self.ari_endpoint)}"
                 )
 
                 async for message in ws:
@@ -271,9 +308,17 @@ class ARIConnection:
             except websockets.ConnectionClosed as e:
                 if not self._running:
                     return
-                logger.warning(
-                    f"[ARI org={self.organization_id}] WebSocket closed: "
-                    f"code={e.code}, reason={e.reason}. Reconnecting..."
+                _log_ari_failure(
+                    classify_exception(
+                        e,
+                        source=ErrorSource.TELEPHONY,
+                        provider="ari",
+                        error_owner="user",
+                    ),
+                    organization_id=self.organization_id,
+                    telephony_configuration_id=self.telephony_configuration_id,
+                    operation="listen to ARI websocket",
+                    websocket_close_code=e.code,
                 )
                 continue
             finally:
@@ -1235,7 +1280,7 @@ class ARIManager:
                 # New configuration - start connection
                 logger.info(
                     f"[ARI Manager] New ARI config {telephony_configuration_id} "
-                    f"for org {org_id}: {ari_endpoint}"
+                    f"for org {org_id}: {redact_failure_message(ari_endpoint)}"
                 )
                 self._connections[key] = conn
                 await conn.start()
@@ -1295,16 +1340,36 @@ class ARIManager:
                 external_pbx = None
 
             if not all([ari_endpoint, app_name, app_password]):
-                logger.warning(
-                    f"[ARI Manager] Incomplete ARI config {row.id} "
-                    f"for org {row.organization_id}, skipping"
+                _log_ari_failure(
+                    DograhFailure(
+                        source=ErrorSource.TELEPHONY,
+                        type=ErrorType.CONFIG_ERROR,
+                        code="ari-incomplete-config",
+                        internal_message="ARI configuration is missing an endpoint, app name, or app password",
+                        external_message="Complete the required ARI connection settings.",
+                        provider="ari",
+                        error_owner="user",
+                        retryable=False,
+                    ),
+                    organization_id=row.organization_id,
+                    telephony_configuration_id=row.id,
                 )
                 continue
 
             if not ws_client_name:
-                logger.warning(
-                    f"[ARI Manager] Missing ws_client_name for config {row.id} "
-                    f"(org {row.organization_id}), externalMedia WebSocket won't work"
+                _log_ari_failure(
+                    DograhFailure(
+                        source=ErrorSource.TELEPHONY,
+                        type=ErrorType.CONFIG_ERROR,
+                        code="ari-missing-ws-client-name",
+                        internal_message="ARI configuration is missing ws_client_name",
+                        external_message="Set the ARI WebSocket client name in telephony configuration.",
+                        provider="ari",
+                        error_owner="user",
+                        retryable=False,
+                    ),
+                    organization_id=row.organization_id,
+                    telephony_configuration_id=row.id,
                 )
 
             configs.append(

--- a/api/services/telephony/factory.py
+++ b/api/services/telephony/factory.py
@@ -20,11 +20,17 @@ joining ``telephony_phone_numbers``.
 from typing import Any, Dict, List, Optional, Tuple, Type
 
 from loguru import logger
+from pipecat.utils.run_context import set_current_org_id
 
 from api.db import db_client
 from api.db.models import TelephonyConfigurationModel, WorkflowRunModel
+from api.errors.failure import log_failure
 from api.services.telephony import registry
 from api.services.telephony.base import TelephonyProvider
+from api.services.telephony.failure_reporting import (
+    classify_telephony_exception,
+    instrument_telephony_provider,
+)
 
 
 async def load_telephony_config_by_id(
@@ -125,6 +131,7 @@ async def get_telephony_provider_by_id(
     telephony_configuration_id: int | str | None,
     organization_id: int,
 ) -> TelephonyProvider:
+    set_current_org_id(organization_id)
     config = await load_telephony_config_by_id(
         telephony_configuration_id, organization_id
     )
@@ -150,6 +157,7 @@ async def get_telephony_provider_for_run(
 
 
 async def get_default_telephony_provider(organization_id: int) -> TelephonyProvider:
+    set_current_org_id(organization_id)
     config = await load_default_telephony_config(organization_id)
     return _instantiate(config)
 
@@ -158,6 +166,7 @@ async def get_telephony_provider_for_inbound(
     organization_id: int, provider_name: str, account_id: Optional[str]
 ) -> Optional[Tuple[int, TelephonyProvider]]:
     """Returns ``(config_id, provider_instance)`` or None when no config matches."""
+    set_current_org_id(organization_id)
     match = await find_telephony_config_for_inbound(
         organization_id, provider_name, account_id
     )
@@ -226,4 +235,12 @@ async def _normalize_with_phone_numbers(
 def _instantiate(config: Dict[str, Any]) -> TelephonyProvider:
     spec = registry.get(config["provider"])
     logger.info(f"Creating {spec.name} telephony provider")
-    return spec.provider_cls(config)
+    try:
+        provider = spec.provider_cls(config)
+    except Exception as exc:
+        log_failure(
+            classify_telephony_exception(exc, provider=spec.name),
+            operation="construct telephony provider",
+        )
+        raise
+    return instrument_telephony_provider(provider)

--- a/api/services/telephony/failure_reporting.py
+++ b/api/services/telephony/failure_reporting.py
@@ -1,0 +1,89 @@
+"""Shared shadow-mode failure reporting for telephony provider operations."""
+
+from functools import wraps
+from typing import TYPE_CHECKING, Any
+
+from api.errors.failure import (
+    DograhFailure,
+    ErrorSource,
+    ErrorType,
+    classify_exception,
+    log_failure,
+)
+
+if TYPE_CHECKING:
+    from api.services.telephony.base import TelephonyProvider
+
+
+def classify_telephony_exception(
+    exc: BaseException, *, provider: object | None
+) -> DograhFailure:
+    """Apply config-aware rules available only at the telephony boundary."""
+
+    try:
+        raw_message = str(exc)
+    except Exception:
+        raw_message = type(exc).__name__
+    message = raw_message.lower()
+    if isinstance(exc, ValueError) and any(
+        marker in message
+        for marker in (
+            "not properly configured",
+            "missing required",
+            "configuration is required",
+        )
+    ):
+        provider_value = getattr(provider, "value", provider) or "telephony"
+        return DograhFailure(
+            source=ErrorSource.TELEPHONY,
+            type=ErrorType.CONFIG_ERROR,
+            code=f"{provider_value}-invalid-config",
+            internal_message=raw_message,
+            external_message="Check the telephony provider configuration and credentials.",
+            provider=str(provider_value),
+            error_owner="user",
+            retryable=False,
+        )
+    return classify_exception(
+        exc,
+        source=ErrorSource.TELEPHONY,
+        provider=provider,
+        error_owner="user",
+    )
+
+
+def instrument_telephony_provider(provider: "TelephonyProvider") -> "TelephonyProvider":
+    """Classify outbound initiation errors without changing propagation semantics."""
+
+    if getattr(provider, "_dograh_failure_reporting_instrumented", False):
+        return provider
+
+    original = provider.initiate_call
+    provider_name = getattr(provider, "PROVIDER_NAME", None)
+
+    @wraps(original)
+    async def initiate_call_with_failure_reporting(*args: Any, **kwargs: Any):
+        workflow_run_id = kwargs.get("workflow_run_id")
+        if workflow_run_id is None and len(args) > 2:
+            workflow_run_id = args[2]
+        organization_id = kwargs.get("organization_id")
+        try:
+            return await original(*args, **kwargs)
+        except Exception as exc:
+            log_failure(
+                classify_telephony_exception(exc, provider=provider_name),
+                organization_id=organization_id,
+                workflow_run_id=workflow_run_id,
+                operation="initiate call",
+            )
+            raise
+
+    try:
+        provider.initiate_call = initiate_call_with_failure_reporting
+        provider._dograh_failure_reporting_instrumented = True
+    except Exception:
+        # Instrumentation must not make a valid provider unusable. All current
+        # providers are mutable Python classes, but retain a safe fallback for
+        # future slotted third-party implementations.
+        pass
+    return provider

--- a/api/services/telephony/providers/ari/provider.py
+++ b/api/services/telephony/providers/ari/provider.py
@@ -128,10 +128,6 @@ class ARIProvider(TelephonyProvider):
                 response_text = await response.text()
 
                 if response.status != 200:
-                    logger.error(
-                        f"[ARI] Channel creation failed: "
-                        f"HTTP {response.status} - {response_text}"
-                    )
                     raise HTTPException(
                         status_code=response.status,
                         detail=f"Failed to create ARI channel: {response_text}",

--- a/api/services/telephony/providers/cloudonix/provider.py
+++ b/api/services/telephony/providers/cloudonix/provider.py
@@ -184,21 +184,7 @@ class CloudonixProvider(TelephonyProvider):
                 response_text = await response.text()
                 response_status = response.status
 
-                # Log response
-                logger.info(
-                    f"[Cloudonix] API Response:\n"
-                    f"  HTTP Status: {response_status}\n"
-                    f"  Response Body: {response_text}"
-                )
-
                 if response_status != 200:
-                    logger.error(
-                        f"[Cloudonix] Call initiation FAILED:\n"
-                        f"  HTTP Status: {response_status}\n"
-                        f"  Error Details: {response_text}\n"
-                        f"  Request: POST {endpoint}\n"
-                        f"  Payload: {json.dumps(data, indent=2)}"
-                    )
                     raise HTTPException(
                         status_code=response_status,
                         detail=f"Failed to initiate call via Cloudonix (HTTP {response_status}): {response_text}",
@@ -212,10 +198,6 @@ class CloudonixProvider(TelephonyProvider):
                 subscriber_id = response_data.get("subscriberId")
 
                 if not session_token:
-                    logger.error(
-                        f"[Cloudonix] Missing session token in response:\n"
-                        f"  Response: {json.dumps(response_data, indent=2)}"
-                    )
                     raise Exception("No session token returned from Cloudonix")
 
                 logger.info(

--- a/api/services/telephony/providers/telnyx/provider.py
+++ b/api/services/telephony/providers/telnyx/provider.py
@@ -143,7 +143,6 @@ class TelnyxProvider(TelephonyProvider):
             ) as response:
                 if response.status != 200:
                     error_data = await response.json()
-                    logger.error(f"Telnyx API error: {error_data}")
                     raise HTTPException(
                         status_code=response.status, detail=json.dumps(error_data)
                     )

--- a/api/services/telephony/providers/twilio/strategies.py
+++ b/api/services/telephony/providers/twilio/strategies.py
@@ -145,22 +145,44 @@ class TwilioHangupStrategy(HangupStrategy):
     async def execute_hangup(self, context: Dict[str, Any]) -> bool:
         """Hang up the Twilio call via REST API."""
         try:
-            account_sid = context["account_sid"]
-            auth_token = context["auth_token"]
-            call_sid = context["call_sid"]
+            account_sid = context.get("account_sid")
+            auth_token = context.get("auth_token")
+            call_sid = context.get("call_sid")
             region = context.get("region")
             edge = context.get("edge")
 
-            if not account_sid or not auth_token or not call_sid:
+            if not account_sid or not auth_token:
                 log_failure(
                     DograhFailure(
                         source=ErrorSource.TELEPHONY,
                         type=ErrorType.CONFIG_ERROR,
-                        code="twilio-missing-hangup-config",
-                        internal_message="Cannot hang up Twilio call: missing required credentials or call SID",
+                        code="twilio-missing-hangup-credentials",
+                        internal_message="Cannot hang up Twilio call: missing required Twilio credentials",
                         external_message="Check the Twilio credentials configured for this call.",
                         provider="twilio",
                         error_owner="user",
+                        retryable=False,
+                    ),
+                    operation="hang up call",
+                )
+                return False
+
+            if not call_sid:
+                log_failure(
+                    DograhFailure(
+                        source=ErrorSource.TELEPHONY,
+                        type=ErrorType.SYSTEM_ERROR,
+                        code="twilio-missing-call-sid",
+                        internal_message=(
+                            "Cannot hang up Twilio call: call SID is missing from "
+                            "runtime call context"
+                        ),
+                        external_message=(
+                            "Dograh could not identify the active Twilio call. Please "
+                            "retry or contact support if the problem continues."
+                        ),
+                        provider="twilio",
+                        error_owner="operator",
                         retryable=False,
                     ),
                     operation="hang up call",

--- a/api/services/telephony/providers/twilio/strategies.py
+++ b/api/services/telephony/providers/twilio/strategies.py
@@ -10,6 +10,15 @@ import aiohttp
 from loguru import logger
 from pipecat.serializers.call_strategies import HangupStrategy, TransferStrategy
 
+from api.errors.failure import (
+    DograhFailure,
+    ErrorSource,
+    ErrorType,
+    classify_exception,
+    classify_http_response,
+    log_failure,
+)
+
 
 class TwilioConferenceStrategy(TransferStrategy):
     """Implements conference-based call transfer for Twilio.
@@ -143,8 +152,18 @@ class TwilioHangupStrategy(HangupStrategy):
             edge = context.get("edge")
 
             if not account_sid or not auth_token or not call_sid:
-                logger.warning(
-                    "Cannot hang up Twilio call: missing required credentials or call_sid"
+                log_failure(
+                    DograhFailure(
+                        source=ErrorSource.TELEPHONY,
+                        type=ErrorType.CONFIG_ERROR,
+                        code="twilio-missing-hangup-config",
+                        internal_message="Cannot hang up Twilio call: missing required credentials or call SID",
+                        external_message="Check the Twilio credentials configured for this call.",
+                        provider="twilio",
+                        error_owner="user",
+                        retryable=False,
+                    ),
+                    operation="hang up call",
                 )
                 return False
 
@@ -166,12 +185,27 @@ class TwilioHangupStrategy(HangupStrategy):
                         return True
                     else:
                         response_text = await response.text()
-                        logger.error(
-                            f"Failed to terminate Twilio call {call_sid}: "
-                            f"Status {response.status}, Response: {response_text}"
+                        log_failure(
+                            classify_http_response(
+                                response.status,
+                                f"Twilio hangup returned HTTP {response.status}: "
+                                f"{response_text}",
+                                source=ErrorSource.TELEPHONY,
+                                provider="twilio",
+                                error_owner="user",
+                            ),
+                            operation="hang up call",
                         )
                         return False
 
         except Exception as e:
-            logger.exception(f"Failed to hang up Twilio call: {e}")
+            log_failure(
+                classify_exception(
+                    e,
+                    source=ErrorSource.TELEPHONY,
+                    provider="twilio",
+                    error_owner="user",
+                ),
+                operation="hang up call",
+            )
             return False

--- a/api/services/telephony/providers/vobiz/provider.py
+++ b/api/services/telephony/providers/vobiz/provider.py
@@ -127,7 +127,6 @@ class VobizProvider(TelephonyProvider):
             async with session.post(endpoint, json=data, headers=headers) as response:
                 if response.status != 201:
                     error_data = await response.text()
-                    logger.error(f"Vobiz API error: {error_data}")
                     raise HTTPException(
                         status_code=response.status,
                         detail=f"Failed to initiate Vobiz call: {error_data}",
@@ -145,9 +144,6 @@ class VobizProvider(TelephonyProvider):
                 )
 
                 if not call_id:
-                    logger.error(
-                        f"No call ID found in Vobiz response. Available keys: {list(response_data.keys())}"
-                    )
                     raise HTTPException(
                         status_code=response.status,
                         detail=f"Vobiz API response missing call identifier. Response: {response_data}"

--- a/api/services/telephony/registry.py
+++ b/api/services/telephony/registry.py
@@ -12,6 +12,7 @@ plus a single import line in ``providers/__init__.py``.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import wraps
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -25,6 +26,8 @@ from typing import (
 )
 
 from pydantic import BaseModel
+
+from api.errors.telephony_errors import log_telephony_error
 
 if TYPE_CHECKING:
     from api.services.telephony.base import TelephonyProvider
@@ -146,6 +149,26 @@ class ProviderSpec:
 _REGISTRY: Dict[str, ProviderSpec] = {}
 
 
+def _instrument_validation_error_response(spec: ProviderSpec) -> None:
+    """Emit classification whenever a provider renders an inbound rejection."""
+
+    original = getattr(spec.provider_cls, "generate_validation_error_response", None)
+    if not callable(original):
+        return
+    if getattr(original, "_dograh_failure_reporting_instrumented", False):
+        return
+
+    @wraps(original)
+    def generate_validation_error_response(error_type, *args, **kwargs):
+        log_telephony_error(error_type, provider=spec.name)
+        return original(error_type, *args, **kwargs)
+
+    generate_validation_error_response._dograh_failure_reporting_instrumented = True
+    spec.provider_cls.generate_validation_error_response = staticmethod(
+        generate_validation_error_response
+    )
+
+
 def register(spec: ProviderSpec) -> None:
     """Register a provider. Called once per provider at import time."""
     if spec.name in _REGISTRY:
@@ -154,6 +177,7 @@ def register(spec: ProviderSpec) -> None:
         if _REGISTRY[spec.name] is not spec:
             raise ValueError(f"Provider '{spec.name}' is already registered")
         return
+    _instrument_validation_error_response(spec)
     _REGISTRY[spec.name] = spec
 
 

--- a/api/services/workflow/pipecat_engine.py
+++ b/api/services/workflow/pipecat_engine.py
@@ -18,6 +18,11 @@ from pipecat.utils.enums import EndTaskReason
 
 from api.db import db_client
 from api.enums import ToolCategory
+from api.errors.failure import (
+    classify_exception,
+    failure_metadata_for_processor,
+    log_failure,
+)
 from api.services.pipecat.audio_playback import play_audio
 from api.services.workflow.workflow_graph import Node, WorkflowGraph
 
@@ -460,8 +465,17 @@ class PipecatEngine:
                     f"Variable extraction completed for node: {node.name}. Extracted: {extracted_data}"
                 )
             except Exception as e:
-                logger.error(
-                    f"Error during variable extraction for node {node.name}: {str(e)}"
+                metadata = failure_metadata_for_processor(self.variable_extraction_llm)
+                log_failure(
+                    classify_exception(
+                        e,
+                        source=metadata.source,
+                        provider=metadata.provider,
+                        error_owner=metadata.error_owner,
+                    ),
+                    organization_id=self._organization_id,
+                    workflow_run_id=self._workflow_run_id,
+                    node_name=node.name,
                 )
 
         if run_in_background:

--- a/api/services/workflow/tools/custom_tool.py
+++ b/api/services/workflow/tools/custom_tool.py
@@ -8,6 +8,15 @@ import httpx
 from loguru import logger
 
 from api.db import db_client
+from api.errors.failure import (
+    DograhFailure,
+    ErrorSource,
+    ErrorType,
+    classify_exception,
+    classify_http_response,
+    log_failure,
+    redact_failure_message,
+)
 from api.services.configuration.masking import mask_key
 from api.utils.credential_auth import build_auth_header
 from api.utils.template_renderer import render_template
@@ -285,11 +294,31 @@ async def execute_http_tool(
                 headers.update(credential_headers)
                 logger.debug(f"Applied credential '{credential.name}' to tool request")
             else:
-                logger.warning(
-                    f"Credential {credential_uuid} not found for tool '{tool.name}'"
+                log_failure(
+                    DograhFailure(
+                        source=ErrorSource.TOOL,
+                        type=ErrorType.CONFIG_ERROR,
+                        code="custom-http-credential-not-found",
+                        internal_message=f"Credential not found for custom tool '{tool.name}'",
+                        external_message="The credential configured for this tool no longer exists.",
+                        provider="custom-http",
+                        error_owner="user",
+                        retryable=False,
+                    ),
+                    organization_id=organization_id,
+                    tool_name=tool.name,
                 )
         except Exception as e:
-            logger.error(f"Failed to fetch credential for tool '{tool.name}': {e}")
+            log_failure(
+                classify_exception(
+                    e,
+                    source=ErrorSource.TOOL,
+                    provider="custom-http",
+                    error_owner="user",
+                ),
+                organization_id=organization_id,
+                tool_name=tool.name,
+            )
 
     request_headers: Dict[str, str] = {}
     if include_request_headers:
@@ -312,7 +341,20 @@ async def execute_http_tool(
                 config, call_context_vars, gathered_context_vars
             )
         except ValueError as e:
-            logger.error(f"Custom tool '{tool.name}' preset parameter error: {e}")
+            log_failure(
+                DograhFailure(
+                    source=ErrorSource.TOOL,
+                    type=ErrorType.CONFIG_ERROR,
+                    code="custom-http-invalid-preset",
+                    internal_message=f"Custom tool '{tool.name}' preset parameter error: {e}",
+                    external_message="A configured tool parameter could not be resolved.",
+                    provider="custom-http",
+                    error_owner="user",
+                    retryable=False,
+                ),
+                organization_id=organization_id,
+                tool_name=tool.name,
+            )
             return build_result({"status": "error", "error": str(e)})
     else:
         preset_arguments = dict(preset_params)
@@ -328,7 +370,8 @@ async def execute_http_tool(
         params = serialize_query_params(resolved_arguments)
 
     logger.info(
-        f"Executing custom tool '{tool.name}' ({tool.tool_uuid}): {method} {url}"
+        f"Executing custom tool '{tool.name}' ({tool.tool_uuid}): "
+        f"{method} {redact_failure_message(url)}"
     )
     if preset_arguments:
         logger.debug(
@@ -361,10 +404,32 @@ async def execute_http_tool(
             logger.debug(
                 f"Custom tool '{tool.name}' completed with status {response.status_code}"
             )
+            if response.status_code >= 400:
+                log_failure(
+                    classify_http_response(
+                        response.status_code,
+                        f"Custom tool '{tool.name}' returned HTTP "
+                        f"{response.status_code}: {response.text[:200]}",
+                        source=ErrorSource.TOOL,
+                        provider="custom-http",
+                        error_owner="user",
+                    ),
+                    organization_id=organization_id,
+                    tool_name=tool.name,
+                )
             return build_result(result)
 
-    except httpx.TimeoutException:
-        logger.error(f"Custom tool '{tool.name}' timed out after {timeout_seconds}s")
+    except httpx.TimeoutException as e:
+        log_failure(
+            classify_exception(
+                e,
+                source=ErrorSource.TOOL,
+                provider="custom-http",
+                error_owner="user",
+            ),
+            organization_id=organization_id,
+            tool_name=tool.name,
+        )
         return build_result(
             {
                 "status": "error",
@@ -372,7 +437,16 @@ async def execute_http_tool(
             }
         )
     except httpx.RequestError as e:
-        logger.error(f"Custom tool '{tool.name}' request failed: {e}")
+        log_failure(
+            classify_exception(
+                e,
+                source=ErrorSource.TOOL,
+                provider="custom-http",
+                error_owner="user",
+            ),
+            organization_id=organization_id,
+            tool_name=tool.name,
+        )
         return build_result(
             {
                 "status": "error",
@@ -380,7 +454,16 @@ async def execute_http_tool(
             }
         )
     except Exception as e:
-        logger.error(f"Custom tool '{tool.name}' execution failed: {e}")
+        log_failure(
+            classify_exception(
+                e,
+                source=ErrorSource.TOOL,
+                provider="custom-http",
+                error_owner="user",
+            ),
+            organization_id=organization_id,
+            tool_name=tool.name,
+        )
         return build_result(
             {
                 "status": "error",

--- a/api/tasks/run_integrations.py
+++ b/api/tasks/run_integrations.py
@@ -13,6 +13,13 @@ from api.constants import BACKEND_API_ENDPOINT, DEFAULT_WEBHOOK_DELIVERY_CONFIG
 from api.db import db_client
 from api.db.models import WorkflowRunModel
 from api.enums import OrganizationConfigurationKey
+from api.errors.failure import (
+    DograhFailure,
+    ErrorSource,
+    ErrorType,
+    classify_exception,
+    log_failure,
+)
 from api.services.integrations import (
     IntegrationCompletionContext,
     has_completion_handlers,
@@ -308,8 +315,20 @@ async def run_integrations_post_workflow_run(_ctx, workflow_run_id: int):
             try:
                 webhook_node = WebhookRFNode.model_validate(node)
             except ValidationError as e:
-                logger.warning(
-                    f"Webhook node #{node_id} failed validation, skipping: {e}"
+                log_failure(
+                    DograhFailure(
+                        source=ErrorSource.WEBHOOK,
+                        type=ErrorType.CONFIG_ERROR,
+                        code="webhook-invalid-config",
+                        internal_message=f"Webhook node #{node_id} failed validation: {e}",
+                        external_message="Check the webhook node configuration.",
+                        provider="webhook",
+                        error_owner="user",
+                        retryable=False,
+                    ),
+                    organization_id=organization_id,
+                    workflow_run_id=workflow_run_id,
+                    node_id=str(node_id),
                 )
                 continue
 
@@ -323,10 +342,23 @@ async def run_integrations_post_workflow_run(_ctx, workflow_run_id: int):
                     webhook_node_id=str(node_id),
                 )
             except Exception as e:
-                logger.warning(f"Failed to enqueue webhook '{webhook_data.name}': {e}")
+                log_failure(
+                    classify_exception(
+                        e,
+                        source=ErrorSource.WEBHOOK,
+                        provider="webhook",
+                        error_owner="user",
+                    ),
+                    organization_id=organization_id,
+                    workflow_run_id=workflow_run_id,
+                    node_id=str(node_id),
+                )
 
     except Exception as e:
-        logger.error(f"Error running integrations: {e}", exc_info=True)
+        log_failure(
+            classify_exception(e, source=ErrorSource.INTEGRATION),
+            workflow_run_id=workflow_run_id,
+        )
         raise
 
 

--- a/api/tasks/webhook_delivery.py
+++ b/api/tasks/webhook_delivery.py
@@ -19,11 +19,18 @@ from typing import Optional
 
 import httpx
 from loguru import logger
-from pipecat.utils.run_context import set_current_run_id
+from pipecat.utils.run_context import set_current_org_id, set_current_run_id
 
 from api.constants import DEFAULT_WEBHOOK_DELIVERY_CONFIG
 from api.db import db_client
 from api.db.models import WebhookDeliveryModel
+from api.errors.failure import (
+    DograhFailure,
+    ErrorSource,
+    classify_exception,
+    classify_http_response,
+    log_failure,
+)
 from api.tasks.function_names import FunctionNames
 from api.utils.credential_auth import build_auth_header
 
@@ -107,13 +114,13 @@ async def _handle_transient_failure(
     attempt: int,
     error: str,
     status_code: Optional[int],
-) -> None:
+) -> bool:
     """Schedule a backed-off retry, or dead-letter once attempts are exhausted."""
     if attempt >= delivery.max_attempts:
         await db_client.mark_webhook_delivery_dead_letter(
             delivery.id, attempt, error, status_code
         )
-        return
+        return True
 
     delay = _backoff_seconds(attempt)
     scheduled_for = datetime.now(UTC) + timedelta(seconds=delay)
@@ -129,6 +136,18 @@ async def _handle_transient_failure(
         f"Webhook '{delivery.webhook_name}' delivery {delivery.id} attempt {attempt} "
         f"failed ({error}); retrying in {delay}s "
         f"(attempt {attempt + 1}/{delivery.max_attempts})"
+    )
+    return False
+
+
+def _log_dead_letter_failure(
+    delivery: WebhookDeliveryModel, failure: DograhFailure
+) -> None:
+    log_failure(
+        failure,
+        organization_id=delivery.organization_id,
+        workflow_run_id=delivery.workflow_run_id,
+        delivery_id=delivery.id,
     )
 
 
@@ -153,6 +172,7 @@ async def deliver_webhook(_ctx, delivery_id: int) -> None:
         return
 
     set_current_run_id(str(delivery.workflow_run_id))
+    set_current_org_id(delivery.organization_id)
     attempt = delivery.attempt_count + 1
     method = (delivery.http_method or "POST").upper()
     timeout = DEFAULT_WEBHOOK_DELIVERY_CONFIG["timeout_seconds"]
@@ -181,27 +201,56 @@ async def deliver_webhook(_ctx, delivery_id: int) -> None:
     except httpx.HTTPStatusError as e:
         status_code = e.response.status_code
         error = f"HTTP {status_code}: {e.response.text[:200]}"
+        failure = classify_http_response(
+            status_code,
+            error,
+            source=ErrorSource.WEBHOOK,
+            provider="webhook",
+            error_owner="user",
+        )
         if status_code in _RETRYABLE_STATUS_CODES:
-            await _handle_transient_failure(delivery, attempt, error, status_code)
+            dead_lettered = await _handle_transient_failure(
+                delivery, attempt, error, status_code
+            )
+            if dead_lettered:
+                _log_dead_letter_failure(delivery, failure)
         else:
             # Permanent (auth/validation/not-found): retrying won't help. Park it.
             await db_client.mark_webhook_delivery_dead_letter(
                 delivery.id, attempt, error, status_code
             )
+            _log_dead_letter_failure(delivery, failure)
         return
     except httpx.RequestError as e:
         # Connect/read timeouts, DNS, connection resets -- the transient class that
         # previously lost the webhook entirely. str(e) is often empty, so use repr.
-        await _handle_transient_failure(delivery, attempt, repr(e), None)
+        dead_lettered = await _handle_transient_failure(
+            delivery, attempt, repr(e), None
+        )
+        if dead_lettered:
+            _log_dead_letter_failure(
+                delivery,
+                classify_exception(
+                    e,
+                    source=ErrorSource.WEBHOOK,
+                    provider="webhook",
+                    error_owner="user",
+                ),
+            )
         return
     except Exception as e:
         # Unexpected (e.g. a bug): don't loop on it, surface as dead-letter.
-        logger.error(
-            f"Webhook '{delivery.webhook_name}' delivery {delivery.id} "
-            f"unexpected error: {e!r}"
-        )
         await db_client.mark_webhook_delivery_dead_letter(
             delivery.id, attempt, repr(e), None
+        )
+        _log_dead_letter_failure(
+            delivery,
+            classify_exception(
+                e,
+                source=ErrorSource.WEBHOOK,
+                provider="webhook",
+                error_owner="user",
+            ),
         )
         return
 

--- a/api/tests/telephony/test_failure_reporting.py
+++ b/api/tests/telephony/test_failure_reporting.py
@@ -1,0 +1,171 @@
+from types import SimpleNamespace
+
+import pytest
+
+from api.errors.failure import DograhFailure, ErrorSource, ErrorType
+from api.errors.telephony_errors import (
+    TelephonyError,
+    failure_from_telephony_error,
+)
+from api.services.telephony.failure_reporting import instrument_telephony_provider
+from api.services.telephony import ari_manager
+
+
+def test_ari_failure_reporting_preserves_repeated_occurrences(monkeypatch):
+    captured = []
+    failure = DograhFailure(
+        source=ErrorSource.TELEPHONY,
+        type=ErrorType.CONFIG_ERROR,
+        code="ari-401",
+        internal_message="ARI rejected the configured credentials",
+        external_message="Check the ARI credentials.",
+        provider="ari",
+        error_owner="user",
+        retryable=False,
+    )
+    monkeypatch.setattr(
+        ari_manager,
+        "log_failure",
+        lambda reported, **context: captured.append((reported, context)),
+    )
+
+    ari_manager._log_ari_failure(
+        failure,
+        organization_id=42,
+        telephony_configuration_id=7,
+    )
+    ari_manager._log_ari_failure(
+        failure,
+        organization_id=42,
+        telephony_configuration_id=7,
+    )
+
+    assert captured == [
+        (
+            failure,
+            {"organization_id": 42, "telephony_configuration_id": 7},
+        ),
+        (
+            failure,
+            {"organization_id": 42, "telephony_configuration_id": 7},
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_outbound_instrumentation_classifies_and_reraises(monkeypatch):
+    captured = []
+
+    class ProviderError(Exception):
+        status_code = 401
+
+    error = ProviderError("Twilio rejected credentials with code 20003")
+
+    async def initiate_call(*_args, **_kwargs):
+        raise error
+
+    provider = SimpleNamespace(
+        PROVIDER_NAME="twilio",
+        initiate_call=initiate_call,
+    )
+    monkeypatch.setattr(
+        "api.services.telephony.failure_reporting.log_failure",
+        lambda failure, **context: captured.append((failure, context)),
+    )
+    instrument_telephony_provider(provider)
+
+    with pytest.raises(ProviderError) as raised:
+        await provider.initiate_call(
+            "+14155550123",
+            "https://dograh.test/webhook",
+            workflow_run_id=88,
+            organization_id=42,
+        )
+
+    assert raised.value is error
+    failure, context = captured[0]
+    assert failure.type == ErrorType.CONFIG_ERROR
+    assert failure.code == "twilio-401"
+    assert failure.provider_error_code is None
+    assert failure.error_owner.value == "user"
+    assert context["organization_id"] == 42
+    assert context["workflow_run_id"] == 88
+
+
+@pytest.mark.asyncio
+async def test_outbound_instrumentation_preserves_success_result():
+    result = object()
+
+    async def initiate_call(*_args, **_kwargs):
+        return result
+
+    provider = SimpleNamespace(
+        PROVIDER_NAME="telnyx",
+        initiate_call=initiate_call,
+    )
+
+    instrument_telephony_provider(provider)
+
+    assert await provider.initiate_call("to", "webhook") is result
+
+
+def test_inbound_validation_mapping_separates_config_and_quota():
+    config = failure_from_telephony_error(
+        TelephonyError.ACCOUNT_VALIDATION_FAILED,
+        provider="plivo",
+    )
+    quota = failure_from_telephony_error(
+        TelephonyError.CONCURRENT_CALL_LIMIT,
+        provider="plivo",
+    )
+
+    assert config is not None
+    assert config.type == ErrorType.CONFIG_ERROR
+    assert config.code == "plivo-account-validation-failed"
+    assert quota is not None
+    assert quota.type == ErrorType.QUOTA_ERROR
+    assert quota.code == "plivo-concurrent-call-limit"
+
+
+def test_signature_failure_is_not_customer_notification_eligible():
+    failure = failure_from_telephony_error(
+        TelephonyError.SIGNATURE_VALIDATION_FAILED,
+        provider="twilio",
+    )
+
+    assert failure is not None
+    assert failure.context["notification_eligible"] is False
+    assert failure.context["tenant_attribution_trusted"] is False
+
+
+def test_unknown_inbound_validation_defaults_to_system_error():
+    failure = failure_from_telephony_error("NOT_A_REAL_ERROR", provider="twilio")
+
+    assert failure is not None
+    assert failure.type == ErrorType.SYSTEM_ERROR
+    assert failure.code == "twilio-unknown-validation-error"
+    assert failure.context["notification_eligible"] is False
+
+
+@pytest.mark.asyncio
+async def test_explicit_provider_configuration_failure_is_config_error(monkeypatch):
+    captured = []
+
+    async def initiate_call(*_args, **_kwargs):
+        raise ValueError("Twilio provider not properly configured")
+
+    provider = SimpleNamespace(
+        PROVIDER_NAME="twilio",
+        initiate_call=initiate_call,
+    )
+    monkeypatch.setattr(
+        "api.services.telephony.failure_reporting.log_failure",
+        lambda failure, **_context: captured.append(failure),
+    )
+    instrument_telephony_provider(provider)
+
+    with pytest.raises(ValueError):
+        await provider.initiate_call("to", "webhook")
+
+    assert captured[0].type == ErrorType.CONFIG_ERROR
+    assert captured[0].code == "twilio-invalid-config"

--- a/api/tests/telephony/twilio/test_strategies.py
+++ b/api/tests/telephony/twilio/test_strategies.py
@@ -1,0 +1,56 @@
+from unittest.mock import patch
+
+import pytest
+
+from api.errors.failure import ErrorOwner, ErrorType
+from api.services.telephony.providers.twilio.strategies import TwilioHangupStrategy
+
+
+@pytest.mark.asyncio
+async def test_hangup_missing_credentials_is_user_owned_config_error():
+    with patch(
+        "api.services.telephony.providers.twilio.strategies.log_failure"
+    ) as log_failure:
+        result = await TwilioHangupStrategy().execute_hangup(
+            {
+                "auth_token": "secret",
+                "call_sid": "CA123",
+            }
+        )
+
+    assert result is False
+    log_failure.assert_called_once()
+    failure = log_failure.call_args.args[0]
+    assert log_failure.call_args.kwargs == {"operation": "hang up call"}
+    assert failure.type == ErrorType.CONFIG_ERROR
+    assert failure.error_owner == ErrorOwner.USER
+    assert failure.code == "twilio-missing-hangup-credentials"
+    assert failure.external_message == (
+        "Check the Twilio credentials configured for this call."
+    )
+
+
+@pytest.mark.asyncio
+async def test_hangup_missing_call_sid_is_operator_owned_system_error():
+    with patch(
+        "api.services.telephony.providers.twilio.strategies.log_failure"
+    ) as log_failure:
+        result = await TwilioHangupStrategy().execute_hangup(
+            {
+                "account_sid": "AC123",
+                "auth_token": "secret",
+                "call_sid": "",
+            }
+        )
+
+    assert result is False
+    log_failure.assert_called_once()
+    failure = log_failure.call_args.args[0]
+    assert log_failure.call_args.kwargs == {"operation": "hang up call"}
+    assert failure.type == ErrorType.SYSTEM_ERROR
+    assert failure.error_owner == ErrorOwner.OPERATOR
+    assert failure.code == "twilio-missing-call-sid"
+    assert failure.external_message == (
+        "Dograh could not identify the active Twilio call. Please retry or contact "
+        "support if the problem continues."
+    )

--- a/api/tests/test_failure_classification.py
+++ b/api/tests/test_failure_classification.py
@@ -259,6 +259,29 @@ def test_redaction_removes_url_query_userinfo_and_auth_secrets():
     assert redacted.count("[REDACTED]") >= 5
 
 
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (
+            r"payload={'client_secret': 'alpha\'omega', 'safe': 'visible'}",
+            "payload={'client_secret': '[REDACTED]', 'safe': 'visible'}",
+        ),
+        (
+            r'payload={"api_key": "alpha\"omega", "safe": "visible"}',
+            'payload={"api_key": "[REDACTED]", "safe": "visible"}',
+        ),
+        (
+            'payload={"private_key": "line-one\nline-two", "safe": "visible"}',
+            'payload={"private_key": "[REDACTED]", "safe": "visible"}',
+        ),
+    ],
+)
+def test_redaction_consumes_entire_escaped_or_multiline_quoted_secret(
+    message, expected
+):
+    assert redact_failure_message(message) == expected
+
+
 def test_factory_metadata_is_authoritative_over_wrapper_class_name():
     service = type("DograhOpenAIRealtimeLLMService", (), {})()
     annotate_failure_metadata(

--- a/api/tests/test_failure_classification.py
+++ b/api/tests/test_failure_classification.py
@@ -1,0 +1,436 @@
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from loguru import logger
+
+from api.errors import failure as failure_module
+from api.errors.failure import (
+    DograhFailure,
+    ErrorOwner,
+    ErrorSource,
+    ErrorType,
+    annotate_failure_metadata,
+    classify_exception,
+    classify_http_response,
+    failure_metadata_for_processor,
+    log_failure,
+    redact_failure_message,
+)
+from api.services.configuration.registry import REGISTRY, ServiceType
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_type", "retryable"),
+    [
+        (400, ErrorType.CONFIG_ERROR, False),
+        (401, ErrorType.CONFIG_ERROR, False),
+        (403, ErrorType.CONFIG_ERROR, False),
+        (404, ErrorType.CONFIG_ERROR, False),
+        (402, ErrorType.QUOTA_ERROR, False),
+        (429, ErrorType.QUOTA_ERROR, False),
+        (408, ErrorType.PROVIDER_ERROR, True),
+        (500, ErrorType.PROVIDER_ERROR, True),
+        (503, ErrorType.PROVIDER_ERROR, True),
+        (302, ErrorType.SYSTEM_ERROR, None),
+    ],
+)
+def test_classify_http_response_status_bands(status_code, expected_type, retryable):
+    failure = classify_http_response(
+        status_code,
+        f"provider returned HTTP {status_code}",
+        source=ErrorSource.STT,
+        provider="deepgram",
+        error_owner=ErrorOwner.USER,
+    )
+
+    assert failure.type == expected_type
+    assert failure.code == f"deepgram-{status_code}"
+    assert failure.retryable is retryable
+    expected_owner = (
+        ErrorOwner.OPERATOR
+        if expected_type == ErrorType.SYSTEM_ERROR
+        else ErrorOwner.USER
+    )
+    assert failure.error_owner == expected_owner
+
+
+@pytest.mark.parametrize(
+    ("error_type", "requested_owner", "expected_owner"),
+    [
+        (ErrorType.CONFIG_ERROR, None, ErrorOwner.USER),
+        (ErrorType.QUOTA_ERROR, None, ErrorOwner.USER),
+        (ErrorType.PROVIDER_ERROR, ErrorOwner.USER, ErrorOwner.USER),
+        (ErrorType.PROVIDER_ERROR, ErrorOwner.OPERATOR, ErrorOwner.OPERATOR),
+        (ErrorType.PROVIDER_ERROR, None, ErrorOwner.OPERATOR),
+        (ErrorType.SYSTEM_ERROR, ErrorOwner.USER, ErrorOwner.OPERATOR),
+    ],
+)
+def test_failure_resolves_binary_owner(error_type, requested_owner, expected_owner):
+    failure = DograhFailure(
+        source=ErrorSource.PLATFORM,
+        type=error_type,
+        code="test-failure",
+        internal_message="Test failure",
+        external_message="Test failure",
+        error_owner=requested_owner,
+    )
+
+    assert failure.error_owner == expected_owner
+
+
+class _StatusException(Exception):
+    def __init__(self, message, **attrs):
+        super().__init__(message)
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+
+def test_status_extraction_skips_vendor_code_and_uses_http_status():
+    exc = _StatusException(
+        'Status 401: {"code": 20003, "message": "Authenticate"}',
+        code=20003,
+        status=401,
+    )
+
+    failure = classify_exception(exc, source=ErrorSource.TELEPHONY, provider="twilio")
+
+    assert failure.type == ErrorType.CONFIG_ERROR
+    assert failure.code == "twilio-401"
+    assert failure.provider_error_code == "20003"
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_code"),
+    [
+        (httpx.ReadTimeout("read timed out"), "custom-http-timeout"),
+        (httpx.ConnectError("DNS lookup failed"), "custom-http-connection"),
+        (ConnectionError("connection reset"), "custom-http-connection"),
+        (OSError("socket closed"), "custom-http-connection"),
+    ],
+)
+def test_network_exceptions_are_provider_errors(exc, expected_code):
+    failure = classify_exception(exc, source=ErrorSource.TOOL, provider="custom_http")
+
+    assert failure.type == ErrorType.PROVIDER_ERROR
+    assert failure.code == expected_code
+    assert failure.retryable is True
+
+
+def test_ambiguous_exception_defaults_to_system_error():
+    failure = classify_exception(
+        ValueError("unexpected response shape"),
+        source=ErrorSource.LLM,
+        provider="openai",
+    )
+
+    assert failure.type == ErrorType.SYSTEM_ERROR
+    assert failure.code == "openai-unknown"
+
+
+@pytest.mark.parametrize(
+    ("provider", "message"),
+    [
+        ("elevenlabs", "quota_exceeded for this subscription"),
+        ("elevenlabs", "voice_not_found"),
+        ("deepgram", "NET-0001 connection lost"),
+        ("google_vertex_realtime", "UNAVAILABLE"),
+        (
+            "sarvam",
+            "Text must contain at least one character from the allowed languages",
+        ),
+    ],
+)
+def test_unstructured_provider_text_never_determines_attribution(provider, message):
+    failure = classify_exception(
+        RuntimeError(message), source=ErrorSource.TTS, provider=provider
+    )
+
+    assert failure.type == ErrorType.SYSTEM_ERROR
+    assert failure.code == f"{provider.replace('_', '-')}-unknown"
+
+
+def test_structured_provider_code_is_metadata_only():
+    failure = classify_exception(
+        _StatusException("connection lost", error_code="NET-0001"),
+        source=ErrorSource.STT,
+        provider="deepgram",
+    )
+
+    assert failure.type == ErrorType.SYSTEM_ERROR
+    assert failure.code == "deepgram-unknown"
+    assert failure.provider_error_code == "net-0001"
+
+
+def test_http_status_determines_type_while_vendor_code_remains_metadata():
+    failure = classify_exception(
+        _StatusException(
+            "subscription limit reached",
+            status_code=429,
+            error_code="quota_exceeded",
+        ),
+        source=ErrorSource.TTS,
+        provider="elevenlabs",
+    )
+
+    assert failure.type == ErrorType.QUOTA_ERROR
+    assert failure.code == "elevenlabs-429"
+    assert failure.provider_error_code == "quota-exceeded"
+
+
+def test_google_http_statuses_are_distinct_without_message_parsing():
+    not_found = classify_exception(
+        _StatusException("NOT_FOUND: bad model", code=404, status="NOT_FOUND"),
+        source=ErrorSource.LLM,
+        provider="google",
+    )
+    unavailable = classify_exception(
+        _StatusException("UNAVAILABLE", code=503, status="UNAVAILABLE"),
+        source=ErrorSource.LLM,
+        provider="google",
+    )
+
+    assert not_found.type == ErrorType.CONFIG_ERROR
+    assert not_found.code == "google-404"
+    assert unavailable.type == ErrorType.PROVIDER_ERROR
+    assert unavailable.code == "google-503"
+
+
+def test_dograh_boundary_changes_attribution():
+    quota = classify_http_response(
+        402,
+        "Insufficient Dograh credits",
+        source=ErrorSource.LLM,
+        provider="dograh",
+    )
+    managed_key_failure = classify_http_response(
+        401,
+        "Managed provider rejected the service key",
+        source=ErrorSource.LLM,
+        provider="dograh",
+    )
+
+    assert quota.type == ErrorType.QUOTA_ERROR
+    assert quota.error_owner == ErrorOwner.USER
+    assert quota.code == "dograh-insufficient-credits"
+    assert managed_key_failure.type == ErrorType.SYSTEM_ERROR
+    assert managed_key_failure.error_owner == ErrorOwner.OPERATOR
+
+
+def test_dograh_credit_prose_does_not_override_safe_default():
+    failure = classify_exception(
+        RuntimeError("insufficient credits"),
+        source=ErrorSource.PLATFORM,
+        provider="dograh",
+    )
+
+    assert failure.type == ErrorType.SYSTEM_ERROR
+    assert failure.error_owner == ErrorOwner.OPERATOR
+    assert failure.code == "dograh-unknown"
+
+
+def test_dograh_transport_failure_stays_system_error_but_keeps_retry_hint():
+    failure = classify_exception(
+        httpx.ConnectError("MPS connection refused"),
+        source=ErrorSource.PLATFORM,
+        provider="dograh",
+    )
+
+    assert failure.type == ErrorType.SYSTEM_ERROR
+    assert failure.error_owner == ErrorOwner.OPERATOR
+    assert failure.code == "dograh-connection"
+    assert failure.retryable is True
+
+
+def test_redaction_removes_url_query_userinfo_and_auth_secrets():
+    message = (
+        "wss://alice:password@pbx.example/ari/events?api_key=user:pass&token=abc "
+        "Authorization: Bearer header-token "
+        "{'X-Auth-Token': 'provider-secret', \"private_key\": \"pem-secret\"}"
+    )
+
+    redacted = redact_failure_message(message)
+
+    assert "password" not in redacted
+    assert "user:pass" not in redacted
+    assert "header-token" not in redacted
+    assert "provider-secret" not in redacted
+    assert "pem-secret" not in redacted
+    assert redacted.count("[REDACTED]") >= 5
+
+
+def test_factory_metadata_is_authoritative_over_wrapper_class_name():
+    service = type("DograhOpenAIRealtimeLLMService", (), {})()
+    annotate_failure_metadata(
+        service,
+        source=ErrorSource.LLM,
+        provider="openai_realtime",
+        error_owner=ErrorOwner.USER,
+    )
+
+    metadata = failure_metadata_for_processor(service)
+
+    assert metadata.source == ErrorSource.LLM
+    assert metadata.provider == "openai-realtime"
+    assert metadata.error_owner == ErrorOwner.USER
+
+
+def test_processor_class_name_is_only_a_fallback_hint():
+    processor = type("DeepgramSTTService", (), {})()
+
+    metadata = failure_metadata_for_processor(processor)
+
+    assert metadata.source == ErrorSource.STT
+    assert metadata.provider == "deepgram"
+    assert metadata.error_owner == ErrorOwner.OPERATOR
+
+
+def test_processor_provider_fallback_comes_from_live_registry(monkeypatch):
+    monkeypatch.setitem(REGISTRY[ServiceType.STT], "acme_voice", object())
+    processor = type("AcmeVoiceSTTService", (), {})()
+
+    metadata = failure_metadata_for_processor(processor)
+
+    assert metadata.source == ErrorSource.STT
+    assert metadata.provider == "acme-voice"
+
+
+def test_processor_provider_fallback_prefers_most_specific_registration():
+    processor = type("OpenAIRealtimeLLMService", (), {})()
+
+    metadata = failure_metadata_for_processor(processor)
+
+    assert metadata.source == ErrorSource.LLM
+    assert metadata.provider == "openai-realtime"
+
+
+def test_log_failure_emits_structured_and_inline_classification():
+    records = []
+    sink_id = logger.add(lambda message: records.append(message.record))
+    try:
+        log_failure(
+            DograhFailure(
+                source=ErrorSource.WEBHOOK,
+                type=ErrorType.CONFIG_ERROR,
+                code="webhook-404",
+                internal_message="Endpoint returned 404",
+                external_message="Check the endpoint.",
+                provider="webhook",
+                provider_error_code="endpoint_missing",
+            ),
+            organization_id=7,
+            workflow_run_id=88,
+        )
+    finally:
+        logger.remove(sink_id)
+
+    record = records[-1]
+    assert "DOGRAH_FAILURE [src=webhook type=config_error code=webhook-404]" in str(
+        record["message"]
+    )
+    assert record["extra"]["classified"] is True
+    assert record["extra"]["classification_mode"] == "explicit"
+    assert record["extra"]["error_owner"] == "user"
+    assert "credential_owner" not in record["extra"]
+    assert record["extra"]["provider_error_code"] == "endpoint-missing"
+    assert record["extra"]["organization_id"] == 7
+    assert record["extra"]["workflow_run_id"] == 88
+    assert record["file"].name == "test_failure_classification.py"
+    assert "[owner=user]" in str(record["message"])
+
+
+def test_log_failure_does_not_add_a_workflow_run_id_alias():
+    records = []
+    sink_id = logger.add(lambda message: records.append(message.record))
+    try:
+        log_failure(
+            DograhFailure(
+                source=ErrorSource.PLATFORM,
+                type=ErrorType.SYSTEM_ERROR,
+                code="platform-test",
+                internal_message="Test failure",
+                external_message="Test failure",
+            ),
+            fatal=True,
+        )
+    finally:
+        logger.remove(sink_id)
+
+    record = records[-1]
+    assert record["extra"]["fatal"] is True
+    assert "workflow_run_id" not in record["extra"]
+
+
+def test_classified_exception_keeps_safe_debugging_context():
+    try:
+        raise RuntimeError("token=provider-secret")
+    except RuntimeError as exc:
+        failure = classify_exception(
+            exc,
+            source=ErrorSource.INTEGRATION,
+            provider="crm",
+        )
+
+    assert failure.context["exception_type"] == "RuntimeError"
+    assert (
+        "test_classified_exception_keeps_safe_debugging_context"
+        in failure.context["exception_traceback"]
+    )
+    assert "provider-secret" not in failure.internal_message
+    assert "provider-secret" not in failure.context["exception_traceback"]
+
+
+def test_log_failure_never_raises_when_logger_fails(monkeypatch):
+    class _BrokenLogger:
+        def bind(self, **_kwargs):
+            raise RuntimeError("logger unavailable")
+
+    monkeypatch.setattr(failure_module, "logger", _BrokenLogger())
+
+    log_failure(
+        DograhFailure(
+            source=ErrorSource.PLATFORM,
+            type=ErrorType.SYSTEM_ERROR,
+            code="platform-test",
+            internal_message="test",
+            external_message="test",
+        )
+    )
+
+
+def test_status_extraction_uses_response_without_mistaking_vendor_code():
+    exc = _StatusException(
+        "request failed", code=20003, response=SimpleNamespace(status_code=503)
+    )
+
+    failure = classify_exception(exc, source=ErrorSource.INTEGRATION, provider="crm")
+
+    assert failure.type == ErrorType.PROVIDER_ERROR
+    assert failure.code == "crm-503"
+    assert failure.provider_error_code == "20003"
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_type", "expected_code"),
+    [
+        (
+            "server rejected WebSocket connection: HTTP 401",
+            ErrorType.CONFIG_ERROR,
+            "ari-401",
+        ),
+        (
+            "server rejected WebSocket connection: HTTP 530",
+            ErrorType.PROVIDER_ERROR,
+            "ari-530",
+        ),
+    ],
+)
+def test_http_status_embedded_in_exception_text_is_classified(
+    message, expected_type, expected_code
+):
+    failure = classify_exception(
+        RuntimeError(message), source=ErrorSource.TELEPHONY, provider="ari"
+    )
+
+    assert failure.type == expected_type
+    assert failure.code == expected_code

--- a/api/tests/test_failure_emission_seams.py
+++ b/api/tests/test_failure_emission_seams.py
@@ -1,0 +1,181 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from loguru import logger
+
+from api.errors.failure import ErrorType
+from api.services.integrations.registry import run_completion_handlers
+from api.services.pipecat.pre_call_fetch import execute_pre_call_fetch
+from api.services.workflow.tools.custom_tool import execute_http_tool
+from api.tasks.webhook_delivery import deliver_webhook
+
+
+def _async_client(*, response=None, error=None):
+    client = MagicMock()
+    if response is not None:
+        client.request = AsyncMock(return_value=response)
+        client.post = AsyncMock(return_value=response)
+    else:
+        client.request = AsyncMock(side_effect=error)
+        client.post = AsyncMock(side_effect=error)
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=client)
+    context.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=context)
+
+
+@pytest.mark.asyncio
+async def test_custom_tool_http_error_is_classified_without_changing_result():
+    response = MagicMock(status_code=401, text="Unauthorized")
+    response.json.return_value = {"error": "Unauthorized"}
+    captured = []
+    tool = SimpleNamespace(
+        name="Customer Lookup",
+        tool_uuid="tool-1",
+        definition={
+            "config": {
+                "method": "POST",
+                "url": "https://customer.test/lookup",
+            }
+        },
+    )
+
+    with (
+        patch(
+            "api.services.workflow.tools.custom_tool.httpx.AsyncClient",
+            _async_client(response=response),
+        ),
+        patch(
+            "api.services.workflow.tools.custom_tool.log_failure",
+            side_effect=lambda failure, **_context: captured.append(failure),
+        ),
+    ):
+        result = await execute_http_tool(tool, {}, organization_id=42)
+
+    assert result == {
+        "status": "success",
+        "status_code": 401,
+        "data": {"error": "Unauthorized"},
+    }
+    assert captured[0].source.value == "tool"
+    assert captured[0].type == ErrorType.CONFIG_ERROR
+    assert captured[0].code == "custom-http-401"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_fetch_classifies_http_failure_and_still_returns_empty():
+    response = MagicMock(status_code=503, text="Unavailable", is_success=False)
+    response.json.return_value = {}
+    captured = []
+
+    with (
+        patch(
+            "api.services.pipecat.pre_call_fetch.httpx.AsyncClient",
+            _async_client(response=response),
+        ),
+        patch(
+            "api.services.pipecat.pre_call_fetch.log_failure",
+            side_effect=lambda failure, **_context: captured.append(failure),
+        ),
+    ):
+        result = await execute_pre_call_fetch(
+            url="https://customer.test/context",
+            credential_uuid=None,
+            call_context_vars={},
+            workflow_id=7,
+            organization_id=42,
+        )
+
+    assert result == {}
+    assert captured[0].source.value == "integration"
+    assert captured[0].type == ErrorType.PROVIDER_ERROR
+    assert captured[0].code == "pre-call-fetch-503"
+
+
+@pytest.mark.asyncio
+async def test_integration_completion_failure_remains_isolated(monkeypatch):
+    package = SimpleNamespace(
+        name="salesforce",
+        run_completion=AsyncMock(side_effect=httpx.ConnectError("connection refused")),
+    )
+    context = SimpleNamespace(
+        workflow_definition={},
+        organization_id=42,
+        workflow_run_id=88,
+    )
+    monkeypatch.setattr(
+        "api.services.integrations.registry.iter_completion_packages",
+        lambda _definition: [(package, [{}])],
+    )
+
+    records = []
+    sink_id = logger.add(lambda message: records.append(message.record))
+    try:
+        result = await run_completion_handlers(context=context)
+    finally:
+        logger.remove(sink_id)
+
+    assert result == {"integration_salesforce": {"error": "completion_handler_failed"}}
+    failure_records = [
+        record for record in records if "DOGRAH_FAILURE" in str(record["message"])
+    ]
+    assert len(failure_records) == 1
+    assert failure_records[0]["extra"]["error_type"] == ErrorType.PROVIDER_ERROR
+    assert failure_records[0]["extra"]["error_code"] == "salesforce-connection"
+    assert failure_records[0]["extra"]["exception_type"] == "ConnectError"
+    assert (
+        "run_completion_handlers" in failure_records[0]["extra"]["exception_traceback"]
+    )
+    assert failure_records[0]["file"].name == "registry.py"
+
+
+def _delivery(*, attempt_count):
+    return SimpleNamespace(
+        id=1,
+        workflow_run_id=88,
+        organization_id=42,
+        attempt_count=attempt_count,
+        max_attempts=5,
+        http_method="POST",
+        credential_uuid=None,
+        custom_headers=[],
+        delivery_uuid="delivery-uuid",
+        endpoint_url="https://customer.test/webhook",
+        payload={"event": "done"},
+        webhook_name="Final Webhook",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("attempt_count", "expected_logs"), [(0, 0), (4, 1)])
+async def test_webhook_failure_logs_only_when_delivery_dead_letters(
+    attempt_count, expected_logs
+):
+    delivery = _delivery(attempt_count=attempt_count)
+    db = MagicMock()
+    db.claim_webhook_delivery = AsyncMock(return_value=delivery)
+    db.get_credential_by_uuid = AsyncMock(return_value=None)
+    db.schedule_webhook_delivery_retry = AsyncMock()
+    db.mark_webhook_delivery_dead_letter = AsyncMock()
+    captured = []
+
+    with (
+        patch("api.tasks.webhook_delivery.db_client", db),
+        patch(
+            "api.tasks.webhook_delivery.httpx.AsyncClient",
+            _async_client(error=httpx.ConnectError("connection refused")),
+        ),
+        patch("api.tasks.webhook_delivery._enqueue_delivery", AsyncMock()),
+        patch(
+            "api.tasks.webhook_delivery.log_failure",
+            side_effect=lambda failure, **_context: captured.append(failure),
+        ),
+    ):
+        await deliver_webhook(None, delivery.id)
+
+    assert len(captured) == expected_logs
+    if expected_logs:
+        assert captured[0].type == ErrorType.PROVIDER_ERROR
+        assert captured[0].code == "webhook-connection"

--- a/api/tests/test_logging_config.py
+++ b/api/tests/test_logging_config.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+
+from pipecat.utils.run_context import run_id_var
+
+from api.logging_config import enrich_log_record
+
+
+def _record(level: int, extra: dict | None = None) -> dict:
+    return {
+        "level": SimpleNamespace(no=level),
+        "extra": dict(extra or {}),
+    }
+
+
+def test_error_without_classification_gets_operator_fallback():
+    token = run_id_var.set("2250")
+    try:
+        record = _record(40)
+        enrich_log_record(record)
+    finally:
+        run_id_var.reset(token)
+
+    assert record["extra"] == {
+        "run_id": "2250",
+        "error_owner": "operator",
+        "error_type": "system_error",
+        "error_source": "platform",
+        "error_code": "unclassified-error",
+        "classified": True,
+        "classification_mode": "fallback",
+    }
+
+
+def test_explicit_error_classification_is_preserved():
+    record = _record(
+        40,
+        {
+            "error_owner": "user",
+            "error_type": "config_error",
+            "error_source": "stt",
+            "error_code": "deepgram-401",
+            "classified": False,
+        },
+    )
+
+    enrich_log_record(record)
+
+    assert record["extra"]["error_owner"] == "user"
+    assert record["extra"]["error_type"] == "config_error"
+    assert record["extra"]["error_source"] == "stt"
+    assert record["extra"]["error_code"] == "deepgram-401"
+    assert record["extra"]["classified"] is True
+    assert record["extra"]["classification_mode"] == "explicit"
+
+
+def test_partial_error_classification_falls_back_as_a_unit():
+    record = _record(40, {"error_owner": "user", "error_type": "config_error"})
+
+    enrich_log_record(record)
+
+    assert record["extra"]["error_owner"] == "operator"
+    assert record["extra"]["error_type"] == "system_error"
+    assert record["extra"]["error_source"] == "platform"
+    assert record["extra"]["error_code"] == "unclassified-error"
+    assert record["extra"]["classification_mode"] == "fallback"
+
+
+def test_warning_only_gets_run_context():
+    record = _record(30)
+
+    enrich_log_record(record)
+
+    assert record["extra"] == {"run_id": None}

--- a/api/tests/test_model_configuration_pricing.py
+++ b/api/tests/test_model_configuration_pricing.py
@@ -1,8 +1,9 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from api.errors.mps import MPSUnavailableError
 from api.routes import organization as organization_routes
 
 
@@ -64,3 +65,25 @@ async def test_model_configuration_pricing_uses_selected_organization(monkeypatc
     assert response.platform_usage.price_per_minute == 0.01
     assert response.dograh_model is not None
     assert response.dograh_model.price_per_minute == 0.07
+
+
+@pytest.mark.asyncio
+async def test_model_configuration_pricing_does_not_duplicate_mps_failure(monkeypatch):
+    route_log_failure = Mock()
+    get_pricing = AsyncMock(
+        side_effect=MPSUnavailableError("get_billing_pricing", status_code=503)
+    )
+    monkeypatch.setattr(organization_routes, "DEPLOYMENT_MODE", "saas")
+    monkeypatch.setattr(
+        organization_routes.mps_service_key_client,
+        "get_billing_pricing",
+        get_pricing,
+    )
+    monkeypatch.setattr(organization_routes, "log_failure", route_log_failure)
+
+    with pytest.raises(MPSUnavailableError):
+        await organization_routes.get_model_configuration_pricing(
+            SimpleNamespace(selected_organization_id=42),
+        )
+
+    route_log_failure.assert_not_called()

--- a/api/tests/test_mps_failure_http.py
+++ b/api/tests/test_mps_failure_http.py
@@ -1,0 +1,46 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from api.errors.mps import MPS_UNAVAILABLE_PUBLIC_MESSAGE, MPSUnavailableError
+from api.routes import user as user_routes
+
+
+@pytest.mark.asyncio
+async def test_voice_catalog_does_not_duplicate_mps_failure(monkeypatch):
+    route_log_failure = Mock()
+    get_voices = AsyncMock(side_effect=MPSUnavailableError("get_voices"))
+    monkeypatch.setattr(
+        user_routes.mps_service_key_client,
+        "get_voices",
+        get_voices,
+    )
+    monkeypatch.setattr(user_routes, "log_failure", route_log_failure)
+
+    with pytest.raises(MPSUnavailableError):
+        await user_routes.get_voices(
+            provider="cartesia",
+            user=SimpleNamespace(
+                selected_organization_id=42,
+                provider_id="provider-123",
+            ),
+        )
+
+    route_log_failure.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mps_unavailable_handler_returns_customer_safe_503():
+    from api.app import app, handle_mps_unavailable_error
+
+    assert app.exception_handlers[MPSUnavailableError] is handle_mps_unavailable_error
+
+    response = await handle_mps_unavailable_error(
+        None,
+        MPSUnavailableError("validate_service_key", status_code=503),
+    )
+
+    assert response.status_code == 503
+    assert json.loads(response.body) == {"detail": MPS_UNAVAILABLE_PUBLIC_MESSAGE}

--- a/api/tests/test_mps_service_key_client.py
+++ b/api/tests/test_mps_service_key_client.py
@@ -1,5 +1,9 @@
+import httpx
 import pytest
 
+from api.errors.failure import ErrorType
+from api.errors.mps import MPSUnavailableError
+from api.services import mps_service_key_client as mps_client_module
 from api.services.mps_service_key_client import MPSServiceKeyClient
 
 
@@ -46,6 +50,174 @@ def test_validate_service_key_uses_bearer_self_usage(monkeypatch):
             },
         )
     ]
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_validate_service_key_returns_false_only_for_auth_rejection(
+    monkeypatch,
+    status_code,
+):
+    emitted = []
+
+    class FakeClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+        def get(self, url, headers):
+            return _Response(status_code)
+
+    monkeypatch.setattr(mps_client_module.httpx, "Client", FakeClient)
+    monkeypatch.setattr(
+        mps_client_module,
+        "log_failure",
+        lambda failure, **context: emitted.append((failure, context)),
+    )
+
+    assert MPSServiceKeyClient().validate_service_key("mps_sk_invalid") is False
+    assert emitted == []
+
+
+def test_validate_service_key_classifies_mps_http_failure(monkeypatch):
+    emitted = []
+
+    class FakeClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+        def get(self, url, headers):
+            return _Response(503, text="upstream unavailable")
+
+    monkeypatch.setattr(mps_client_module.httpx, "Client", FakeClient)
+    monkeypatch.setattr(
+        mps_client_module,
+        "log_failure",
+        lambda failure, **context: emitted.append((failure, context)),
+    )
+
+    with pytest.raises(MPSUnavailableError) as exc_info:
+        MPSServiceKeyClient().validate_service_key(
+            "mps_sk_secret",
+            organization_id=42,
+            created_by="provider-123",
+        )
+
+    assert exc_info.value.status_code == 503
+    assert len(emitted) == 1
+    failure, context = emitted[0]
+    assert failure.type == ErrorType.SYSTEM_ERROR
+    assert failure.code == "dograh-503"
+    assert failure.provider == "dograh"
+    assert failure.error_owner.value == "operator"
+    assert "mps_sk_secret" not in failure.internal_message
+    assert context == {
+        "organization_id": 42,
+        "operation": "validate_service_key",
+    }
+
+
+def test_validate_service_key_classifies_mps_connection_failure(monkeypatch):
+    emitted = []
+    request_error = httpx.ConnectError(
+        "All connection attempts failed",
+        request=httpx.Request("GET", "https://services.dograh.com"),
+    )
+
+    class FakeClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+        def get(self, url, headers):
+            raise request_error
+
+    monkeypatch.setattr(mps_client_module.httpx, "Client", FakeClient)
+    monkeypatch.setattr(
+        mps_client_module,
+        "log_failure",
+        lambda failure, **context: emitted.append((failure, context)),
+    )
+
+    with pytest.raises(MPSUnavailableError) as exc_info:
+        MPSServiceKeyClient().validate_service_key(
+            "mps_sk_secret",
+            organization_id=42,
+        )
+
+    assert exc_info.value.__cause__ is request_error
+    assert len(emitted) == 1
+    failure, context = emitted[0]
+    assert failure.type == ErrorType.SYSTEM_ERROR
+    assert failure.code == "dograh-connection"
+    assert failure.retryable is True
+    assert context == {
+        "organization_id": 42,
+        "operation": "validate_service_key",
+    }
+
+
+@pytest.mark.asyncio
+async def test_pricing_and_voice_failures_each_emit_one_classified_record(monkeypatch):
+    emitted = []
+    responses = [_Response(502), _Response(503)]
+
+    class FakeAsyncClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url, headers, params=None):
+            return responses.pop(0)
+
+    monkeypatch.setattr(mps_client_module, "DEPLOYMENT_MODE", "saas")
+    monkeypatch.setattr(mps_client_module.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(
+        mps_client_module,
+        "log_failure",
+        lambda failure, **context: emitted.append((failure, context)),
+    )
+    client = MPSServiceKeyClient()
+
+    with pytest.raises(MPSUnavailableError):
+        await client.get_billing_pricing(42)
+    with pytest.raises(MPSUnavailableError):
+        await client.get_voices(provider="cartesia", organization_id=42)
+
+    assert len(emitted) == 2
+    pricing_failure, pricing_context = emitted[0]
+    voice_failure, voice_context = emitted[1]
+    assert pricing_failure.code == "dograh-502"
+    assert pricing_context == {
+        "organization_id": 42,
+        "operation": "get_billing_pricing",
+    }
+    assert voice_failure.code == "dograh-503"
+    assert voice_context == {
+        "organization_id": 42,
+        "operation": "get_voices",
+        "requested_provider": "cartesia",
+    }
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_pipeline_error_handling.py
+++ b/api/tests/test_pipeline_error_handling.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pipecat.frames.frames import ErrorFrame
+
+from api.services.pipecat.event_handlers import register_event_handlers
+
+
+class _EventSource:
+    def __init__(self):
+        self.handlers = {}
+
+    def event_handler(self, name):
+        def decorator(handler):
+            self.handlers[name] = handler
+            return handler
+
+        return decorator
+
+
+@pytest.mark.asyncio
+async def test_nonfatal_pipeline_error_does_not_end_call(monkeypatch):
+    task = _EventSource()
+    transport = _EventSource()
+    engine = SimpleNamespace(end_call_with_reason=AsyncMock())
+    audio_buffer = SimpleNamespace(
+        start_recording=AsyncMock(),
+        stop_recording=AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "api.services.pipecat.event_handlers.db_client.get_workflow_run_by_id",
+        AsyncMock(),
+    )
+
+    register_event_handlers(
+        task=task,
+        transport=transport,
+        workflow_run_id=88,
+        engine=engine,
+        audio_buffer=audio_buffer,
+        in_memory_logs_buffer=SimpleNamespace(),
+        transcript_log_coordinator=SimpleNamespace(),
+        pipeline_metrics_aggregator=SimpleNamespace(),
+        audio_config=SimpleNamespace(pipeline_sample_rate=16000),
+    )
+
+    await task.handlers["on_pipeline_error"](
+        task,
+        ErrorFrame("recoverable provider reconnect", fatal=False),
+    )
+
+    engine.end_call_with_reason.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fatal_pipeline_error_still_ends_call(monkeypatch):
+    task = _EventSource()
+    transport = _EventSource()
+    engine = SimpleNamespace(end_call_with_reason=AsyncMock())
+    audio_buffer = SimpleNamespace(
+        start_recording=AsyncMock(),
+        stop_recording=AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "api.services.pipecat.event_handlers.db_client.get_workflow_run_by_id",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "api.services.pipecat.event_handlers._capture_call_event",
+        AsyncMock(),
+    )
+
+    register_event_handlers(
+        task=task,
+        transport=transport,
+        workflow_run_id=88,
+        engine=engine,
+        audio_buffer=audio_buffer,
+        in_memory_logs_buffer=SimpleNamespace(),
+        transcript_log_coordinator=SimpleNamespace(),
+        pipeline_metrics_aggregator=SimpleNamespace(),
+        audio_config=SimpleNamespace(pipeline_sample_rate=16000),
+    )
+
+    await task.handlers["on_pipeline_error"](
+        task,
+        ErrorFrame("unrecoverable failure", fatal=True),
+    )
+
+    engine.end_call_with_reason.assert_awaited_once()

--- a/api/tests/test_realtime_feedback_observer.py
+++ b/api/tests/test_realtime_feedback_observer.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 from pipecat.frames.frames import (
+    ErrorFrame,
     TranscriptionFrame,
     TTSTextFrame,
 )
@@ -119,6 +120,56 @@ async def test_observer_waits_for_tts_text_from_output_transport():
             "payload": {"text": "Hello"},
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_observer_classifies_each_distinct_error_frame(monkeypatch):
+    messages = []
+    failures = []
+
+    async def ws_sender(message):
+        messages.append(message)
+
+    def capture_failure(failure, **context):
+        failures.append((failure, context))
+
+    monkeypatch.setattr(
+        "api.services.pipecat.realtime_feedback_observer.log_failure",
+        capture_failure,
+    )
+    processor = type("DeepgramSTTService", (), {})()
+    observer = RealtimeFeedbackObserver(ws_sender=ws_sender)
+
+    first = ErrorFrame(
+        "Authentication failed",
+        processor=processor,
+        exception=type("ProviderError", (Exception,), {"status_code": 401})(
+            "Authentication failed"
+        ),
+    )
+    repeat = ErrorFrame(
+        "Authentication failed again",
+        fatal=True,
+        processor=processor,
+        exception=type("ProviderError", (Exception,), {"status_code": 401})(
+            "Authentication failed again"
+        ),
+    )
+
+    await observer.on_push_frame(_frame_pushed(first, FrameDirection.UPSTREAM))
+    await observer.on_push_frame(_frame_pushed(repeat, FrameDirection.UPSTREAM))
+    await observer.on_push_frame(_frame_pushed(first, FrameDirection.DOWNSTREAM))
+
+    # Distinct attempts are retained; re-observing the identical frame is not.
+    assert len(messages) == 2
+    assert len(failures) == 2
+    assert failures[0][0].source.value == "stt"
+    assert failures[0][0].type.value == "config_error"
+    assert failures[0][0].error_owner.value == "user"
+    assert failures[0][0].provider == "deepgram"
+    assert failures[0][0].code == "deepgram-401"
+    assert failures[0][1] == {"fatal": False}
+    assert failures[1][1] == {"fatal": True}
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_service_factory_failure_reporting.py
+++ b/api/tests/test_service_factory_failure_reporting.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.errors.failure import ErrorSource, ErrorType, failure_metadata_for_processor
+from api.services.pipecat.service_factory import create_llm_service_from_provider
+
+
+def test_service_factory_classifies_constructor_failure_and_reraises(monkeypatch):
+    captured = []
+    monkeypatch.setattr(
+        "api.services.pipecat.service_factory.log_failure",
+        lambda failure: captured.append(failure),
+    )
+
+    with pytest.raises(HTTPException):
+        create_llm_service_from_provider(
+            provider="not-a-provider",
+            model="model",
+            api_key="key",
+        )
+
+    assert captured[0].source == ErrorSource.LLM
+    assert captured[0].type == ErrorType.CONFIG_ERROR
+    assert captured[0].code == "not-a-provider-400"
+    assert captured[0].error_owner.value == "user"
+
+
+def test_service_factory_tags_success_with_authoritative_ownership():
+    service = SimpleNamespace()
+    with patch(
+        "api.services.pipecat.service_factory.OpenAILLMService",
+        return_value=service,
+    ):
+        result = create_llm_service_from_provider(
+            provider="openai",
+            model="gpt-4.1-mini",
+            api_key="key",
+        )
+
+    metadata = failure_metadata_for_processor(result)
+    assert metadata.source == ErrorSource.LLM
+    assert metadata.provider == "openai"
+    assert metadata.error_owner.value == "user"
+
+
+def test_managed_service_constructor_failure_is_attributed_to_dograh(monkeypatch):
+    captured = []
+    monkeypatch.setattr(
+        "api.services.pipecat.service_factory.log_failure",
+        lambda failure: captured.append(failure),
+    )
+    with (
+        patch(
+            "api.services.pipecat.service_factory.DograhLLMService",
+            side_effect=ValueError("bad managed response"),
+        ),
+        pytest.raises(ValueError),
+    ):
+        create_llm_service_from_provider(
+            provider="dograh",
+            model="gpt-4.1-mini",
+            api_key="managed-key",
+        )
+
+    assert captured[0].type == ErrorType.SYSTEM_ERROR
+    assert captured[0].error_owner.value == "operator"

--- a/api/tests/test_user_configuration_validation.py
+++ b/api/tests/test_user_configuration_validation.py
@@ -1,14 +1,22 @@
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from api.errors.mps import MPSUnavailableError
 from api.routes import user as user_routes
-from api.schemas.ai_model_configuration import EffectiveAIModelConfiguration
+from api.schemas.ai_model_configuration import (
+    DograhManagedAIModelConfiguration,
+    EffectiveAIModelConfiguration,
+    OrganizationAIModelConfigurationV2,
+    compile_ai_model_configuration_v2,
+)
+from api.services.configuration import check_validity
 from api.services.configuration.ai_model_configuration import (
     ResolvedAIModelConfiguration,
 )
+from api.services.configuration.check_validity import UserConfigurationValidator
 
 
 @pytest.mark.asyncio
@@ -97,3 +105,60 @@ async def test_validate_user_configurations_uses_fresh_org_v2_validation_cache(
     assert response == {"status": []}
     validate.assert_not_awaited()
     touch_validation_cache.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_managed_service_key_is_checked_once_per_validation_request(monkeypatch):
+    validate_service_key = Mock(return_value=True)
+    monkeypatch.setattr(
+        check_validity.mps_service_key_client,
+        "validate_service_key",
+        validate_service_key,
+    )
+    configuration = compile_ai_model_configuration_v2(
+        OrganizationAIModelConfigurationV2(
+            mode="dograh",
+            dograh=DograhManagedAIModelConfiguration(api_key="mps-shared-key"),
+        )
+    )
+    validator = UserConfigurationValidator()
+
+    assert await validator.validate(
+        configuration,
+        organization_id=42,
+        created_by="provider-123",
+    ) == {"status": [{"model": "all", "message": "ok"}]}
+    assert await validator.validate(
+        configuration,
+        organization_id=42,
+        created_by="provider-123",
+    ) == {"status": [{"model": "all", "message": "ok"}]}
+
+    assert validate_service_key.call_count == 2
+    validate_service_key.assert_called_with(
+        "mps-shared-key",
+        organization_id=42,
+        created_by="provider-123",
+    )
+
+
+@pytest.mark.asyncio
+async def test_mps_outage_is_not_reported_as_invalid_customer_key(monkeypatch):
+    monkeypatch.setattr(
+        check_validity.mps_service_key_client,
+        "validate_service_key",
+        Mock(side_effect=MPSUnavailableError("validate_service_key")),
+    )
+    configuration = compile_ai_model_configuration_v2(
+        OrganizationAIModelConfigurationV2(
+            mode="dograh",
+            dograh=DograhManagedAIModelConfiguration(api_key="mps-shared-key"),
+        )
+    )
+
+    with pytest.raises(MPSUnavailableError):
+        await UserConfigurationValidator().validate(
+            configuration,
+            organization_id=42,
+            created_by="provider-123",
+        )

--- a/ui/src/app/workflow/[workflowId]/page.tsx
+++ b/ui/src/app/workflow/[workflowId]/page.tsx
@@ -10,6 +10,7 @@ import type { WorkflowResponse } from '@/client/types.gen';
 import { FlowEdge, FlowNode } from '@/components/flow/types';
 import SpinLoader from '@/components/SpinLoader';
 import { PostHogEvent } from '@/constants/posthog-events';
+import { detailFromError } from '@/lib/apiError';
 import { useAuth } from '@/lib/auth';
 import logger from '@/lib/logger';
 import { WorkflowConfigurations } from '@/types/workflow-configurations';
@@ -40,11 +41,24 @@ export default function WorkflowDetailPage() {
                         workflow_id: Number(params.workflowId)
                     },
                 });
+
+                if (response.error) {
+                    const fallback = response.response?.status === 503
+                        ? 'Dograh is temporarily unavailable. Please try again later.'
+                        : 'Failed to fetch workflow';
+                    setError(detailFromError(response.error, fallback));
+                    return;
+                }
+
                 const workflow = response.data;
+                if (!workflow) {
+                    setError('Workflow not found');
+                    return;
+                }
                 setWorkflow(workflow);
                 posthog.capture(PostHogEvent.WORKFLOW_EDITOR_OPENED, {
-                    workflow_id: workflow?.id,
-                    workflow_name: workflow?.name,
+                    workflow_id: workflow.id,
+                    workflow_name: workflow.name,
                 });
             } catch (err) {
                 setError('Failed to fetch workflow');

--- a/ui/src/app/workflow/[workflowId]/run/[runId]/hooks/useWebSocketRTC.tsx
+++ b/ui/src/app/workflow/[workflowId]/run/[runId]/hooks/useWebSocketRTC.tsx
@@ -7,6 +7,7 @@ import { WorkflowValidationError } from "@/components/flow/types";
 import type { ConversationNodeTransitionItem, RealtimeFeedbackMessage as FeedbackMessage } from "@/components/workflow/conversation";
 import { useAppConfig } from "@/context/AppConfigContext";
 import { resolveBrowserBackendUrl } from '@/lib/apiClient';
+import { detailFromError } from '@/lib/apiError';
 import logger from '@/lib/logger';
 
 import { sdpFilterCodec } from "../utils";
@@ -704,16 +705,28 @@ export const useWebSocketRTC = ({ workflowId, workflowRunId, accessToken, initia
             });
 
             if (response.error) {
+                const isServiceUnavailable = response.response?.status === 503;
+                const message = detailFromError(
+                    response.error,
+                    isServiceUnavailable
+                        ? 'Dograh is temporarily unavailable. Please try again later.'
+                        : 'API Key Error',
+                );
+
+                if (isServiceUnavailable) {
+                    // MPS is a Dograh-owned dependency. Do not tell the customer
+                    // to change credentials when Dograh could not validate them.
+                    setApiKeyModalOpen(false);
+                    setApiKeyError(null);
+                    setApiKeyErrorCode(null);
+                    setPermissionError(message);
+                    setConnectionStatus('failed');
+                    return;
+                }
+
                 setApiKeyModalOpen(true);
                 setApiKeyErrorCode('invalid_api_key');
-                let msg = 'API Key Error';
-                const detail = (response.error as unknown as { detail?: { errors: { model: string; message: string }[] } }).detail;
-                if (Array.isArray(detail)) {
-                    msg = detail
-                        .map((e: { model: string; message: string }) => `${e.model}: ${e.message}`)
-                        .join('\n');
-                }
-                setApiKeyError(msg);
+                setApiKeyError(message);
                 setConnectionStatus('failed');
                 return;
             }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured failure classification at error sources and key seams with safe, user-facing messages and consistent logging. MPS outages now raise a typed error that returns HTTP 503 with a clear message; telephony, pipeline, integrations, tools, and webhooks emit one classified event per failure without changing runtime behavior. Redaction now covers escaped quoted credentials in failure logs.

- **New Features**
  - Introduced a stable failure taxonomy and `log_failure` to emit structured, shadow‑mode error events.
  - Added a typed MPS boundary (`MPSUnavailableError`) with a FastAPI handler that returns 503 and a safe message; routes re‑raise to avoid duplicate logs.
  - Instrumented telephony, pipeline, integrations, tools, and webhooks to classify errors at the source; non‑fatal pipeline `ErrorFrame`s no longer end calls.
  - Service factories tag processors and classify constructor failures; registry exposes provider name/matching helpers.
  - Logging injects `run_id` and applies a conservative fallback classification to any unclassified ERROR.
  - UI shows a clear outage message when the backend returns 503 on workflow pages and during WebSocket setup.

- **Bug Fixes**
  - Twilio hangup: classify ownership correctly (user‑owned config errors for missing credentials; provider or transient errors otherwise) and emit a single, typed failure per attempt.
  - Redaction: scrub escaped or quoted credentials in failure messages for HTTP tools, webhooks, and telephony paths.

<sup>Written for commit 910e9486c2c7f68be9ceff1346a71e3b0ed057f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change introduces structured failure classification, redacted failure logging, and customer-safe outage handling for Dograh-managed dependencies across backend services and workflow UI flows.

The MPS service-key validation behavior was exercised with mocked authoritative credential failures, MPS 503 responses, and transport failures. The prior behavior incorrectly treated all of those conditions as invalid credentials. The current implementation preserves `false` for authoritative 401/403 responses while raising the typed unavailable-dependency error for 503 responses, allowing the FastAPI boundary to return the customer-safe 503 message. The focused MPS client suite also passed all 15 tests.

The previously observed MPS outage misclassification is not reported because the executed current-code probe contradicted it: 503 responses now raise `MPSUnavailableError` rather than returning an invalid-key result.

<h3>Confidence Score: 5/5</h3>

The PR is safe to merge; no blocking failure remains.

The focused runtime checks verified that invalid service keys remain distinguishable from managed-service outages, and the corresponding MPS client tests passed.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a narrow mock-based MPS classification probe against the parent commit for 401, 403, 503, and transport failures; the probe returned false for all conditions, indicating the old behavior.
- Executed the documented focused backend test suite with pytest; 15 tests passed in api/tests/test\_mps\_service\_key\_client.py -q.
- Ran the same MPS probe on the current code; 401 and 403 still returned false, while a mocked 503 raised MPSUnavailableError, showing that unavailable MPS responses no longer follow the invalid-service-key path.
- Noted that the P1 behavior observed before PR #618 is fixed in the current change, as validated by the runtime and test results.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: redact escaped quoted credentials"](https://github.com/dograh-hq/dograh/commit/910e9486c2c7f68be9ceff1346a71e3b0ed057f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50044317)</sub>

<!-- /greptile_comment -->