### PR TITLE
fix(auth): default to 'local' not 'stack' when provider is missing

### DIFF
--- a/ui/src/lib/auth/providers/AuthProvider.tsx
+++ b/ui/src/lib/auth/providers/AuthProvider.tsx
@@ -50,7 +50,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       .then((res) => res.json())
       .then((data) => {
         logger.debug(`Setting auth provider as ${data.provider}`)
-        setAuthProvider(data.provider || 'stack')
+        setAuthProvider(data.provider || 'local')
   })
       .catch((e) => {
         logger.error(`Got error ${e} while setting auth provider`)


### PR DESCRIPTION
## Problem

`AuthProvider.tsx:53` defaults to `'stack'` when `/api/config/auth` returns a response with a falsy `provider` field:

```tsx
setAuthProvider(data.provider || 'stack')
```

This is inconsistent with **every other fallback path** in the auth resolution chain:

| Location | Fallback |
|----------|----------|
| `config.ts:28` (server-side `getAuthProvider`) | `'local'` |
| `AuthProvider.tsx:57` (catch block) | `'local'` |
| **`AuthProvider.tsx:53` (success path)** | **`'stack'`** ← bug |

### Impact

On OSS / self-hosted deployments, if `/api/config/auth` ever returns a 200 with an empty or missing `provider` field (e.g., backend health endpoint degraded, response shape change), the UI will crash into Stack Auth instead of falling back to local auth. This breaks login on the entire app.

## Fix

Change the fallback from `'stack'` to `'local'` to match all other code paths:

```diff
- setAuthProvider(data.provider || 'stack')
+ setAuthProvider(data.provider || 'local')
```

## Verification

- [x] Searched entire `ui/src` for other `|| 'stack'` fallbacks — none found
- [x] Confirmed server-side `config.ts` already defaults to `'local'` on error
- [x] Confirmed error catch handler already defaults to `'local'`
- [x] One-line change, no new logic introduced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default to 'local' instead of 'stack' when the auth provider is missing, matching other code paths and preventing unintended Stack Auth redirects on OSS/self-hosted installs.

- **Bug Fixes**
  - In `AuthProvider.tsx`, set `setAuthProvider(data.provider || 'local')` on successful `/api/config/auth` response to align with the server default and catch handler.

<sup>Written for commit f425a6fadde2b393c288b0b5c6cd198512e37caf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the client authentication fallback so missing or empty provider configuration uses local authentication rather than Stack Auth. Browser testing exercised missing, empty, and explicit `stack` responses: missing and empty responses rendered the local sign-in page and initialized the OSS auth endpoint, while explicit Stack configuration continued to select Stack Auth without initializing local authentication. The tested regression was disproved: the changed behavior routes each provider response to the intended authentication flow.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the authentication fallback behaves correctly for unavailable, empty, and explicit provider configuration.

The changed client-side selection was exercised in Chromium against intercepted configuration responses. Missing and empty values reached the local sign-in flow, and an explicit Stack value remained isolated from the local auth wrapper.

**Files Needing Attention:** No files need additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Conducted a focused Chromium browser check comparing the parent revision and the changed revision with intercepted /api/config/auth responses for missing provider, empty provider, and explicit stack.
- Observed that the parent revision routed missing and empty responses to Stack Auth.
- Observed on the changed revision that missing and empty responses rendered the local sign-in page and triggered an /api/auth/oss request, while an explicit stack payload produced no OSS request, confirming Stack Auth was selected.
- Reproduced the test in a real Chromium browser; for missing and falsy config payloads, the rendered login page was visible and the LocalProviderWrapper-only /api/auth/oss request occurred.
- In the same real Chromium run, an explicit stack payload produced no /api/auth/oss request, showing StackProviderWrapper was selected; the parent revision behavior for missing/falsy payloads routed them to Stack as in the earlier run.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): default to &#39;local&#39; not &#39;stack..."](https://github.com/dograh-hq/dograh/commit/f425a6fadde2b393c288b0b5c6cd198512e37caf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50145920)</sub>

<!-- /greptile_comment -->