### PR TITLE
fix:ARI provider: campaigns can't dial through a standard Asterisk/Fr…

### DIFF
--- a/api/services/telephony/providers/ari/__init__.py
+++ b/api/services/telephony/providers/ari/__init__.py
@@ -23,6 +23,7 @@ def _config_loader(value: Dict[str, Any]) -> Dict[str, Any]:
         "app_name": value.get("app_name"),
         "app_password": value.get("app_password"),
         "external_pbx": value.get("external_pbx"),
+        "dial_string_template": value.get("dial_string_template"),
         "from_numbers": value.get("from_numbers", []),
     }
 
@@ -54,6 +55,13 @@ _UI_METADATA = ProviderUIMetadata(
             label="websocket_client.conf Name",
             type="text",
             description="websocket_client.conf connection name for externalMedia",
+        ),
+        ProviderUIField(
+            name="dial_string_template",
+            label="Dial String Template",
+            type="text",
+            required=False,
+            description="Asterisk dial string template for plain numbers (e.g. Local/{number}@from-internal)",
         ),
         ProviderUIField(
             name="from_numbers",

--- a/api/services/telephony/providers/ari/config.py
+++ b/api/services/telephony/providers/ari/config.py
@@ -85,6 +85,10 @@ class ARIConfigurationRequest(BaseModel):
         default=None,
         description="Optional external PBX connected through this Asterisk instance",
     )
+    dial_string_template: Optional[str] = Field(
+        default=None,
+        description="Optional Asterisk dial string template (e.g. 'Local/{number}@from-internal') used when number has no tech prefix.",
+    )
     from_numbers: List[str] = Field(
         default_factory=list,
         description="List of SIP extensions/numbers for outbound calls (optional)",
@@ -100,4 +104,5 @@ class ARIConfigurationResponse(BaseModel):
     app_password: str  # Masked
     ws_client_name: str = ""
     external_pbx: Optional[VicidialExternalPBXConfiguration] = None
+    dial_string_template: Optional[str] = None
     from_numbers: List[str]

--- a/api/services/telephony/providers/ari/provider.py
+++ b/api/services/telephony/providers/ari/provider.py
@@ -54,6 +54,7 @@ class ARIProvider(TelephonyProvider):
         self.app_password = config.get("app_password", "")
         self.from_numbers = config.get("from_numbers", [])
         self.default_from_number = config.get("default_from_number")
+        self.dial_string_template = config.get("dial_string_template")
         self.external_pbx_adapter = create_adapter(config.get("external_pbx"))
 
         if isinstance(self.from_numbers, str):
@@ -89,6 +90,8 @@ class ARIProvider(TelephonyProvider):
         # to_number can be a SIP URI or extension
         if to_number.startswith("SIP/") or to_number.startswith("PJSIP/"):
             sip_endpoint = to_number
+        elif self.dial_string_template:
+            sip_endpoint = self.dial_string_template.format(number=to_number)
         else:
             # Default to PJSIP technology
             sip_endpoint = f"PJSIP/{to_number}"
@@ -468,6 +471,8 @@ class ARIProvider(TelephonyProvider):
         # Build SIP endpoint
         if destination.startswith("SIP/") or destination.startswith("PJSIP/"):
             sip_endpoint = destination
+        elif self.dial_string_template:
+            sip_endpoint = self.dial_string_template.format(number=destination)
         else:
             sip_endpoint = f"PJSIP/{destination}"
 


### PR DESCRIPTION
## What does this PR do?
This PR adds a new `dial_string_template` optional field to the ARI provider configuration to fix outbound call allocation failures on standard Asterisk/FreePBX deployments.

## Why is this needed?
Currently, when a campaign dials a plain E.164 number (without a `SIP/` or `PJSIP/` tech prefix), `ARIProvider.initiate_call()` automatically formats the dial string as `PJSIP/{number}`. Asterisk interprets this as a PJSIP endpoint name (which does not exist), causing channel creation to fail with `{"error":"Allocation failed"}`.

By introducing `dial_string_template`, users can specify templates like `Local/{number}@from-internal` or `PJSIP/{number}@my-trunk`. This allows plain numbers to be routed into the dialplan so FreePBX outbound routes can handle the number translation and trunk selection naturally, making campaigns usable again. 

## Changes Made
- Added `dial_string_template` to `ARIConfigurationRequest` and `ARIConfigurationResponse` schemas.
- Exposed the field dynamically in the frontend UI via `_UI_METADATA`.
- Updated `initiate_call` and `transfer_call` in the ARI provider to format plain numbers using the configured template (falling back to `PJSIP/` if none is provided).

## Testing
- Verified syntax and updated models locally.
- Confirmed backward compatibility: if the field is left blank, the legacy `PJSIP/` fallback is preserved.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional `dial_string_template` to the ARI provider so campaigns can dial plain E.164 numbers through standard Asterisk/FreePBX routes. Fixes channel allocation failures when numbers lack a SIP/PJSIP tech prefix.

- **Bug Fixes**
  - Added optional `dial_string_template` to ARI config and UI.
  - Used template in `initiate_call` and `transfer_call` when the number has no tech prefix (e.g., `Local/{number}@from-internal`).
  - Kept fallback to `PJSIP/{number}` for backward compatibility.

<sup>Written for commit 3d06612af8a67edf9f4b218261b8c45b9d0b86f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds an optional ARI dial-string template for plain-number outbound calls and transfers while preserving direct technology-prefixed destinations and the PJSIP fallback.

Focused execution confirmed that malformed templates and unsupported placeholders can be saved, then cause both call initiation and transfer to fail before an ARI request is sent.

<h3>Confidence Score: 4/5</h3>





<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and referenced the corresponding review comment for details.
- T-Rex produced a second proof for a posted P1 finding and cited the related review comment.
- T-Rex ran the requested contract verification, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **ARI dial string template is saved without validating its Python format fields**

   - **Bug**
     - `ARIConfigurationRequest` accepts and persists malformed `Local/{number` and unsupported `Local/{destination}@ctx`. `ARIProvider.initiate_call` and `transfer_call` then call `.format(number=...)`, raising `ValueError` for the malformed template and `KeyError` for the unsupported placeholder before entering the ARI HTTP request block.
   - **Cause**
     - The newly added `dial_string_template` field is typed only as `Optional[str]`; it has no validator that parses the format string or restricts placeholders to `{number}`.
   - **Fix**
     - Add a Pydantic field validator that rejects invalid format syntax and any replacement field other than `number` (including attribute/index expressions as appropriate), returning a clear validation error before configuration is saved.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix:ARI provider: campaigns can&#39;t dial t..."](https://github.com/dograh-hq/dograh/commit/3d06612af8a67edf9f4b218261b8c45b9d0b86f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50362624)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->