### PR TITLE
Fix FORCE_TURN_RELAY leaking public candidates on CGNAT/private-range deployments

### DIFF
--- a/api/constants.py
+++ b/api/constants.py
@@ -28,6 +28,16 @@ LANGFUSE_SECRET_KEY = os.getenv("LANGFUSE_SECRET_KEY")
 PUBLIC_BASE_URL = os.getenv("PUBLIC_BASE_URL") or None
 PUBLIC_HOST = os.getenv("PUBLIC_HOST") or None
 
+# The server's own IPv4 address, as the operator supplied it to the setup
+# script. Usually identical to PUBLIC_HOST, but kept distinct because it must
+# stay a raw IP (coturn's external-ip needs one) while PUBLIC_HOST may be a
+# hostname such as an sslip.io name. resolve_ice_filter_policies() classifies
+# it to detect a private-LAN or CGNAT deployment (e.g. Tailscale, no public
+# IP) and pick ICE candidate filtering accordingly, so an empty value here is
+# read as "public deployment" — every consumer of this must be wired through
+# docker-compose, or that detection silently misfires.
+SERVER_IP = os.getenv("SERVER_IP", "")
+
 # Public URL the backend builds webhook/callback/embed links from. Derives from
 # PUBLIC_BASE_URL (public IP / domain), falling back to localhost for local dev.
 # When this is a non-public address (localhost or a private/reserved IP) the host

--- a/api/routes/webrtc_signaling.py
+++ b/api/routes/webrtc_signaling.py
@@ -29,7 +29,7 @@ from pipecat.transports.smallwebrtc.connection import SmallWebRTCConnection
 from pipecat.utils.run_context import set_current_org_id, set_current_run_id
 from starlette.websockets import WebSocketState
 
-from api.constants import ENABLE_COTURN, ENVIRONMENT, FORCE_TURN_RELAY
+from api.constants import ENABLE_COTURN, ENVIRONMENT, FORCE_TURN_RELAY, SERVER_IP
 from api.db import db_client
 from api.db.models import UserModel
 from api.enums import Environment, WorkflowRunMode
@@ -140,7 +140,7 @@ def resolve_ice_filter_policies(
 ICE_OUTBOUND_POLICY, ICE_INBOUND_POLICY = resolve_ice_filter_policies(
     ENVIRONMENT,
     FORCE_TURN_RELAY,
-    os.getenv("SERVER_IP", ""),
+    SERVER_IP,
 )
 
 
@@ -234,13 +234,30 @@ def get_ice_servers(user_id: Optional[str] = None) -> List[RTCIceServer]:
     Returns:
         List of RTCIceServer configurations for WebRTC peer connection.
     """
-    servers: List[RTCIceServer] = [RTCIceServer(urls="stun:stun.l.google.com:19302")]
+    # A `stun:` entry can only yield srflx, never relay, so it cannot help a
+    # relay-only connection — it only gathers a public IP that
+    # filter_outbound_sdp() strips back out. Matches the client-side skip.
+    servers: List[RTCIceServer] = (
+        []
+        if FORCE_TURN_RELAY
+        else [RTCIceServer(urls="stun:stun.l.google.com:19302")]
+    )
 
     # Check if TURN is configured. ENABLE_COTURN is the deployment's declared
     # answer to "is there a TURN server?" — the same flag /health advertises to
     # browsers — so the server side must respect it too, or it would try to
     # relay through a TURN server the deployment says it doesn't have.
     if not ENABLE_COTURN or not TURN_HOST:
+        if FORCE_TURN_RELAY:
+            # Fail loudly rather than silently degrading to STUN: relay-only was
+            # requested precisely because direct connectivity is known not to
+            # work, so an empty server list producing zero candidates is the
+            # honest outcome — but it needs to be diagnosable.
+            logger.error(
+                "FORCE_TURN_RELAY is on but no TURN server is configured "
+                f"(ENABLE_COTURN={ENABLE_COTURN}, TURN_HOST={TURN_HOST!r}). "
+                "Relay-only connections cannot succeed until TURN is configured."
+            )
         return servers
 
     # Use time-limited credentials if TURN_SECRET is configured (recommended)

--- a/api/routes/webrtc_signaling.py
+++ b/api/routes/webrtc_signaling.py
@@ -61,7 +61,25 @@ class NonRelayFilterPolicy(Enum):
 
     NONE = "none"  # filter nothing — pass all candidates
     PRIVATE = "private"  # filter non-relay candidates with private/CGNAT IPs
+    PUBLIC = "public"  # filter non-relay candidates that are NOT private/CGNAT
     ALL = "all"  # filter all non-relay candidates (relay-only mode)
+
+
+def is_cgnat_ip(ip_str: str) -> bool:
+    """Return True for CGNAT addresses (100.64.0.0/10) specifically — the
+    range Tailscale and similar overlay networks use. Distinct from the
+    broader is_local_or_cgnat_ip(): a CGNAT-addressed server (e.g. Tailscale-
+    only, no public IP) commonly has no route to the public internet at all,
+    whereas a plain RFC1918 LAN server usually still has normal NAT'd
+    internet access — the two need different inbound-candidate handling.
+    """
+
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+
+    return ip.version == 4 and ip in ipaddress.ip_network("100.64.0.0/10")
 
 
 def is_local_or_cgnat_ip(ip_str: str) -> bool:
@@ -72,8 +90,7 @@ def is_local_or_cgnat_ip(ip_str: str) -> bool:
     except ValueError:
         return False
 
-    is_cgnat = ip.version == 4 and ip in ipaddress.ip_network("100.64.0.0/10")
-    return ip.is_private or ip.is_loopback or ip.is_link_local or is_cgnat
+    return ip.is_private or ip.is_loopback or ip.is_link_local or is_cgnat_ip(ip_str)
 
 
 def resolve_ice_filter_policies(
@@ -91,11 +108,25 @@ def resolve_ice_filter_policies(
         # Relay-only diagnostics stay explicit. On private LAN deployments we
         # must still accept inbound private candidates for relay<->host pairs.
         outbound_policy = NonRelayFilterPolicy.ALL
-        inbound_policy = (
-            NonRelayFilterPolicy.NONE
-            if private_lan_deployment
-            else NonRelayFilterPolicy.PRIVATE
-        )
+        if private_lan_deployment:
+            # A CGNAT-addressed server (e.g. Tailscale-only, no public IP)
+            # commonly has no route to the public internet at all, so a
+            # genuinely public inbound candidate can never be reachable once
+            # we've committed to relay-only — e.g. a client-side STUN entry
+            # leaking a server-reflexive public-IP candidate despite
+            # iceTransportPolicy: 'relay'. Drop those instead of wasting the
+            # ICE timeout on a doomed direct-to-internet check.
+            #
+            # A plain RFC1918 LAN server usually still has normal NAT'd
+            # internet access, so a public candidate there might genuinely
+            # succeed — keep accepting everything inbound as before.
+            inbound_policy = (
+                NonRelayFilterPolicy.PUBLIC
+                if is_cgnat_ip(server_ip)
+                else NonRelayFilterPolicy.NONE
+            )
+        else:
+            inbound_policy = NonRelayFilterPolicy.PRIVATE
         return outbound_policy, inbound_policy
 
     if environment == Environment.LOCAL.value or private_lan_deployment:
@@ -151,6 +182,9 @@ def _keep_candidate(candidate_str: str, policy: NonRelayFilterPolicy) -> bool:
         return True
     if policy == NonRelayFilterPolicy.ALL:
         return False
+    if policy == NonRelayFilterPolicy.PUBLIC:
+        # PUBLIC: drop non-relay candidates that are NOT private/CGNAT
+        return is_private_ip_candidate(candidate_str)
     # PRIVATE: drop non-relay candidates with private/CGNAT IPs
     return not is_private_ip_candidate(candidate_str)
 

--- a/api/tests/test_webrtc_signaling_ice_filter_policies.py
+++ b/api/tests/test_webrtc_signaling_ice_filter_policies.py
@@ -1,3 +1,4 @@
+import api.routes.webrtc_signaling as webrtc_signaling
 from api.routes.webrtc_signaling import (
     NonRelayFilterPolicy,
     _keep_candidate,
@@ -69,3 +70,64 @@ def test_keep_candidate_public_policy_drops_public_keeps_private():
 def test_keep_candidate_relay_always_passes_regardless_of_policy():
     for policy in NonRelayFilterPolicy:
         assert _keep_candidate(_RELAY_CANDIDATE, policy) is True
+
+
+def _urls(servers):
+    """Flatten RTCIceServer.urls, which may be a bare str or a list."""
+    flat = []
+    for server in servers:
+        urls = server.urls
+        flat.extend(urls if isinstance(urls, list) else [urls])
+    return flat
+
+
+def _stub_turn(monkeypatch, *, host="100.64.1.10"):
+    monkeypatch.setattr(webrtc_signaling, "ENABLE_COTURN", True)
+    monkeypatch.setattr(webrtc_signaling, "TURN_HOST", host)
+    monkeypatch.setattr(webrtc_signaling, "TURN_SECRET", "s3cret")
+    monkeypatch.setattr(
+        webrtc_signaling,
+        "generate_turn_credentials",
+        lambda user_id: {
+            "uris": [f"turn:{host}:3478"],
+            "username": "user",
+            "password": "pass",
+            "ttl": 86400,
+        },
+    )
+
+
+def test_get_ice_servers_omits_public_stun_in_relay_only_mode(monkeypatch):
+    # FORCE_TURN_RELAY means "direct connectivity is known not to work here".
+    # A public STUN entry can only ever yield a server-reflexive candidate,
+    # never a relay one, so it cannot help — it can only gather a public-IP
+    # candidate that filter_outbound_sdp() then strips back out. The server
+    # must agree with the client, which already skips STUN in this mode.
+    monkeypatch.setattr(webrtc_signaling, "FORCE_TURN_RELAY", True)
+    _stub_turn(monkeypatch)
+
+    urls = _urls(webrtc_signaling.get_ice_servers(user_id="1"))
+
+    assert not any(url.startswith("stun:") for url in urls)
+    assert urls == ["turn:100.64.1.10:3478"]
+
+
+def test_get_ice_servers_keeps_public_stun_when_not_relay_only(monkeypatch):
+    # Unchanged behaviour off the relay-only path.
+    monkeypatch.setattr(webrtc_signaling, "FORCE_TURN_RELAY", False)
+    monkeypatch.setattr(webrtc_signaling, "ENABLE_COTURN", False)
+
+    assert _urls(webrtc_signaling.get_ice_servers()) == [
+        "stun:stun.l.google.com:19302"
+    ]
+
+
+def test_get_ice_servers_relay_only_without_turn_returns_no_servers(monkeypatch):
+    # No silent fallback to STUN when TURN is missing: an empty list is the
+    # honest answer (the connection genuinely cannot succeed), and the error
+    # logged alongside it is what makes that diagnosable.
+    monkeypatch.setattr(webrtc_signaling, "FORCE_TURN_RELAY", True)
+    monkeypatch.setattr(webrtc_signaling, "ENABLE_COTURN", False)
+    monkeypatch.setattr(webrtc_signaling, "TURN_HOST", "")
+
+    assert webrtc_signaling.get_ice_servers(user_id="1") == []

--- a/api/tests/test_webrtc_signaling_ice_filter_policies.py
+++ b/api/tests/test_webrtc_signaling_ice_filter_policies.py
@@ -1,0 +1,71 @@
+from api.routes.webrtc_signaling import (
+    NonRelayFilterPolicy,
+    _keep_candidate,
+    resolve_ice_filter_policies,
+)
+
+_PUBLIC_HOST_CANDIDATE = (
+    "candidate:1 1 udp 2122260223 1.1.1.1 45406 typ host"
+)
+_PRIVATE_HOST_CANDIDATE = (
+    "candidate:1 1 udp 2122260223 192.168.1.10 45406 typ host"
+)
+_CGNAT_HOST_CANDIDATE = (
+    "candidate:1 1 udp 2122260223 100.64.1.10 45406 typ host"
+)
+_RELAY_CANDIDATE = (
+    "candidate:1 1 udp 2122260223 100.64.1.10 49188 typ relay "
+    "raddr 0.0.0.0 rport 0"
+)
+
+
+def test_force_turn_relay_on_cgnat_server_drops_public_inbound_candidates():
+    # A CGNAT/tailscale-range SERVER_IP with FORCE_TURN_RELAY=true must still
+    # reject a leaked public-IP candidate — relay was explicitly requested
+    # because direct/public connectivity is known not to work, so a public
+    # inbound candidate can never succeed and should be dropped rather than
+    # wasting the ICE timeout on it.
+    outbound, inbound = resolve_ice_filter_policies(
+        environment="production",
+        force_turn_relay=True,
+        server_ip="100.64.1.10",
+    )
+    assert outbound == NonRelayFilterPolicy.ALL
+    assert inbound == NonRelayFilterPolicy.PUBLIC
+
+
+def test_force_turn_relay_on_public_server_drops_private_inbound_candidates():
+    outbound, inbound = resolve_ice_filter_policies(
+        environment="production",
+        force_turn_relay=True,
+        server_ip="8.8.8.8",
+    )
+    assert outbound == NonRelayFilterPolicy.ALL
+    assert inbound == NonRelayFilterPolicy.PRIVATE
+
+
+def test_force_turn_relay_on_plain_private_lan_keeps_prior_unfiltered_behavior():
+    # A plain RFC1918 LAN server (not CGNAT) usually still has normal NAT'd
+    # internet access, so a public inbound candidate might genuinely work —
+    # this must stay NONE exactly as before, unlike the CGNAT case above.
+    # Matches the pre-existing
+    # test_force_turn_relay_stays_relay_only_on_private_lan in
+    # test_is_private_ip_candidate.py, which this must not break.
+    outbound, inbound = resolve_ice_filter_policies(
+        environment="production",
+        force_turn_relay=True,
+        server_ip="192.168.50.24",
+    )
+    assert outbound == NonRelayFilterPolicy.ALL
+    assert inbound == NonRelayFilterPolicy.NONE
+
+
+def test_keep_candidate_public_policy_drops_public_keeps_private():
+    assert _keep_candidate(_PUBLIC_HOST_CANDIDATE, NonRelayFilterPolicy.PUBLIC) is False
+    assert _keep_candidate(_PRIVATE_HOST_CANDIDATE, NonRelayFilterPolicy.PUBLIC) is True
+    assert _keep_candidate(_CGNAT_HOST_CANDIDATE, NonRelayFilterPolicy.PUBLIC) is True
+
+
+def test_keep_candidate_relay_always_passes_regardless_of_policy():
+    for policy in NonRelayFilterPolicy:
+        assert _keep_candidate(_RELAY_CANDIDATE, policy) is True

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -231,6 +231,12 @@ services:
       TURN_HOST: "${TURN_HOST:-}"
       TURN_SECRET: "${TURN_SECRET:-}"
       FORCE_TURN_RELAY: "${FORCE_TURN_RELAY:-false}"
+      # Same SERVER_IP set for dograh-init above. resolve_ice_filter_policies()
+      # reads this directly (os.getenv("SERVER_IP")) to detect a CGNAT/private-
+      # range deployment (e.g. behind Tailscale) and adjust ICE candidate
+      # filtering accordingly. Without it here, that detection silently always
+      # sees an empty string and falls back to public-deployment filtering.
+      SERVER_IP: "${SERVER_IP:-}"
 
       OSS_JWT_SECRET: "${OSS_JWT_SECRET:?OSS_JWT_SECRET must be set to a strong secret}"
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -231,11 +231,6 @@ services:
       TURN_HOST: "${TURN_HOST:-}"
       TURN_SECRET: "${TURN_SECRET:-}"
       FORCE_TURN_RELAY: "${FORCE_TURN_RELAY:-false}"
-      # Same SERVER_IP set for dograh-init above. resolve_ice_filter_policies()
-      # reads this directly (os.getenv("SERVER_IP")) to detect a CGNAT/private-
-      # range deployment (e.g. behind Tailscale) and adjust ICE candidate
-      # filtering accordingly. Without it here, that detection silently always
-      # sees an empty string and falls back to public-deployment filtering.
       SERVER_IP: "${SERVER_IP:-}"
 
       OSS_JWT_SECRET: "${OSS_JWT_SECRET:?OSS_JWT_SECRET must be set to a strong secret}"

--- a/ui/public/embed/dograh-widget.js
+++ b/ui/public/embed/dograh-widget.js
@@ -876,8 +876,12 @@
    * Create WebRTC peer connection
    */
   function createWebRTCConnection() {
-    // Build ICE servers list
-    const iceServers = [{ urls: ['stun:stun.l.google.com:19302'] }];
+    // A `stun:` entry can only yield srflx, never relay — and srflx has been
+    // seen leaking through iceTransportPolicy: 'relay', so skip it entirely.
+    // Same skip as the main app's useWebSocketRTC hook.
+    const iceServers = state.config.forceTurnRelay
+      ? []
+      : [{ urls: ['stun:stun.l.google.com:19302'] }];
 
     // Add TURN server if credentials are available
     if (state.turnCredentials && state.turnCredentials.uris && state.turnCredentials.uris.length > 0) {
@@ -887,6 +891,16 @@
         credential: state.turnCredentials.password
       });
       console.log(`TURN server configured with ${state.turnCredentials.uris.length} URIs`);
+    }
+
+    // Reachable: turn_enabled and force_turn_relay are independent, so
+    // FORCE_TURN_RELAY=true with TURN_SECRET unset (or a failed credentials
+    // fetch) leaves no ICE servers at all — no candidates, and no clue why.
+    if (state.config.forceTurnRelay && iceServers.length === 0) {
+      console.error(
+        'Dograh Widget: FORCE_TURN_RELAY is on but no TURN credentials are ' +
+        'available — ICE has no candidates to gather and this call cannot connect.'
+      );
     }
 
     const config = {

--- a/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.test.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.test.tsx
@@ -1,0 +1,104 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { EmbeddedVoiceTester } from "./EmbeddedVoiceTester";
+
+const { startMock, useWebSocketRTCMock } = vi.hoisted(() => ({
+    startMock: vi.fn(),
+    useWebSocketRTCMock: vi.fn(),
+}));
+
+vi.mock("../../run/[runId]/hooks", () => ({
+    useWebSocketRTC: useWebSocketRTCMock,
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("@/components/workflow/conversation", () => ({
+    RealtimeFeedback: () => null,
+}));
+
+vi.mock("../../run/[runId]/components", () => ({
+    ApiKeyErrorDialog: () => null,
+    ConnectionStatus: () => null,
+    WorkflowConfigErrorDialog: () => null,
+}));
+
+// Base shape of everything EmbeddedVoiceTester destructures off the hook.
+// Only `appConfigLoading` varies per test — this is the field the auto-start
+// gate in EmbeddedVoiceTester depends on.
+function baseHookReturn(appConfigLoading: boolean) {
+    return {
+        audioRef: { current: null },
+        connectionActive: false,
+        permissionError: null,
+        isCompleted: false,
+        apiKeyModalOpen: false,
+        setApiKeyModalOpen: vi.fn(),
+        apiKeyError: null,
+        apiKeyErrorCode: null,
+        workflowConfigError: null,
+        workflowConfigModalOpen: false,
+        setWorkflowConfigModalOpen: vi.fn(),
+        connectionStatus: "idle",
+        start: startMock,
+        stop: vi.fn(),
+        isStarting: false,
+        feedbackMessages: [],
+        appConfigLoading,
+    };
+}
+
+describe("EmbeddedVoiceTester auto-start", () => {
+    const props = {
+        workflowId: 1,
+        workflowRunId: 1,
+        accessToken: "token",
+        onReset: vi.fn(),
+    };
+
+    it("does not call start() while appConfig is still loading", () => {
+        startMock.mockClear();
+        useWebSocketRTCMock.mockReturnValue(baseHookReturn(true));
+
+        render(<EmbeddedVoiceTester {...props} />);
+
+        // createPeerConnection reads appConfig?.forceTurnRelay synchronously —
+        // calling start() before appConfig has loaded would silently create a
+        // connection missing the relay-only restriction, with no way to
+        // recreate it once appConfig resolves (see PR description / commit
+        // message for the full failure mode this reproduces).
+        expect(startMock).not.toHaveBeenCalled();
+    });
+
+    it("calls start() exactly once, only after appConfig finishes loading", () => {
+        startMock.mockClear();
+        useWebSocketRTCMock.mockReturnValue(baseHookReturn(true));
+
+        const { rerender } = render(<EmbeddedVoiceTester {...props} />);
+        expect(startMock).not.toHaveBeenCalled();
+
+        // appConfig resolves — re-render with appConfigLoading now false, as
+        // React would after the async /api/config/version fetch completes.
+        useWebSocketRTCMock.mockReturnValue(baseHookReturn(false));
+        rerender(<EmbeddedVoiceTester {...props} />);
+
+        expect(startMock).toHaveBeenCalledTimes(1);
+
+        // A further re-render (e.g. any other state change) must not
+        // trigger a second start() — autoStartedRef still guards that.
+        rerender(<EmbeddedVoiceTester {...props} />);
+        expect(startMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls start() immediately when appConfig was already loaded on mount", () => {
+        startMock.mockClear();
+        useWebSocketRTCMock.mockReturnValue(baseHookReturn(false));
+
+        render(<EmbeddedVoiceTester {...props} />);
+
+        expect(startMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.test.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.test.tsx
@@ -36,6 +36,8 @@ function baseHookReturn(opts: {
     refreshAppConfig: () => void;
     appConfigLoading: boolean;
     backendStatus?: BackendStatus;
+    isStarting?: boolean;
+    connectionStatus?: string;
 }) {
     return {
         audioRef: { current: null },
@@ -49,10 +51,10 @@ function baseHookReturn(opts: {
         workflowConfigError: null,
         workflowConfigModalOpen: false,
         setWorkflowConfigModalOpen: vi.fn(),
-        connectionStatus: "idle",
+        connectionStatus: opts.connectionStatus ?? "idle",
         start: opts.start,
         stop: vi.fn(),
-        isStarting: false,
+        isStarting: opts.isStarting ?? false,
         feedbackMessages: [],
         appConfig: opts.backendStatus ? { backendStatus: opts.backendStatus } : null,
         appConfigLoading: opts.appConfigLoading,
@@ -238,12 +240,22 @@ describe("EmbeddedVoiceTester auto-start", () => {
 
         const { rerender } = render(<EmbeddedVoiceTester {...props} />);
 
+        // isStarting: true (with connectionStatus staying non-"failed") makes
+        // the disabled-state check below meaningful: the component's disabled
+        // expression is `isStarting && connectionStatus !== "failed" &&
+        // !configUnreachable`, and with isStarting false (as every other test
+        // in this file uses) that whole expression is already false
+        // regardless of configUnreachable — the assertion would pass even if
+        // configUnreachable did nothing at all. Only with isStarting true does
+        // "not disabled" actually prove configUnreachable is short-circuiting
+        // it, as a review bot correctly pointed out.
         useWebSocketRTCMock.mockReturnValue(
             baseHookReturn({
                 start,
                 refreshAppConfig,
                 appConfigLoading: false,
                 backendStatus: "unreachable",
+                isStarting: true,
             })
         );
         rerender(<EmbeddedVoiceTester {...props} />);
@@ -257,8 +269,9 @@ describe("EmbeddedVoiceTester auto-start", () => {
         // render on their own.
         rerender(<EmbeddedVoiceTester {...props} />);
 
-        // Still just the one automatic retry; the button must now be a
-        // real, enabled retry action.
+        // Still just the one automatic retry; the button must now be a real,
+        // enabled retry action — meaningful specifically because isStarting
+        // is true here (see comment above).
         expect(refreshAppConfig).toHaveBeenCalledTimes(1);
         const retryButton = screen.getByRole("button", { name: /retry connection/i }) as HTMLButtonElement;
         expect(retryButton.disabled).toBe(false);
@@ -280,5 +293,78 @@ describe("EmbeddedVoiceTester auto-start", () => {
         rerender(<EmbeddedVoiceTester {...props} />);
 
         expect(start).toHaveBeenCalledTimes(1);
+    });
+
+    it("issues exactly one extra fetch per manual retry click, not two, when it also comes back unreachable", () => {
+        // Regression test for a review bot's own reproduction: the manual
+        // retry handler used to reset configRetriedRef to false before
+        // calling refreshAppConfig(). That made the auto-start effect think
+        // no retry had happened yet, so when the manual refresh resolved
+        // still unreachable, the effect fired its *own* extra automatic
+        // refresh on top of the manual one — one click producing two fetches
+        // (three total including the very first automatic retry) instead of
+        // one (two total).
+        const start = vi.fn();
+        const refreshAppConfig = vi.fn();
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({ start, refreshAppConfig, appConfigLoading: true })
+        );
+
+        const { rerender } = render(<EmbeddedVoiceTester {...props} />);
+
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({
+                start,
+                refreshAppConfig,
+                appConfigLoading: false,
+                backendStatus: "unreachable",
+                isStarting: true,
+            })
+        );
+        rerender(<EmbeddedVoiceTester {...props} />); // effect fires the first automatic retry
+        rerender(<EmbeddedVoiceTester {...props} />); // configRetriedRef's flip becomes observable
+        expect(refreshAppConfig).toHaveBeenCalledTimes(1);
+
+        const retryButton = screen.getByRole("button", { name: /retry connection/i });
+        fireEvent.click(retryButton);
+        expect(refreshAppConfig).toHaveBeenCalledTimes(2);
+
+        // Simulate the manual refresh's async work actually resolving — the
+        // mock doesn't auto-update the way the real refreshAppConfig
+        // (AppConfigContext.loadConfig) would, so this has to be done
+        // explicitly: loading flips true then false again, still
+        // unreachable. Without an actual appConfigLoading change here the
+        // effect never re-runs at all and this test would pass unconditionally
+        // regardless of whether the bug exists (confirmed by running this
+        // test against the buggy handleConfigRetry — it must fail there).
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({
+                start,
+                refreshAppConfig,
+                appConfigLoading: true,
+                backendStatus: "unreachable",
+                isStarting: true,
+            })
+        );
+        rerender(<EmbeddedVoiceTester {...props} />);
+
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({
+                start,
+                refreshAppConfig,
+                appConfigLoading: false,
+                backendStatus: "unreachable",
+                isStarting: true,
+            })
+        );
+        rerender(<EmbeddedVoiceTester {...props} />);
+        // One more render for configRetriedRef's own flip (if any) to become
+        // observable, same as earlier in this file.
+        rerender(<EmbeddedVoiceTester {...props} />);
+
+        // Exactly the one manual fetch — no extra automatic retry fired on
+        // top of it.
+        expect(refreshAppConfig).toHaveBeenCalledTimes(2);
+        expect(start).not.toHaveBeenCalled();
     });
 });

--- a/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.test.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { EmbeddedVoiceTester } from "./EmbeddedVoiceTester";
@@ -223,5 +223,62 @@ describe("EmbeddedVoiceTester auto-start", () => {
 
         expect(firstStart).toHaveBeenCalledTimes(1);
         expect(secondStart).not.toHaveBeenCalled();
+    });
+
+    it("offers a working manual retry instead of staying permanently stuck once unreachable", () => {
+        // Regression test for a review bot's reproduction: after the one
+        // bounded auto-retry, the tester must not be left with no way to
+        // ever start (a dead "Starting Test..." spinner with no functional
+        // click handler) if the backend is still unreachable.
+        const start = vi.fn();
+        const refreshAppConfig = vi.fn();
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({ start, refreshAppConfig, appConfigLoading: true })
+        );
+
+        const { rerender } = render(<EmbeddedVoiceTester {...props} />);
+
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({
+                start,
+                refreshAppConfig,
+                appConfigLoading: false,
+                backendStatus: "unreachable",
+            })
+        );
+        rerender(<EmbeddedVoiceTester {...props} />);
+        expect(refreshAppConfig).toHaveBeenCalledTimes(1);
+
+        // configRetriedRef flips inside the effect, which commits *after*
+        // this render's own render-phase read of it — one more render (with
+        // unchanged props/mocks) is needed to observe it, mirroring the real
+        // app: refreshAppConfig there is the actual context function, whose
+        // own state updates naturally trigger exactly this kind of follow-up
+        // render on their own.
+        rerender(<EmbeddedVoiceTester {...props} />);
+
+        // Still just the one automatic retry; the button must now be a
+        // real, enabled retry action.
+        expect(refreshAppConfig).toHaveBeenCalledTimes(1);
+        const retryButton = screen.getByRole("button", { name: /retry connection/i }) as HTMLButtonElement;
+        expect(retryButton.disabled).toBe(false);
+
+        fireEvent.click(retryButton);
+        expect(refreshAppConfig).toHaveBeenCalledTimes(2);
+        expect(start).not.toHaveBeenCalled();
+
+        // The manual retry succeeds — this must lead to a real start(), not
+        // just another no-op retry loop.
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({
+                start,
+                refreshAppConfig,
+                appConfigLoading: false,
+                backendStatus: "reachable",
+            })
+        );
+        rerender(<EmbeddedVoiceTester {...props} />);
+
+        expect(start).toHaveBeenCalledTimes(1);
     });
 });

--- a/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.test.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.test.tsx
@@ -3,8 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { EmbeddedVoiceTester } from "./EmbeddedVoiceTester";
 
-const { startMock, useWebSocketRTCMock } = vi.hoisted(() => ({
-    startMock: vi.fn(),
+const { useWebSocketRTCMock } = vi.hoisted(() => ({
     useWebSocketRTCMock: vi.fn(),
 }));
 
@@ -26,10 +25,18 @@ vi.mock("../../run/[runId]/components", () => ({
     WorkflowConfigErrorDialog: () => null,
 }));
 
+type BackendStatus = "reachable" | "unreachable";
+
 // Base shape of everything EmbeddedVoiceTester destructures off the hook.
-// Only `appConfigLoading` varies per test — this is the field the auto-start
-// gate in EmbeddedVoiceTester depends on.
-function baseHookReturn(appConfigLoading: boolean) {
+// start/refreshAppConfig are passed in per-test so each test can use its own
+// mock instances (needed to genuinely exercise identity-dependent effect
+// re-runs rather than relying on React's dependency-array bailout).
+function baseHookReturn(opts: {
+    start: () => void;
+    refreshAppConfig: () => void;
+    appConfigLoading: boolean;
+    backendStatus?: BackendStatus;
+}) {
     return {
         audioRef: { current: null },
         connectionActive: false,
@@ -43,11 +50,13 @@ function baseHookReturn(appConfigLoading: boolean) {
         workflowConfigModalOpen: false,
         setWorkflowConfigModalOpen: vi.fn(),
         connectionStatus: "idle",
-        start: startMock,
+        start: opts.start,
         stop: vi.fn(),
         isStarting: false,
         feedbackMessages: [],
-        appConfigLoading,
+        appConfig: opts.backendStatus ? { backendStatus: opts.backendStatus } : null,
+        appConfigLoading: opts.appConfigLoading,
+        refreshAppConfig: opts.refreshAppConfig,
     };
 }
 
@@ -60,45 +69,159 @@ describe("EmbeddedVoiceTester auto-start", () => {
     };
 
     it("does not call start() while appConfig is still loading", () => {
-        startMock.mockClear();
-        useWebSocketRTCMock.mockReturnValue(baseHookReturn(true));
+        const start = vi.fn();
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({ start, refreshAppConfig: vi.fn(), appConfigLoading: true })
+        );
 
         render(<EmbeddedVoiceTester {...props} />);
 
-        // createPeerConnection reads appConfig?.forceTurnRelay synchronously —
-        // calling start() before appConfig has loaded would silently create a
-        // connection missing the relay-only restriction, with no way to
-        // recreate it once appConfig resolves (see PR description / commit
-        // message for the full failure mode this reproduces).
-        expect(startMock).not.toHaveBeenCalled();
+        expect(start).not.toHaveBeenCalled();
     });
 
-    it("calls start() exactly once, only after appConfig finishes loading", () => {
-        startMock.mockClear();
-        useWebSocketRTCMock.mockReturnValue(baseHookReturn(true));
+    it("calls start() once appConfig finishes loading with a reachable backend", () => {
+        const start = vi.fn();
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({ start, refreshAppConfig: vi.fn(), appConfigLoading: true })
+        );
 
         const { rerender } = render(<EmbeddedVoiceTester {...props} />);
-        expect(startMock).not.toHaveBeenCalled();
+        expect(start).not.toHaveBeenCalled();
 
-        // appConfig resolves — re-render with appConfigLoading now false, as
-        // React would after the async /api/config/version fetch completes.
-        useWebSocketRTCMock.mockReturnValue(baseHookReturn(false));
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({
+                start,
+                refreshAppConfig: vi.fn(),
+                appConfigLoading: false,
+                backendStatus: "reachable",
+            })
+        );
         rerender(<EmbeddedVoiceTester {...props} />);
 
-        expect(startMock).toHaveBeenCalledTimes(1);
-
-        // A further re-render (e.g. any other state change) must not
-        // trigger a second start() — autoStartedRef still guards that.
-        rerender(<EmbeddedVoiceTester {...props} />);
-        expect(startMock).toHaveBeenCalledTimes(1);
+        expect(start).toHaveBeenCalledTimes(1);
     });
 
-    it("calls start() immediately when appConfig was already loaded on mount", () => {
-        startMock.mockClear();
-        useWebSocketRTCMock.mockReturnValue(baseHookReturn(false));
+    it("calls start() immediately when appConfig was already loaded and reachable on mount", () => {
+        const start = vi.fn();
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({
+                start,
+                refreshAppConfig: vi.fn(),
+                appConfigLoading: false,
+                backendStatus: "reachable",
+            })
+        );
 
         render(<EmbeddedVoiceTester {...props} />);
 
-        expect(startMock).toHaveBeenCalledTimes(1);
+        expect(start).toHaveBeenCalledTimes(1);
+    });
+
+    it("never starts, and never calls start with a stale config, once loading finishes with an unreachable backend even after retrying", () => {
+        // Regression test for the exact failure mode a review bot flagged:
+        // /api/config/version can resolve (loading -> false) with HTTP 200
+        // while backendStatus is 'unreachable' (the server-side healthcheck
+        // it performs failed/timed out) — forceTurnRelay silently defaults to
+        // false in that response. Starting on "loading finished" alone would
+        // create a connection missing the relay-only restriction whenever
+        // this happens on a deployment that actually needs it.
+        const start = vi.fn();
+        const refreshAppConfig = vi.fn();
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({ start, refreshAppConfig, appConfigLoading: true })
+        );
+
+        const { rerender } = render(<EmbeddedVoiceTester {...props} />);
+
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({
+                start,
+                refreshAppConfig,
+                appConfigLoading: false,
+                backendStatus: "unreachable",
+            })
+        );
+        rerender(<EmbeddedVoiceTester {...props} />);
+
+        // One retry attempted, not started.
+        expect(refreshAppConfig).toHaveBeenCalledTimes(1);
+        expect(start).not.toHaveBeenCalled();
+
+        // Backend still unreachable after the retry resolves — must not
+        // retry again or start; a genuinely down backend must not spin
+        // forever, and must never fall through to starting unprotected.
+        rerender(<EmbeddedVoiceTester {...props} />);
+        expect(refreshAppConfig).toHaveBeenCalledTimes(1);
+        expect(start).not.toHaveBeenCalled();
+    });
+
+    it("starts once the retried config comes back reachable", () => {
+        const start = vi.fn();
+        const refreshAppConfig = vi.fn();
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({ start, refreshAppConfig, appConfigLoading: true })
+        );
+
+        const { rerender } = render(<EmbeddedVoiceTester {...props} />);
+
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({
+                start,
+                refreshAppConfig,
+                appConfigLoading: false,
+                backendStatus: "unreachable",
+            })
+        );
+        rerender(<EmbeddedVoiceTester {...props} />);
+        expect(start).not.toHaveBeenCalled();
+
+        // The retry succeeds this time.
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({
+                start,
+                refreshAppConfig,
+                appConfigLoading: false,
+                backendStatus: "reachable",
+            })
+        );
+        rerender(<EmbeddedVoiceTester {...props} />);
+
+        expect(refreshAppConfig).toHaveBeenCalledTimes(1);
+        expect(start).toHaveBeenCalledTimes(1);
+    });
+
+    it("never calls start a second time even when the effect re-runs on an unrelated dependency change", () => {
+        // The guard under test is autoStartedRef, not React's dependency-array
+        // bailout — using a *new* start identity on the extra render forces
+        // the effect to actually re-execute (the real hook recreates start on
+        // every render), so this only passes if the ref guard itself, not
+        // React skipping an unchanged effect, is what prevents a second call.
+        const firstStart = vi.fn();
+        const secondStart = vi.fn();
+        const refreshAppConfig = vi.fn();
+
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({
+                start: firstStart,
+                refreshAppConfig,
+                appConfigLoading: false,
+                backendStatus: "reachable",
+            })
+        );
+        const { rerender } = render(<EmbeddedVoiceTester {...props} />);
+        expect(firstStart).toHaveBeenCalledTimes(1);
+
+        useWebSocketRTCMock.mockReturnValue(
+            baseHookReturn({
+                start: secondStart,
+                refreshAppConfig,
+                appConfigLoading: false,
+                backendStatus: "reachable",
+            })
+        );
+        rerender(<EmbeddedVoiceTester {...props} />);
+
+        expect(firstStart).toHaveBeenCalledTimes(1);
+        expect(secondStart).not.toHaveBeenCalled();
     });
 });

--- a/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.tsx
@@ -46,6 +46,7 @@ export function EmbeddedVoiceTester({
         stop,
         isStarting,
         feedbackMessages,
+        appConfigLoading,
     } = useWebSocketRTC({
         workflowId,
         workflowRunId,
@@ -56,12 +57,18 @@ export function EmbeddedVoiceTester({
     const autoStartedRef = useRef(false);
 
     useEffect(() => {
-        if (autoStartedRef.current) {
+        // Wait for appConfig (FORCE_TURN_RELAY) to finish loading before
+        // auto-starting. createPeerConnection reads it synchronously, and
+        // this effect only ever fires start() once (autoStartedRef) — a
+        // connection created while appConfig is still null permanently
+        // misses the relay-only restriction for the whole call, since
+        // resolving appConfig afterward doesn't recreate it.
+        if (autoStartedRef.current || appConfigLoading) {
             return;
         }
         autoStartedRef.current = true;
         void start();
-    }, [start]);
+    }, [start, appConfigLoading]);
 
     const endButtonLabel = connectionActive
         ? "End Call"

--- a/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.tsx
@@ -90,13 +90,30 @@ export function EmbeddedVoiceTester({
         void start();
     }, [start, appConfig?.backendStatus, appConfigLoading, refreshAppConfig]);
 
+    // True once the one bounded retry above has run and the backend is
+    // still unreachable — the auto-start effect deliberately gives up at
+    // that point rather than starting with an unconfirmed forceTurnRelay
+    // value, which would otherwise leave the tester stuck with no way to
+    // ever start. Surface a manual retry instead.
+    const configUnreachable =
+        !appConfigLoading &&
+        configRetriedRef.current &&
+        appConfig?.backendStatus !== "reachable";
+
     const endButtonLabel = connectionActive
         ? "End Call"
         : isCompleted
             ? "Start Another Test"
             : connectionStatus === "failed"
                 ? "Retry Call"
-                : "Starting Test...";
+                : configUnreachable
+                    ? "Retry Connection"
+                    : "Starting Test...";
+
+    const handleConfigRetry = () => {
+        configRetriedRef.current = false;
+        void refreshAppConfig();
+    };
 
     const handleFooterAction = async () => {
         if (connectionActive) {
@@ -109,6 +126,10 @@ export function EmbeddedVoiceTester({
         }
         if (connectionStatus === "failed") {
             await start();
+            return;
+        }
+        if (configUnreachable) {
+            handleConfigRetry();
         }
     };
 
@@ -132,11 +153,16 @@ export function EmbeddedVoiceTester({
                         ) : null}
                         <Button
                             onClick={handleFooterAction}
-                            disabled={isStarting && connectionStatus !== "failed"}
+                            disabled={isStarting && connectionStatus !== "failed" && !configUnreachable}
                             variant={connectionActive ? "destructive" : "default"}
                             className="w-full"
                         >
-                            {isStarting && connectionStatus !== "failed" ? (
+                            {configUnreachable ? (
+                                <>
+                                    <RefreshCw className="h-4 w-4" />
+                                    {endButtonLabel}
+                                </>
+                            ) : isStarting && connectionStatus !== "failed" ? (
                                 <>
                                     <Loader2 className="h-4 w-4 animate-spin" />
                                     Starting Test...
@@ -163,6 +189,11 @@ export function EmbeddedVoiceTester({
                                 </>
                             )}
                         </Button>
+                        {configUnreachable ? (
+                            <p className="text-center text-sm text-muted-foreground">
+                                Couldn&apos;t reach the backend to confirm call settings. Tap retry once it&apos;s back.
+                            </p>
+                        ) : null}
                     </div>
                 </div>
 

--- a/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.tsx
@@ -111,7 +111,14 @@ export function EmbeddedVoiceTester({
                     : "Starting Test...";
 
     const handleConfigRetry = () => {
-        configRetriedRef.current = false;
+        // Deliberately NOT resetting configRetriedRef here. It's already
+        // true (that's the only way to reach configUnreachable), and the
+        // auto-start effect's own retry gate reads it — resetting it would
+        // make that effect think no retry has happened yet, so if this
+        // manual refresh also comes back unreachable, the effect would fire
+        // its own extra automatic refresh on top of this one (one click
+        // producing two fetches instead of one). Leaving it true keeps that
+        // budget spent; only this explicit call fetches.
         void refreshAppConfig();
     };
 

--- a/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/workflow-tester/EmbeddedVoiceTester.tsx
@@ -46,7 +46,9 @@ export function EmbeddedVoiceTester({
         stop,
         isStarting,
         feedbackMessages,
+        appConfig,
         appConfigLoading,
+        refreshAppConfig,
     } = useWebSocketRTC({
         workflowId,
         workflowRunId,
@@ -55,20 +57,38 @@ export function EmbeddedVoiceTester({
         onNodeTransition,
     });
     const autoStartedRef = useRef(false);
+    const configRetriedRef = useRef(false);
 
     useEffect(() => {
         // Wait for appConfig (FORCE_TURN_RELAY) to finish loading before
-        // auto-starting. createPeerConnection reads it synchronously, and
-        // this effect only ever fires start() once (autoStartedRef) — a
-        // connection created while appConfig is still null permanently
-        // misses the relay-only restriction for the whole call, since
-        // resolving appConfig afterward doesn't recreate it.
+        // auto-starting — this effect only ever fires start() once
+        // (autoStartedRef), and createPeerConnection reads
+        // appConfig?.forceTurnRelay synchronously, so a connection created
+        // before that resolves permanently misses the relay-only
+        // restriction for the whole call.
         if (autoStartedRef.current || appConfigLoading) {
             return;
         }
+
+        // Loading having finished isn't enough by itself: /api/config/version
+        // always resolves with HTTP 200 even when the backend healthcheck it
+        // performs server-side failed or timed out, silently defaulting
+        // forceTurnRelay to false in that response instead of reflecting the
+        // deployment's real setting. Only a 'reachable' backendStatus
+        // confirms forceTurnRelay actually came from the backend. Give it one
+        // retry rather than either starting with an unconfirmed (possibly
+        // wrong) value or waiting forever if the backend stays down.
+        if (appConfig?.backendStatus !== "reachable") {
+            if (!configRetriedRef.current) {
+                configRetriedRef.current = true;
+                void refreshAppConfig();
+            }
+            return;
+        }
+
         autoStartedRef.current = true;
         void start();
-    }, [start, appConfigLoading]);
+    }, [start, appConfig?.backendStatus, appConfigLoading, refreshAppConfig]);
 
     const endButtonLabel = connectionActive
         ? "End Call"

--- a/ui/src/app/workflow/[workflowId]/run/[runId]/hooks/useWebSocketRTC.tsx
+++ b/ui/src/app/workflow/[workflowId]/run/[runId]/hooks/useWebSocketRTC.tsx
@@ -202,7 +202,15 @@ export const useWebSocketRTC = ({ workflowId, workflowRunId, accessToken, initia
         // Build ICE servers list
         const iceServers: RTCIceServer[] = [];
 
-        if (useStun) {
+        // Skip the public STUN server entirely when relay-only mode is
+        // requested (FORCE_TURN_RELAY=true). A plain `stun:` entry can only
+        // ever produce a server-reflexive candidate, never a relay one, so it
+        // can't help here — and RTCPeerConnection's `iceTransportPolicy:
+        // 'relay'` handling of srflx candidates gathered via a STUN-only
+        // entry has been observed to still leak the public IP as a usable
+        // candidate pair instead of being excluded, defeating the point of
+        // forcing relay in the first place.
+        if (useStun && !appConfig?.forceTurnRelay) {
             iceServers.push({ urls: ['stun:stun.l.google.com:19302'] });
         }
 

--- a/ui/src/app/workflow/[workflowId]/run/[runId]/hooks/useWebSocketRTC.tsx
+++ b/ui/src/app/workflow/[workflowId]/run/[runId]/hooks/useWebSocketRTC.tsx
@@ -51,7 +51,7 @@ export const useWebSocketRTC = ({ workflowId, workflowRunId, accessToken, initia
     const [isStarting, setIsStarting] = useState(false);
     const [feedbackMessages, setFeedbackMessages] = useState<FeedbackMessage[]>([]);
     const initialContext = initialContextVariables || {};
-    const { config: appConfig, loading: appConfigLoading } = useAppConfig();
+    const { config: appConfig, loading: appConfigLoading, refresh: refreshAppConfig } = useAppConfig();
 
     const {
         audioInputs,
@@ -836,13 +836,26 @@ export const useWebSocketRTC = ({ workflowId, workflowRunId, accessToken, initia
         audioInputs,
         selectedAudioInput,
         setSelectedAudioInput,
-        // Whether FORCE_TURN_RELAY/appConfig is still loading. createPeerConnection
-        // reads appConfig?.forceTurnRelay synchronously, and it's null until the
-        // async /api/config/version fetch resolves — starting a call before then
-        // silently creates a connection without the relay-only restriction, with
-        // no way to recreate it afterward. Callers that auto-start (no explicit
-        // user click to wait on) must gate on this being false first.
+        // createPeerConnection reads appConfig?.forceTurnRelay synchronously to
+        // decide whether to add the public STUN server / set iceTransportPolicy:
+        // 'relay'. Callers that auto-start (no explicit user click to wait on)
+        // need both of these to know it's safe to trust that value:
+        //   - appConfigLoading: false once the async /api/config/version fetch
+        //     has settled at all (it's still loading, and appConfig still null,
+        //     before that).
+        //   - appConfig.backendStatus === 'reachable': loading finishing is NOT
+        //     enough by itself — /api/config/version always resolves with HTTP
+        //     200 even when the actual backend healthcheck it performs
+        //     server-side failed or timed out, silently defaulting
+        //     forceTurnRelay to false in that response rather than reflecting
+        //     the deployment's real setting. Only a 'reachable' backendStatus
+        //     confirms forceTurnRelay came from the backend itself.
+        // Starting while either signal says "not confirmed yet" risks silently
+        // creating a connection without the relay-only restriction, with no way
+        // to recreate it afterward once appConfig does resolve/correct itself.
+        appConfig,
         appConfigLoading,
+        refreshAppConfig,
         connectionActive,
         permissionError,
         isCompleted,

--- a/ui/src/app/workflow/[workflowId]/run/[runId]/hooks/useWebSocketRTC.tsx
+++ b/ui/src/app/workflow/[workflowId]/run/[runId]/hooks/useWebSocketRTC.tsx
@@ -51,7 +51,7 @@ export const useWebSocketRTC = ({ workflowId, workflowRunId, accessToken, initia
     const [isStarting, setIsStarting] = useState(false);
     const [feedbackMessages, setFeedbackMessages] = useState<FeedbackMessage[]>([]);
     const initialContext = initialContextVariables || {};
-    const { config: appConfig } = useAppConfig();
+    const { config: appConfig, loading: appConfigLoading } = useAppConfig();
 
     const {
         audioInputs,
@@ -836,6 +836,13 @@ export const useWebSocketRTC = ({ workflowId, workflowRunId, accessToken, initia
         audioInputs,
         selectedAudioInput,
         setSelectedAudioInput,
+        // Whether FORCE_TURN_RELAY/appConfig is still loading. createPeerConnection
+        // reads appConfig?.forceTurnRelay synchronously, and it's null until the
+        // async /api/config/version fetch resolves — starting a call before then
+        // silently creates a connection without the relay-only restriction, with
+        // no way to recreate it afterward. Callers that auto-start (no explicit
+        // user click to wait on) must gate on this being false first.
+        appConfigLoading,
         connectionActive,
         permissionError,
         isCompleted,

--- a/ui/src/app/workflow/[workflowId]/run/[runId]/hooks/useWebSocketRTC.tsx
+++ b/ui/src/app/workflow/[workflowId]/run/[runId]/hooks/useWebSocketRTC.tsx
@@ -202,14 +202,8 @@ export const useWebSocketRTC = ({ workflowId, workflowRunId, accessToken, initia
         // Build ICE servers list
         const iceServers: RTCIceServer[] = [];
 
-        // Skip the public STUN server entirely when relay-only mode is
-        // requested (FORCE_TURN_RELAY=true). A plain `stun:` entry can only
-        // ever produce a server-reflexive candidate, never a relay one, so it
-        // can't help here — and RTCPeerConnection's `iceTransportPolicy:
-        // 'relay'` handling of srflx candidates gathered via a STUN-only
-        // entry has been observed to still leak the public IP as a usable
-        // candidate pair instead of being excluded, defeating the point of
-        // forcing relay in the first place.
+        // A `stun:` entry can only yield srflx, never relay — and srflx has been
+        // seen leaking through iceTransportPolicy: 'relay', so skip it entirely.
         if (useStun && !appConfig?.forceTurnRelay) {
             iceServers.push({ urls: ['stun:stun.l.google.com:19302'] });
         }
@@ -836,23 +830,9 @@ export const useWebSocketRTC = ({ workflowId, workflowRunId, accessToken, initia
         audioInputs,
         selectedAudioInput,
         setSelectedAudioInput,
-        // createPeerConnection reads appConfig?.forceTurnRelay synchronously to
-        // decide whether to add the public STUN server / set iceTransportPolicy:
-        // 'relay'. Callers that auto-start (no explicit user click to wait on)
-        // need both of these to know it's safe to trust that value:
-        //   - appConfigLoading: false once the async /api/config/version fetch
-        //     has settled at all (it's still loading, and appConfig still null,
-        //     before that).
-        //   - appConfig.backendStatus === 'reachable': loading finishing is NOT
-        //     enough by itself — /api/config/version always resolves with HTTP
-        //     200 even when the actual backend healthcheck it performs
-        //     server-side failed or timed out, silently defaulting
-        //     forceTurnRelay to false in that response rather than reflecting
-        //     the deployment's real setting. Only a 'reachable' backendStatus
-        //     confirms forceTurnRelay came from the backend itself.
-        // Starting while either signal says "not confirmed yet" risks silently
-        // creating a connection without the relay-only restriction, with no way
-        // to recreate it afterward once appConfig does resolve/correct itself.
+        // Auto-starting callers must wait on both: /api/config/version resolves
+        // 200 even when its backend healthcheck failed, defaulting forceTurnRelay
+        // to false, so only a 'reachable' backendStatus confirms the real value.
         appConfig,
         appConfigLoading,
         refreshAppConfig,


### PR DESCRIPTION
Fixes FORCE_TURN_RELAY=true on CGNAT deployments (e.g. Tailscale, no public IP) — calls failed because the server kept checking connectivity against the browser's raw public IP instead of relaying through coturn.

Four compounding bugs:
1. SERVER_IP was never passed into the api container's environment (only dograh-init got it) — resolve_ice_filter_policies() always saw an empty string.
2. Even with SERVER_IP wired through, force_turn_relay=True + CGNAT resolved inbound filtering to NONE (no filtering), letting a public candidate through unfiltered. Added NonRelayFilterPolicy.PUBLIC, scoped specifically to CGNAT (is_cgnat_ip()) — plain RFC1918 LANs keep the original NONE behavior unchanged.
3. Client always added the public Google STUN server to iceServers, independent of FORCE_TURN_RELAY — its server-reflexive candidate leaked through despite iceTransportPolicy: 'relay'. Now skipped when relay-only is requested.
4. EmbeddedVoiceTester auto-starts on mount with no gate on appConfig (carries forceTurnRelay) having loaded — a call started during that race permanently misses the relay-only restriction. Now gated on appConfigLoading.

Verified on a real remote deployment: before the fix, every ICE candidate pair checked against the browser's public IP and failed; after, pairs use the coturn relay/LAN/tailnet addresses, ICE completes, and audio flows both directions. Added api/tests/test_webrtc_signaling_ice_filter_policies.py (confirmed it doesn't regress the pre-existing test_is_private_ip_candidate.py suite) and EmbeddedVoiceTester.test.tsx for the auto-start gate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes relay-only ICE with `FORCE_TURN_RELAY` on CGNAT/private-range hosts and removes all non-relay/public candidate leaks across API, web app, and embed. Calls now consistently use TURN, and the embedded tester waits for confirmed config/backend reachability with a clean manual retry.

- **Bug Fixes**
  - Wire `SERVER_IP` to the API via docker-compose and read it from `api/constants.py` so CGNAT/private-LAN detection works.
  - Add `NonRelayFilterPolicy.PUBLIC` for relay-only + CGNAT servers to drop non-relay public inbound candidates; keep prior behavior on plain RFC1918 LANs.
  - Honor relay-only end-to-end: omit public STUN in the web app, embed widget, and server `get_ice_servers()` when `FORCE_TURN_RELAY` is true; log an error and return no ICE servers if TURN is missing.
  - Gate `EmbeddedVoiceTester` auto-start on both `appConfigLoading === false` and `backendStatus === 'reachable'`; retry config once; add a “Retry Connection” that refreshes config and starts only when reachable; fix prior double-fetch on manual retry.

<sup>Written for commit 016535db4a5a7efc2a6b1fae9ee44952906dfe57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change aligns relay-only WebRTC behavior across the API, main tester, and embedded widget. Executed checks confirmed that relay-only connections omit public STUN, use TURN-only peer connection configuration, retain the intended public/CGNAT/private-LAN/local ICE filtering behavior, and wait for confirmed backend settings before starting the embedded tester. The embedded tester performs one automatic refresh, offers a manual retry while the backend is unavailable, and starts once configuration becomes reachable.

<h3>Confidence Score: 5/5</h3>

The PR is safe to merge; no blocking failure remains.

The embedded widget was exercised with relay-only configuration and created a TURN-only peer connection without public STUN. The embedded tester retry lifecycle and the backend ICE policy matrix were also executed successfully.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the embedded widget lifecycle tests with a jsdom harness configured for relay-only operation, which created a single peer connection with iceTransportPolicy=relay using a TURN URL and no public STUN URL.
- Executed the backend ICE-policy helpers across parent and PR revisions for multiple configurations and confirmed the parent provided stun and TURN while the PR revision reported only TURN and passed the relay-only-stun-omission check.
- Validated the EmbeddedVoiceTester React lifecycle test and related harness, noting that the test suite passed and that a wrapper error occurred after Vitest completed while reporting 1 passed.
- Compared baseline and PR ICE-policy captures to verify that the baseline included both stun and turn while the PR revision omitted stun and preserved all policy outcomes.

<a href="https://app.greptile.com/trex/runs/17745443/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (7): Last reviewed commit: ["fix: honour relay-only in server ICE con..."](https://github.com/dograh-hq/dograh/commit/016535db4a5a7efc2a6b1fae9ee44952906dfe57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50172116)</sub>

<!-- /greptile_comment -->