### PR TITLE
chore: bump pipecat submodule to 1.7.0

### DIFF
--- a/.agents/skills/merge-pipecat-upstream/SKILL.md
+++ b/.agents/skills/merge-pipecat-upstream/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: merge-pipecat-upstream
+description: Merge the latest upstream pipecat-ai/pipecat tag into the pipecat submodule fork (dograh-hq/pipecat) and bump the dograh repo to it. Use whenever the user asks to bump, upgrade, sync, or merge pipecat, resolve pipecat merge conflicts, audit whether upstream changes break or supersede Dograh's in-fork patches, or verify the api/ wrapper subclasses still match the upstream classes they wrap.
+---
+
+# Merging upstream pipecat
+
+`pipecat/` is a git submodule of the fork `dograh-hq/pipecat` (`origin`), installed editable by `scripts/setup_requirements.sh`. Upstream is `https://github.com/pipecat-ai/pipecat` and is usually not configured as a remote. Fork `main` is the integration branch; the dograh repo pins a commit of it via the submodule pointer.
+
+Dograh customization lives in two layers, and both must be audited on every merge:
+
+1. **In-fork changes** — dograh-owned modules that don't exist upstream (`src/pipecat/services/dograh/`, serializers like `vobiz.py`/`cloudonix.py`/`asterisk.py`, `call_strategies.py`, `tests/test_dograh_services.py`) plus **patches to upstream files** (aggregators, transports, turn tracking, serializers).
+2. **api/-side wrappers** — subclasses in the dograh repo (`api/services/pipecat/`, `api/services/telephony/providers/*/`, `api/services/workflow/pipecat_engine*.py`) that override upstream hooks and reach into private state (`self._session`, `self._bot_is_responding`, …). These break **silently** on upstream refactors — no merge conflict, no import error.
+
+Freshness rule: trust the current repos over any inventory in this file. Discover state with the commands below; don't assume file lists here are complete.
+
+## 1. Baseline and setup
+
+```bash
+cd pipecat
+git log --first-parent --oneline --merges | grep -m1 "Merge tag"   # OLD_TAG = last merged upstream tag
+git remote add upstream https://github.com/pipecat-ai/pipecat.git 2>/dev/null
+git fetch upstream --tags
+git tag --sort=-v:refname | head -5                                # pick NEW_TAG (latest stable)
+git checkout -b merge-vNEW origin/main
+```
+
+In the dograh repo, work on a `bump-pipecat-X.Y` branch.
+
+## 2. Recon before merging
+
+Do this **before** `git merge` — conflict resolution decisions must be made from evidence, not on the fly.
+
+```bash
+git diff NEW_TAG...origin/main --stat -- src tests    # full surviving dograh delta (three-dot = from merge-base)
+git log --first-parent --oneline OLD_MERGE_COMMIT..origin/main   # dograh commits since last merge
+```
+
+Classify each dograh-touched file:
+
+- **Dograh-owned** (`git cat-file -e NEW_TAG:<path>` fails → file doesn't exist upstream): merges clean, but must be adapted to new upstream contracts afterwards.
+- **Patched upstream file**: the risk zone. For each, get upstream's changes in the range and decide a verdict *per patch*:
+  ```bash
+  git log --oneline OLD_TAG..NEW_TAG -- <path>
+  git diff OLD_TAG NEW_TAG -- <path>
+  ```
+  - **keep ours** — upstream didn't touch the patched logic
+  - **take theirs** — upstream fixed the same problem; carrying the dograh patch would be redundant or fight upstream's fix
+  - **rework** — both changed; port the dograh intent onto the new upstream code
+
+Read `CHANGELOG.md` for the OLD_TAG..NEW_TAG range — it names breaking changes and deprecations that the diff alone obscures.
+
+## 3. Merge
+
+```bash
+git merge NEW_TAG
+```
+
+Resolve conflicts using the recon verdicts. Then adapt dograh-owned modules to changed upstream contracts (base-class signatures, renamed frames/params) — precedent: the v1.5.0 merge needed a follow-up "Fix Dograh services for Pipecat 1.5 contracts" touching `src/pipecat/services/dograh/` and `tests/test_dograh_services.py`.
+
+## 4. Audit the Dograh MPS services (fork side)
+
+The services in `src/pipecat/services/dograh/` are thin clients for model services (`~/Projects/dograh/model_services`). The wire protocol is fixed by the separately-deployed server; the pipecat-facing half must track upstream base contracts. For each service, diff its base classes OLD_TAG..NEW_TAG and verify every wire message still fires at the same conversational boundary — STT finalization on end of user speech, TTS context open/close/cancel across turn end and interruption, LLM billing metadata on every request. These couplings live in lifecycle hooks and private base state, so they drift silently rather than error. Answer server-behavior questions from model_services source; never change wire verbs without a coordinated model_services change.
+
+## 5. Audit the api/ wrappers
+
+Inventory the wrapper surface (in the dograh repo):
+
+```bash
+rg -n "class Dograh\w+\(" api --type py                       # named wrappers
+rg -l "^from pipecat" api/services api/utils --type py        # full consumer surface
+```
+
+For each subclass of a pipecat class (realtime services, `service_factory.py` LLM subclasses, `minimax_tts.py`, FrameProcessors, observers, telephony transports/serializers/strategies):
+
+1. Diff the wrapped upstream class: `git -C pipecat diff OLD_TAG NEW_TAG -- <upstream file>`. Unchanged file → wrapper is fine, move on.
+2. If changed, verify every **overridden method** still exists upstream with the same call semantics (when it's called, what `super()` now does, sync vs async).
+3. Verify every **base-class private attr** the wrapper reads or writes still exists with the same meaning:
+   ```bash
+   rg -o "self\._\w+" <wrapper.py> | sort -u   # then check names not defined in the wrapper against NEW_TAG's class
+   ```
+4. Check **redundancy/conflict**: upstream absorbs Dograh behavior over time (mute gating, deferred function calls, reconnect handling). If the new upstream class now does what the override does, the wrapper duplicates it (double-firing) or fights it (two competing code paths) — trim the override instead of stacking behavior.
+
+Also check non-subclass consumers: `pipecat_engine*.py` and frame/type imports across `api/` — removed or renamed symbols surface only at import time.
+
+## 6. Validate
+
+```bash
+./scripts/setup_requirements.sh        # reinstall; first check its hardcoded extras list still matches upstream pyproject extras
+source venv/bin/activate && python -c "import api.app"   # import smoke test
+cd pipecat && python -m pytest tests/test_dograh_services.py
+```
+
+Run api tests with `set -a && source api/.env.test && set +a`: first the tests matching audited wrappers (e.g. `api/tests/test_azure_realtime_wrapper.py`) and `api/tests/telephony/` serializer tests for fast iteration, then the full `api/tests/` suite as the final check.
+
+Never rebase fork `main` — old dograh-repo commits reference its commits via submodule pointers; history must stay append-only.

--- a/.agents/skills/review-agents-md/references/dograh-seams.md
+++ b/.agents/skills/review-agents-md/references/dograh-seams.md
@@ -18,12 +18,18 @@ The repo root still revolves around these contributor-relevant directories:
 - `ui/`
 - `scripts/`
 - `docs/`
-- `pipecat/`
+- `pipecat/`, which is the upstream Pipecat git submodule; Dograh-owned
+  adapters around it live under `api/services/pipecat/`
 
-Current code-heavy top-level subtrees that can matter during hierarchy reviews:
+Other top-level subtrees that can matter during hierarchy reviews:
 
-- `evals/` for evaluation tooling, including `evals/visualizer/`
-- `sdk/` for packaged SDK work, especially `sdk/python/` and `sdk/typescript/`
+- `evals/` for STT evaluation tooling and the separate app under
+  `evals/visualizer/`
+- `sdk/` for packaged SDK work, especially `sdk/python/`, `sdk/typescript/`,
+  and the shared generators under `sdk/codegen/`
+- `examples/` for Python and TypeScript SDK examples
+- `deploy/` for Helm, managed-Traefik, and shared deployment templates;
+  root Compose files, `config/`, and `nginx/` hold related deployment inputs
 
 Root `AGENTS.md` should stay at this level.
 
@@ -31,16 +37,41 @@ Root `AGENTS.md` should stay at this level.
 
 ### Route aggregation
 
+- top-level FastAPI wiring lives in `api/app.py`: it mounts the REST router
+  under `/api/v1` and the Dograh MCP server under `/api/v1/mcp`
 - REST routers are aggregated in `api/routes/main.py`.
 - Telephony has its main cross-provider route file at `api/routes/telephony.py`.
 - Integration package routers are mounted through `api.services.integrations.all_routers()`.
 - Node-type metadata is exposed from `api/routes/node_types.py`.
 
+### Route, service, and database boundary
+
+The live backend does not enforce a mandatory route -> service -> database
+call chain.
+
+- `api/db/db_client.py` composes the specialized clients under `api/db/`; all
+  runtime persistence-query construction, ORM eager-loading choices, direct
+  session use, and transaction details must live in this package
+- authenticated handlers commonly call `api.db.db_client` directly for simple,
+  organization-scoped reads and CRUD; examples span workflows, folders, tools,
+  credentials, campaigns, and telephony configuration
+- reusable multi-step orchestration and cross-domain policy belong in
+  `api/services/` (and background orchestration in `api/tasks/`); a route may
+  combine those helpers with direct scoped client calls
+- tenant isolation is an additional non-negotiable boundary: derive the
+  organization from an authenticated or otherwise verified context and pass it
+  into a scoped client method, or establish ownership with a scoped parent
+  lookup before using a child identifier
+- direct SQLAlchemy query construction or session use in another runtime
+  application package is a boundary violation, not an accepted exception
+
+
 ### Workflow execution
 
 Workflow execution is not a single folder.
 
-- workflow graph, DTOs, node data, node-spec generation, QA, and tool helpers live under `api/services/workflow/`
+- workflow graph, DTOs, node data, node-spec generation, text-chat execution,
+  QA, and tool helpers live under `api/services/workflow/`
 - live pipeline execution lives under `api/services/pipecat/`
 - Dograh-specific realtime provider adapters live under `api/services/pipecat/realtime/`
 - post-call QA, registered integrations, and webhook execution live in `api/tasks/run_integrations.py`
@@ -51,7 +82,30 @@ If `api/AGENTS.md` implies workflow execution lives in only one place, treat tha
 
 - core node specs are registered lazily from `api/services/workflow/dto.py` by `api/services/workflow/node_specs/__init__.py`
 - integration node specs are merged through `api.services.integrations.all_node_specs()`
-- the frontend and SDK-facing node catalog is served from `api/routes/node_types.py`
+- the node catalog is exposed to REST clients from `api/routes/node_types.py`
+  and to MCP clients from `api/mcp_server/tools/node_types.py`
+- `scripts/generate_sdk.sh` reads the in-process node-spec registry for typed
+  Python/TypeScript node APIs and a filtered OpenAPI surface for generated SDK
+  models and client methods
+- committed language-SDK output lives under `sdk/python/src/dograh_sdk/` and
+  `sdk/typescript/src/`; the UI client under `ui/src/client/` is generated
+  separately with the `ui` package's `generate-client` script
+
+### Dograh MCP server
+
+Do not confuse the Dograh-hosted MCP API with customer-configured MCP tools used
+inside a workflow.
+
+- `api/app.py` mounts the stateless FastMCP application created in
+  `api/mcp_server/server.py`
+- MCP authentication and tool implementations live under `api/mcp_server/`,
+  with tool registration centralized in `api/mcp_server/server.py`
+- workflow authoring tools use `api/mcp_server/ts_bridge.py` and the AST-only
+  TypeScript bridge under `api/mcp_server/ts_validator/`, then validate through
+  the normal workflow DTO and graph layers
+- customer-configured MCP tool sessions instead live in
+  `api/services/workflow/mcp_tool_session.py` and
+  `api/services/workflow/tools/mcp_tool.py`
 
 ### Telephony
 
@@ -62,8 +116,14 @@ Current telephony architecture is registry-driven.
 - provider lookup, org-scoped config normalization, inbound matching, and run-scoped resolution live in `api/services/telephony/factory.py`
 - per-provider HTTP routers live in `api/services/telephony/providers/<name>/routes.py` and are auto-mounted by `api/routes/telephony.py`
 - provider-local implementations live in `api/services/telephony/providers/<name>/`
+- organization-scoped telephony configuration CRUD, provider form metadata,
+  and phone-number management live in `api/routes/organization.py`, backed by
+  `api/db/telephony_configuration_client.py` and
+  `api/schemas/telephony_config.py` rather than provider route modules
 - current provider packages include `ari`, `cloudonix`, `plivo`, `telnyx`, `twilio`, `vobiz`, and `vonage`
 - not every provider has an HTTP route module; for example, `ari` is transport-focused and skipped by the auto-mounter
+- ARI-specific external-PBX adapters have their own registry under
+  `api/services/telephony/providers/ari/external_pbx/`
 
 ### Integrations
 
@@ -72,7 +132,8 @@ Current integrations are also registry-driven.
 - package discovery lives in `api/services/integrations/loader.py` via `pkgutil.iter_modules(...)`
 - package registration and runtime/completion orchestration live in `api/services/integrations/registry.py`
 - shared package/session context types live in `api/services/integrations/base.py`
-- a concrete package example exists at `api/services/integrations/tuner/`
+- concrete self-registering package examples live at
+  `api/services/integrations/paygent/` and `api/services/integrations/tuner/`
 
 ## Frontend anchors
 
@@ -96,7 +157,9 @@ Current integrations are also registry-driven.
 
 ### Client and auth
 
-- generated API client code lives under `ui/src/client/`, with generated subtrees in `ui/src/client/client/` and `ui/src/client/core/`
+- generated API client code lives under `ui/src/client/`: generated root files
+  sit alongside the `client/` and `core/` generated subtrees; configure it in
+  `ui/openapi-ts.config.ts` and regenerate it via the `ui` package script
 - auth exports live in `ui/src/lib/auth/index.ts`
 - auth provider wrappers live under `ui/src/lib/auth/providers/`
 - server-side auth helpers live in `ui/src/lib/auth/server.ts`
@@ -109,6 +172,10 @@ Current integrations are also registry-driven.
 - it described flat provider files like `twilio_provider.py` and `vonage_provider.py`
 - it told contributors to add schemas to `api/schemas/telephony_config.py`
 - it referenced legacy patterns such as direct `TwilioService` usage
+- it described the old organization-configuration storage shape and claimed
+  compatibility through `/api/v1/twilio/*` redirects and a retained
+  `TwilioService`; the live runtime uses dedicated telephony-configuration
+  tables and provider-package routes instead
 
 The live code instead uses provider packages under `providers/<name>/`, registry-driven provider resolution, and route auto-mounting from `api/routes/telephony.py`. Use this as a reminder that prose in adjacent docs may have drifted even when the code is coherent.
 
@@ -117,7 +184,9 @@ The live code instead uses provider packages under `providers/<name>/`, registry
 These are review prompts, not frozen conclusions.
 
 - pay extra attention to deep subtrees that define extension contracts, registration points, or multi-file execution paths
-- in Dograh, common examples include telephony, workflow execution, generated SDK surfaces, and other service subtrees that span many files
+- in Dograh, common examples include telephony, workflow execution, the Dograh
+  MCP server, generated SDK surfaces, deployment charts, and other service
+  subtrees that span many files
 
 Ask:
 

--- a/.agents/skills/review-agents-md/scripts/inventory_agents_md.py
+++ b/.agents/skills/review-agents-md/scripts/inventory_agents_md.py
@@ -123,6 +123,26 @@ def descendant_agents(root: Path, agents: list[Path]) -> list[Path]:
     ]
 
 
+def direct_child_agents(root: Path, agents: list[Path]) -> list[Path]:
+    """Return the nearest descendant AGENTS.md boundaries for ``root``.
+
+    A deeper AGENTS.md is owned by an intervening child scope, so listing it
+    again at the ancestor would make the printed ownership hierarchy look
+    flatter than it is.
+    """
+
+    descendants = descendant_agents(root, agents)
+    return [
+        agent
+        for agent in descendants
+        if not any(
+            possible_parent != agent
+            and possible_parent.parent in agent.parent.parents
+            for possible_parent in descendants
+        )
+    ]
+
+
 def immediate_child_dirs(root: Path) -> list[Path]:
     children = []
     for child in sorted(root.iterdir()):
@@ -171,7 +191,7 @@ def nested_hotspots(summary: DirSummary, agents: list[Path], threshold: int) -> 
 
 def print_scope(scope_dir: Path, agents: list[Path], cwd: Path, threshold: int) -> None:
     scope_agent = scope_dir / "AGENTS.md"
-    child_agents = descendant_agents(scope_dir, agents)
+    child_agents = direct_child_agents(scope_dir, agents)
 
     print(f"AGENTS: {format_path(scope_agent, cwd)}")
 

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -23,12 +23,8 @@ The main failure modes in this repo are:
    - GitHub PR: `gh pr diff <N>` or `gh pr view <N> --json files,additions,deletions`
    - Local branch: `git diff origin/main...HEAD`
 2. Bucket changed files into the sections below.
-3. Read the current repo as source of truth before finalizing findings:
-   - `api/AGENTS.md` for org scoping and worker-sync
-   - `ui/AGENTS.md` for generated client rules
-   - Touched models, DB clients, routes, services, and migrations
-4. Run only the sections relevant to the changed files.
-5. Report findings as `<file>:<line> -> <problem> -> <correct pattern>`.
+3. Run only the sections relevant to the changed files.
+4. Report findings as `<file>:<line> -> <problem> -> <correct pattern>`.
 
 ## Freshness rule
 

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -43,7 +43,9 @@ api/
 
 ## Routes vs Service Layer
 
-**Keep route handlers thin** — parse/validate the request, resolve auth and `organization_id`, delegate, shape the response. Domain logic (orchestration, business rules, external calls, computation) belongs in `services/`. Before adding logic to a handler, find its home: extend an existing `services/<domain>/` module that owns the concern (see *Where to Find Things*) before adding a focused new module; never a catch-all. Keep DB access in `db/` clients — routes call services, services call DB clients. Litmus test: if `tasks/`, `mcp_server/`, or another route could reuse it, it must live in `services/` to be importable.
+**Keep route handlers focused on HTTP concerns** — parse and validate the request, resolve auth and `organization_id`, and shape the response. Simple CRUD, list, and detail handlers may call `db/` client methods directly when the call is organization-scoped, or when a scoped parent lookup has already established ownership of a child identifier. All runtime query construction, ORM loading choices, direct session use, and transaction details belong in `db/`; routes, services, tasks, and MCP code must call DB clients instead of importing SQLAlchemy or opening sessions. Do not create pass-through services solely to preserve a route → service → DB call chain.
+
+Put reusable or multi-step orchestration, business rules, external calls, and substantial computation in `services/` (or `tasks/` for background work). Before adding such logic to a handler, extend an existing `services/<domain>/` module that owns the concern (see *Where to Find Things*) before adding a focused new module; never a catch-all. Litmus test: if `tasks/`, `mcp_server/`, or another route could reuse it, it must live in `services/` to be importable.
 
 ## Database Migrations
 

--- a/api/db/telephony_configuration_client.py
+++ b/api/db/telephony_configuration_client.py
@@ -19,6 +19,10 @@ class TelephonyConfigurationInUseError(Exception):
     """Raised when deleting a config that is still referenced by a campaign."""
 
 
+class TelephonyConfigurationConflictError(Exception):
+    """Raised when a telephony configuration violates a DB constraint."""
+
+
 class TelephonyConfigurationClient(BaseDBClient):
     async def list_telephony_configurations(
         self, organization_id: int
@@ -176,7 +180,7 @@ class TelephonyConfigurationClient(BaseDBClient):
                 await session.commit()
             except IntegrityError as e:
                 await session.rollback()
-                raise e
+                raise TelephonyConfigurationConflictError(str(e)) from e
             await session.refresh(row)
             return row
 
@@ -201,7 +205,7 @@ class TelephonyConfigurationClient(BaseDBClient):
                 await session.commit()
             except IntegrityError as e:
                 await session.rollback()
-                raise e
+                raise TelephonyConfigurationConflictError(str(e)) from e
             await session.refresh(row)
             return row
 

--- a/api/db/telephony_phone_number_client.py
+++ b/api/db/telephony_phone_number_client.py
@@ -20,6 +20,10 @@ from api.db.models import (
 from api.utils.telephony_address import normalize_telephony_address
 
 
+class TelephonyPhoneNumberConflictError(Exception):
+    """Raised when a phone number violates a DB constraint."""
+
+
 class TelephonyPhoneNumberClient(BaseDBClient):
     async def list_phone_numbers_for_config(
         self, telephony_configuration_id: int
@@ -257,7 +261,7 @@ class TelephonyPhoneNumberClient(BaseDBClient):
                 await session.commit()
             except IntegrityError as e:
                 await session.rollback()
-                raise e
+                raise TelephonyPhoneNumberConflictError(str(e)) from e
             await session.refresh(row)
             return row
 

--- a/api/db/workflow_client.py
+++ b/api/db/workflow_client.py
@@ -350,6 +350,61 @@ class WorkflowClient(BaseDBClient):
             result = await session.execute(query)
             return result.scalars().all()
 
+    async def list_workflows_for_model_configuration_migration(
+        self, organization_id: int
+    ) -> list[WorkflowModel]:
+        """Load an organization's workflows and every version for migration."""
+        async with self.async_session() as session:
+            result = await session.execute(
+                select(WorkflowModel)
+                .options(selectinload(WorkflowModel.definitions))
+                .where(WorkflowModel.organization_id == organization_id)
+            )
+            return list(result.scalars().unique().all())
+
+    async def bulk_update_workflow_model_configurations(
+        self,
+        *,
+        organization_id: int,
+        workflow_updates: list[tuple[int, dict]],
+        definition_updates: list[tuple[int, dict]],
+    ) -> None:
+        """Atomically update workflow and version configurations for one org."""
+        if not workflow_updates and not definition_updates:
+            return
+
+        async with self.async_session() as session:
+            try:
+                for workflow_id, workflow_configurations in workflow_updates:
+                    await session.execute(
+                        update(WorkflowModel)
+                        .where(
+                            WorkflowModel.id == workflow_id,
+                            WorkflowModel.organization_id == organization_id,
+                        )
+                        .values(workflow_configurations=workflow_configurations)
+                    )
+
+                organization_workflow_ids = select(WorkflowModel.id).where(
+                    WorkflowModel.organization_id == organization_id
+                )
+                for definition_id, workflow_configurations in definition_updates:
+                    await session.execute(
+                        update(WorkflowDefinitionModel)
+                        .where(
+                            WorkflowDefinitionModel.id == definition_id,
+                            WorkflowDefinitionModel.workflow_id.in_(
+                                organization_workflow_ids
+                            ),
+                        )
+                        .values(workflow_configurations=workflow_configurations)
+                    )
+
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
     async def get_all_workflows_for_listing(
         self, organization_id: int = None, status: str = None
     ) -> list[WorkflowModel]:

--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -4,7 +4,6 @@ from typing import Any, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel
-from sqlalchemy.exc import IntegrityError
 
 from api.constants import (
     DEFAULT_CAMPAIGN_RETRY_CONFIG,
@@ -13,7 +12,11 @@ from api.constants import (
 )
 from api.db import db_client
 from api.db.models import UserModel
-from api.db.telephony_configuration_client import TelephonyConfigurationInUseError
+from api.db.telephony_configuration_client import (
+    TelephonyConfigurationConflictError,
+    TelephonyConfigurationInUseError,
+)
+from api.db.telephony_phone_number_client import TelephonyPhoneNumberConflictError
 from api.enums import OrganizationConfigurationKey, PostHogEvent
 from api.errors.failure import ErrorSource, classify_exception, log_failure
 from api.errors.mps import MPSUnavailableError
@@ -722,7 +725,7 @@ async def create_telephony_configuration(
             credentials=credentials,
             is_default_outbound=request.is_default_outbound,
         )
-    except IntegrityError as e:
+    except TelephonyConfigurationConflictError as e:
         if "uq_telephony_configurations_org_name" in str(e):
             raise HTTPException(
                 status_code=409,
@@ -965,7 +968,7 @@ async def create_phone_number(
             is_default_caller_id=request.is_default_caller_id,
             extra_metadata=request.extra_metadata,
         )
-    except IntegrityError:
+    except TelephonyPhoneNumberConflictError:
         raise HTTPException(
             status_code=409,
             detail="A phone number with this address already exists in the org.",
@@ -1195,7 +1198,7 @@ async def save_telephony_configuration(
                 telephony_configuration_id=row.id,
                 address=addr,
             )
-        except IntegrityError:
+        except TelephonyPhoneNumberConflictError:
             logger.warning(
                 f"Skipping duplicate phone number {addr!r} for config {row.id}"
             )

--- a/api/services/configuration/ai_model_configuration.py
+++ b/api/services/configuration/ai_model_configuration.py
@@ -7,16 +7,10 @@ from typing import Literal
 
 from loguru import logger
 from pydantic import ValidationError
-from sqlalchemy import select, update
-from sqlalchemy.orm import selectinload
 
 from api.constants import MPS_API_URL
 from api.db import db_client
-from api.db.models import (
-    OrganizationConfigurationModel,
-    WorkflowDefinitionModel,
-    WorkflowModel,
-)
+from api.db.models import OrganizationConfigurationModel
 from api.enums import OrganizationConfigurationKey
 from api.schemas.ai_model_configuration import (
     DOGRAH_DEFAULT_LANGUAGE,
@@ -172,7 +166,9 @@ async def migrate_workflow_model_configurations_to_v2(
     organization_id: int,
     fallback_user_config: EffectiveAIModelConfiguration,
 ) -> WorkflowAIModelConfigurationMigrationResult:
-    workflows = await _list_workflows_for_model_configuration_migration(organization_id)
+    workflows = await db_client.list_workflows_for_model_configuration_migration(
+        organization_id
+    )
     workflow_updates: list[tuple[int, dict]] = []
     definition_updates: list[tuple[int, dict]] = []
     migrated_workflow_ids: set[int] = set()
@@ -202,20 +198,11 @@ async def migrate_workflow_model_configurations_to_v2(
                 migrated_workflow_ids.add(workflow.id)
 
     if workflow_updates or definition_updates:
-        async with db_client.async_session() as session:
-            for workflow_id, workflow_configs in workflow_updates:
-                await session.execute(
-                    update(WorkflowModel)
-                    .where(WorkflowModel.id == workflow_id)
-                    .values(workflow_configurations=workflow_configs)
-                )
-            for definition_id, definition_configs in definition_updates:
-                await session.execute(
-                    update(WorkflowDefinitionModel)
-                    .where(WorkflowDefinitionModel.id == definition_id)
-                    .values(workflow_configurations=definition_configs)
-                )
-            await session.commit()
+        await db_client.bulk_update_workflow_model_configurations(
+            organization_id=organization_id,
+            workflow_updates=workflow_updates,
+            definition_updates=definition_updates,
+        )
 
     return WorkflowAIModelConfigurationMigrationResult(
         workflow_count=len(migrated_workflow_ids),
@@ -374,18 +361,6 @@ def _merge_byok_secret_fields(incoming_byok: dict | None, existing_byok: dict | 
         existing_section = existing_container.get(section_name)
         if isinstance(incoming_section, dict) and isinstance(existing_section, dict):
             _merge_service_secret_fields(incoming_section, existing_section)
-
-
-async def _list_workflows_for_model_configuration_migration(
-    organization_id: int,
-) -> list[WorkflowModel]:
-    async with db_client.async_session() as session:
-        result = await session.execute(
-            select(WorkflowModel)
-            .options(selectinload(WorkflowModel.definitions))
-            .where(WorkflowModel.organization_id == organization_id)
-        )
-        return list(result.scalars().unique().all())
 
 
 def _merge_service_secret_fields(incoming: dict, existing: dict):

--- a/api/services/pipecat/gemini_json_schema_adapter.py
+++ b/api/services/pipecat/gemini_json_schema_adapter.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from pipecat.adapters.schemas.tools_schema import AdapterType, ToolsSchema
 from pipecat.adapters.services.gemini_adapter import GeminiLLMAdapter
+from pipecat.adapters.services.gemini_live_adapter import GeminiLiveLLMAdapter
 
 
 class DograhGeminiJSONSchemaAdapter(GeminiLLMAdapter):
@@ -37,3 +38,14 @@ class DograhGeminiJSONSchemaAdapter(GeminiLLMAdapter):
             custom_gemini_tools = tools_schema.custom_tools.get(AdapterType.GEMINI, [])
 
         return formatted_standard_tools + custom_gemini_tools
+
+
+class DograhGeminiLiveJSONSchemaAdapter(GeminiLiveLLMAdapter, DograhGeminiJSONSchemaAdapter):
+    """Gemini Live adapter with the JSON Schema tool-parameter fix.
+
+    Combines :class:`GeminiLiveLLMAdapter` (tool calls and results converted to
+    text, which is all Gemini Live's API accepts when seeding a session) with
+    the ``parameters_json_schema`` tool formatting above.
+    """
+
+    pass

--- a/api/services/pipecat/gemini_json_schema_adapter.py
+++ b/api/services/pipecat/gemini_json_schema_adapter.py
@@ -40,7 +40,9 @@ class DograhGeminiJSONSchemaAdapter(GeminiLLMAdapter):
         return formatted_standard_tools + custom_gemini_tools
 
 
-class DograhGeminiLiveJSONSchemaAdapter(GeminiLiveLLMAdapter, DograhGeminiJSONSchemaAdapter):
+class DograhGeminiLiveJSONSchemaAdapter(
+    GeminiLiveLLMAdapter, DograhGeminiJSONSchemaAdapter
+):
     """Gemini Live adapter with the JSON Schema tool-parameter fix.
 
     Combines :class:`GeminiLiveLLMAdapter` (tool calls and results converted to

--- a/api/services/pipecat/realtime/gemini_live.py
+++ b/api/services/pipecat/realtime/gemini_live.py
@@ -25,7 +25,7 @@ from google.genai.types import Content, Part
 from loguru import logger
 
 from api.services.pipecat.gemini_json_schema_adapter import (
-    DograhGeminiJSONSchemaAdapter,
+    DograhGeminiLiveJSONSchemaAdapter,
 )
 from api.services.pipecat.realtime.static_greeting import format_static_greeting_prompt
 from pipecat.frames.frames import (
@@ -52,10 +52,11 @@ class DograhGeminiLiveLLMService(GeminiLiveLLMService):
 
     # Route tool schemas through Gemini's ``parameters_json_schema`` field so
     # MCP/imported tools that use JSON Schema keywords (``const``, ``not``,
-    # nested ``anyOf``) rejected by the strict ``Schema`` model are accepted.
-    # Mirrors the non-realtime ``DograhGoogleLLMService`` fix;
+    # nested ``anyOf``) rejected by the strict ``Schema`` model are accepted,
+    # while keeping upstream's Live-specific tool-call-to-text conversion for
+    # seeded contexts. Mirrors the non-realtime ``DograhGoogleLLMService`` fix;
     # ``DograhGeminiLiveVertexLLMService`` inherits this via MRO.
-    adapter_class = DograhGeminiJSONSchemaAdapter
+    adapter_class = DograhGeminiLiveJSONSchemaAdapter
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/api/tests/integrations/test_run_pipeline_text_greeting.py
+++ b/api/tests/integrations/test_run_pipeline_text_greeting.py
@@ -9,9 +9,10 @@ The flow under test:
 2. ``MockTTSService`` synthesises audio for the greeting; the real
    ``MediaSender`` machinery in ``MockOutputTransport`` emits
    ``BotStartedSpeakingFrame`` and ``BotStoppedSpeakingFrame``.
-3. The TTS service emits an ``LLMAssistantPushAggregationFrame`` after
-   ``TTSStoppedFrame``, so the greeting is appended to the assistant
-   context by ``LLMAssistantAggregator``.
+3. The TTS service emits an ``LLMAssistantPushAggregationFrame``, so the
+   greeting is appended to the assistant context by ``LLMAssistantAggregator``.
+   Audio playback can still be draining at this point, so the test also waits
+   for ``BotStoppedSpeakingFrame`` to unmute user input.
 4. We then push a ``TranscriptionFrame`` into the pipeline. After the
    user-turn-stop timeout, ``LLMUserAggregator`` pushes a context frame
    to the LLM, ``MockLLMService`` returns an ``end_call`` tool call, and
@@ -206,9 +207,16 @@ async def _run_test_body(workflow_run_setup, db_session) -> None:
             )
             context = assistant_aggregator.context
 
+            user_aggregator = _find_processor_by_class_name(
+                pipeline_task, "LLMUserAggregator"
+            )
+            assert user_aggregator is not None, (
+                "LLMUserAggregator not found in pipeline"
+            )
+
             # Wait for the greeting to be appended to the assistant context. The
-            # TTSSpeakFrame -> audio frames -> BotStoppedSpeaking -> assistant
-            # aggregation push chain runs through the real pipeline.
+            # TTSSpeakFrame -> audio frames -> assistant aggregation push chain
+            # runs through the real pipeline.
             appeared = await _wait_for(
                 lambda: _greeting_in_assistant_context(context), timeout=5.0
             )
@@ -216,6 +224,16 @@ async def _run_test_body(workflow_run_setup, db_session) -> None:
                 "Greeting was not appended to the assistant context. "
                 f"Messages: {context.get_messages()}"
             )
+
+            # Context aggregation can finish before the output transport has
+            # drained the greeting audio. Until BotStoppedSpeakingFrame reaches
+            # the user aggregator, MuteUntilFirstBotCompleteUserMuteStrategy
+            # intentionally suppresses transcripts. Wait for that real playback
+            # boundary before simulating the caller's reply.
+            unmuted = await _wait_for(
+                lambda: not user_aggregator._user_is_muted, timeout=2.0
+            )
+            assert unmuted, "User input stayed muted after greeting playback"
 
             # The LLM must not have been invoked yet — the greeting bypasses
             # the LLM entirely (goes straight to TTS via TTSSpeakFrame).

--- a/api/tests/test_ai_model_configuration_v2.py
+++ b/api/tests/test_ai_model_configuration_v2.py
@@ -19,6 +19,7 @@ from api.services.configuration.ai_model_configuration import (
     mask_ai_model_configuration_v2,
     merge_ai_model_configuration_v2_secrets,
     migrate_workflow_configuration_model_override_to_v2,
+    migrate_workflow_model_configurations_to_v2,
     upsert_organization_ai_model_configuration_v2,
 )
 from api.services.configuration.check_validity import UserConfigurationValidator
@@ -482,6 +483,58 @@ def test_workflow_model_override_migration_removes_invalid_v1_override_marker():
     assert changed is True
     assert "model_overrides" not in migrated
     assert migrated["ambient_noise_configuration"] == {"enabled": False}
+
+
+@pytest.mark.asyncio
+async def test_workflow_model_configuration_migration_delegates_db_access(
+    monkeypatch,
+):
+    from api.services.configuration import ai_model_configuration
+
+    workflow = SimpleNamespace(
+        id=7,
+        workflow_configurations={"model_overrides": None, "scope": "workflow"},
+        definitions=[
+            SimpleNamespace(
+                id=11,
+                workflow_configurations={
+                    "model_overrides": None,
+                    "scope": "definition",
+                },
+            ),
+            SimpleNamespace(
+                id=12,
+                workflow_configurations={"scope": "unchanged"},
+            ),
+        ],
+    )
+    list_workflows = AsyncMock(return_value=[workflow])
+    bulk_update = AsyncMock()
+    monkeypatch.setattr(
+        ai_model_configuration.db_client,
+        "list_workflows_for_model_configuration_migration",
+        list_workflows,
+    )
+    monkeypatch.setattr(
+        ai_model_configuration.db_client,
+        "bulk_update_workflow_model_configurations",
+        bulk_update,
+    )
+
+    result = await migrate_workflow_model_configurations_to_v2(
+        organization_id=42,
+        fallback_user_config=EffectiveAIModelConfiguration(),
+    )
+
+    list_workflows.assert_awaited_once_with(42)
+    bulk_update.assert_awaited_once_with(
+        organization_id=42,
+        workflow_updates=[(7, {"scope": "workflow"})],
+        definition_updates=[(11, {"scope": "definition"})],
+    )
+    assert result.workflow_count == 1
+    assert result.definition_count == 1
+    assert result.workflow_ids == [7]
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_db_layer_boundary.py
+++ b/api/tests/test_db_layer_boundary.py
@@ -1,0 +1,74 @@
+"""Architecture guard for the runtime database-access boundary."""
+
+import ast
+import re
+from pathlib import Path
+
+API_ROOT = Path(__file__).resolve().parents[1]
+NON_RUNTIME_TOP_LEVEL = {"alembic", "db", "tests"}
+NON_RUNTIME_FILES = {Path("conftest.py")}
+INTERNAL_TOOLING_PREFIXES = {("services", "admin_utils")}
+DATABASE_IMPORT_ROOTS = {"asyncpg", "psycopg", "psycopg2", "sqlalchemy"}
+DIRECT_DATABASE_CALLS = {"async_session", "execute_raw_query"}
+SQL_LITERAL = re.compile(
+    r"^\s*(?:"
+    r"SELECT\b.+\bFROM\b|"
+    r"INSERT\s+INTO\b|"
+    r"UPDATE\s+[A-Za-z_]\w*\s+SET\b|"
+    r"DELETE\s+FROM\b|"
+    r"WITH\s+[A-Za-z_]\w*\s+AS\s*\("
+    r")",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _runtime_python_files():
+    for path in API_ROOT.rglob("*.py"):
+        relative = path.relative_to(API_ROOT)
+        if relative in NON_RUNTIME_FILES:
+            continue
+        if relative.parts[0] in NON_RUNTIME_TOP_LEVEL:
+            continue
+        if any(
+            relative.parts[: len(prefix)] == prefix
+            for prefix in INTERNAL_TOOLING_PREFIXES
+        ):
+            continue
+        yield path, relative
+
+
+def test_runtime_database_access_is_confined_to_db_clients():
+    violations: list[str] = []
+
+    for path, relative in _runtime_python_files():
+        tree = ast.parse(path.read_text(), filename=str(relative))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name.split(".", 1)[0] in DATABASE_IMPORT_ROOTS:
+                        violations.append(f"{relative}:{node.lineno}: {alias.name}")
+            elif isinstance(node, ast.ImportFrom):
+                if (
+                    node.module
+                    and node.module.split(".", 1)[0] in DATABASE_IMPORT_ROOTS
+                ):
+                    violations.append(f"{relative}:{node.lineno}: {node.module}")
+            elif (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in DIRECT_DATABASE_CALLS
+            ):
+                violations.append(
+                    f"{relative}:{node.lineno}: direct {node.func.attr}() access"
+                )
+            elif (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and SQL_LITERAL.search(node.value)
+            ):
+                violations.append(f"{relative}:{node.lineno}: raw SQL literal")
+
+    assert violations == [], (
+        "Runtime database imports, SQL, and direct session/query access must live in "
+        f"api/db/: {violations}"
+    )

--- a/api/tests/test_dograh_managed_correlation.py
+++ b/api/tests/test_dograh_managed_correlation.py
@@ -60,11 +60,12 @@ def test_dograh_llm_uses_explicit_mps_correlation_id():
 async def test_dograh_stt_config_uses_explicit_mps_correlation_id(monkeypatch):
     fake_ws = _FakeWebSocket()
 
-    async def fake_connect(url, additional_headers):
+    async def fake_connect(self, url, additional_headers):
         return fake_ws
 
     monkeypatch.setattr(
-        "pipecat.services.dograh.stt.websocket_connect",
+        DograhSTTService,
+        "_websocket_connect",
         fake_connect,
     )
 
@@ -86,11 +87,12 @@ async def test_dograh_stt_config_uses_explicit_mps_correlation_id(monkeypatch):
 async def test_dograh_tts_messages_use_explicit_mps_correlation_id(monkeypatch):
     fake_ws = _FakeWebSocket()
 
-    async def fake_connect(url, additional_headers):
+    async def fake_connect(self, url, additional_headers):
         return fake_ws
 
     monkeypatch.setattr(
-        "pipecat.services.dograh.tts.websocket_connect",
+        DograhTTSService,
+        "_websocket_connect",
         fake_connect,
     )
 

--- a/api/tests/test_gemini_json_schema_adapter.py
+++ b/api/tests/test_gemini_json_schema_adapter.py
@@ -3,10 +3,12 @@ from unittest.mock import patch
 from google.genai.types import GenerateContentConfig, LiveConnectConfig
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
+from pipecat.adapters.services.gemini_live_adapter import GeminiLiveLLMAdapter
 
 from api.services.configuration.registry import ServiceProviders
 from api.services.pipecat.gemini_json_schema_adapter import (
     DograhGeminiJSONSchemaAdapter,
+    DograhGeminiLiveJSONSchemaAdapter,
 )
 from api.services.pipecat.realtime.gemini_live import DograhGeminiLiveLLMService
 from api.services.pipecat.realtime.gemini_live_vertex import (
@@ -127,10 +129,19 @@ def test_google_vertex_llm_service_factory_uses_dograh_service_class():
 
 
 def test_gemini_live_service_classes_use_dograh_gemini_adapter_class():
-    assert DograhGeminiLiveLLMService.adapter_class is DograhGeminiJSONSchemaAdapter
+    assert DograhGeminiLiveLLMService.adapter_class is DograhGeminiLiveJSONSchemaAdapter
     # Vertex Live inherits adapter_class from DograhGeminiLiveLLMService via MRO.
     assert (
-        DograhGeminiLiveVertexLLMService.adapter_class is DograhGeminiJSONSchemaAdapter
+        DograhGeminiLiveVertexLLMService.adapter_class
+        is DograhGeminiLiveJSONSchemaAdapter
+    )
+    # The Live adapter must keep upstream's tool-call-to-text conversion for
+    # seeded contexts (GeminiLiveLLMAdapter) alongside the JSON Schema fix.
+    assert issubclass(DograhGeminiLiveJSONSchemaAdapter, GeminiLiveLLMAdapter)
+    assert issubclass(DograhGeminiLiveJSONSchemaAdapter, DograhGeminiJSONSchemaAdapter)
+    assert (
+        DograhGeminiLiveJSONSchemaAdapter.to_provider_tools_format
+        is DograhGeminiJSONSchemaAdapter.to_provider_tools_format
     )
 
 

--- a/api/tests/test_workflow_versioning.py
+++ b/api/tests/test_workflow_versioning.py
@@ -557,6 +557,71 @@ class TestVersionDataOnDefinition:
 
 
 # ---------------------------------------------------------------------------
+# Model-configuration migration persistence
+# ---------------------------------------------------------------------------
+
+
+class TestModelConfigurationMigrationPersistence:
+    async def test_migration_reads_and_updates_are_organization_scoped(
+        self, db_session, async_session, org_and_user
+    ):
+        org, user = org_and_user
+        other_org = OrganizationModel(provider_id="test-org-migration-other")
+        async_session.add(other_org)
+        await async_session.flush()
+        other_user = UserModel(
+            provider_id="test-user-migration-other",
+            selected_organization_id=other_org.id,
+        )
+        async_session.add(other_user)
+        await async_session.flush()
+
+        workflow = await db_session.create_workflow(
+            name="Migration target",
+            workflow_definition=GRAPH_V1,
+            user_id=user.id,
+            organization_id=org.id,
+        )
+        other_workflow = await db_session.create_workflow(
+            name="Other organization workflow",
+            workflow_definition=GRAPH_V1,
+            user_id=other_user.id,
+            organization_id=other_org.id,
+        )
+        workflow_definition = (await db_session.get_workflow_versions(workflow.id))[0]
+        other_definition = (await db_session.get_workflow_versions(other_workflow.id))[
+            0
+        ]
+
+        loaded = await db_session.list_workflows_for_model_configuration_migration(
+            org.id
+        )
+        assert [row.id for row in loaded] == [workflow.id]
+        assert [row.id for row in loaded[0].definitions] == [workflow_definition.id]
+
+        await db_session.bulk_update_workflow_model_configurations(
+            organization_id=org.id,
+            workflow_updates=[
+                (workflow.id, {"migrated": True}),
+                (other_workflow.id, {"cross_tenant": True}),
+            ],
+            definition_updates=[
+                (workflow_definition.id, {"migrated": True}),
+                (other_definition.id, {"cross_tenant": True}),
+            ],
+        )
+        await async_session.refresh(workflow)
+        await async_session.refresh(other_workflow)
+        await async_session.refresh(workflow_definition)
+        await async_session.refresh(other_definition)
+
+        assert workflow.workflow_configurations == {"migrated": True}
+        assert workflow_definition.workflow_configurations == {"migrated": True}
+        assert other_workflow.workflow_configurations != {"cross_tenant": True}
+        assert other_definition.workflow_configurations != {"cross_tenant": True}
+
+
+# ---------------------------------------------------------------------------
 # Run creation uses published (or draft for testing)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped `pipecat` to v1.7.0 and aligned our Gemini Live adapter and DB boundaries to keep Dograh wrappers compatible and improve error handling. Also tightened migration and telephony flows to be org-scoped and return clear 409s on conflicts.

- **Dependencies**
  - Updated `pipecat` submodule to v1.7.0 and added the merge-upstream skill doc.

- **Bug Fixes**
  - Gemini Live JSON Schema adapter now subclasses the Live adapter, keeping tool-call-to-text conversion while using `parameters_json_schema`.
  - Telephony configuration and phone-number writes raise custom conflict errors; routes return 409 instead of generic server errors.
  - Delegated workflow model-config migration reads/writes to `api/db/workflow_client.py` with org-scoped bulk updates.
  - Added an architecture guard to prevent runtime code from importing `sqlalchemy` or using raw SQL outside `api/db`.

<sup>Written for commit c392551421decfe7dd993fde18fb71dc7dc3fc6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds explicit completion and inactivity handling for text-chat sessions, updates the Pipecat/Gemini integration, and moves selected workflow migration queries behind DB clients.

The text-chat end flow completes a session successfully on its first request, but a repeated request carrying the prior revision is accepted after completion and schedules downstream completion work again. This can cause duplicate completion processing, such as integrations, webhooks, or billing-related work, for a conversation that has already ended. The completion path should preserve optimistic-concurrency behavior for stale requests and avoid re-enqueuing already completed runs.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until completed text-chat sessions reject stale end requests and avoid scheduling completion work again.

The end flow was executed with a focused revision-aware persistence seam. The first request completed the session, while a repeated request with the original revision succeeded and queued completion work a second time.

**Files Needing Attention:** api/services/workflow/text_chat_session_service.py, particularly the completed-run branch in complete_text_chat_session.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and linked it to the review comment.
- T-Rex produced a second finding-proof for another posted P1 finding.
- T-Rex executed contract validation and confirmed the harness progressed as expected: revision advanced to 8, the session and run completed, and a completion job was enqueued; a stale-repeat end with the expected revision 7 returned success with revision 8 and enqueued a second completion job.

<a href="https://app.greptile.com/trex/runs/17602048/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `api/services/workflow/text_chat_session_service.py`, line 203-206 ([link](https://github.com/dograh-hq/dograh/blob/c392551421decfe7dd993fde18fb71dc7dc3fc6a/api/services/workflow/text_chat_session_service.py#L203-L206)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale end requests bypass optimistic concurrency**

   Once a text-chat run is completed, this branch runs before the revision check in `complete_workflow_run_text_session`. Repeating either end endpoint with an old `expected_revision` therefore returns success instead of the documented conflict response and enqueues `PROCESS_WORKFLOW_COMPLETION` again. Validate `expected_revision` before this completed-run branch, and return the completed session without scheduling completion work again.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Evidence from the check](https://app.greptile.com/trex/artifacts/41421a86-0aba-474d-873c-b0a1aa14af62)**

   - Authored and executed source that extracts the exact changed embed-end and completion functions, simulates atomic revision persistence, and invokes the end flow twice; it demonstrates the stale request is accepted.

   **[Command output from the check](https://app.greptile.com/trex/artifacts/85002654-e5c7-4bb7-8d23-ea96a5ee2487)**

   - Executed initial end command from \`/home/user/repo\`; it shows atomic completion, revision 7 to 8, and exactly one completion job, establishing the baseline.

   **[Command output from the check](https://app.greptile.com/trex/artifacts/35340157-3baa-422c-a2c3-71d027d20a35)**

   - Executed repeated end command with stale expected revision 7; it shows success at revision 8 and two total completion jobs, proving stale conflict behavior is bypassed.

   **[Command output from the check](https://app.greptile.com/trex/artifacts/d506121d-7889-4815-b828-20eddd5dc1d4)**

   - Executed Python compilation for the harness and directly exercised changed completion, embed, and route modules; the command exited successfully, confirming syntax validity.

   **[Command output from the check](https://app.greptile.com/trex/artifacts/257eb80d-f8b6-48cf-b1cc-e7a865918755)**

   - Executed the focused text-chat service and public embed pytest command; it was blocked during conftest import because the unavailable environment lacks dotenv, so no database environment was fabricated.

   <a href="https://app.greptile.com/trex/runs/17602048/artifacts?artifact=41421a86-0aba-474d-873c-b0a1aa14af62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale explicit end requests bypass revision conflicts and re-enqueue completion processing**

   - **Bug**
     - After a public embed text-chat end has committed revision 8, repeating `/end` with stale `expected_revision=7` succeeds because `complete_text_chat_session` returns early whenever the loaded run is already completed. The early return neither checks the supplied revision nor suppresses the completion enqueue. The same shared service is called by authenticated `POST /workflow/{workflow_id}/text-chat/sessions/{run_id}/end`, so that endpoint has the same behavior.
   - **Cause**
     - `complete_text_chat_session` checks `workflow_run.is_completed` before invoking the atomic DB method that validates `expected_revision`; its idempotent branch unconditionally calls `_enqueue_text_chat_completion(run_id)`.
   - **Fix**
     - In `complete_text_chat_session`, enforce the expected revision against the loaded session before the completed-run idempotency return (return `TextChatSessionRevisionConflictError` when stale). For an already completed run with a matching/omitted revision, return the reloaded session without re-enqueueing completion work; rely on the original successful transition and deterministic job handling for recovery.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["chore: fix test suite"](https://github.com/dograh-hq/dograh/commit/c392551421decfe7dd993fde18fb71dc7dc3fc6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50769811)</sub>

<!-- /greptile_comment -->