### PR TITLE
chore: triage errors to define owners

### DIFF
--- a/api/db/telephony_configuration_client.py
+++ b/api/db/telephony_configuration_client.py
@@ -43,41 +43,52 @@ class TelephonyConfigurationClient(BaseDBClient):
             return await session.get(TelephonyConfigurationModel, config_id)
 
     async def get_telephony_configuration_for_org(
-        self, config_id: int, organization_id: int
+        self,
+        config_id: int,
+        organization_id: int,
+        active_only: bool = True,
     ) -> Optional[TelephonyConfigurationModel]:
-        """Lookup scoped to an org — used to authorize per-org access."""
+        """Lookup scoped to an org, excluding parked configs by default.
+
+        Management flows that need to display, repair, or reactivate a parked
+        row must opt in with ``active_only=False``.
+        """
         async with self.async_session() as session:
-            result = await session.execute(
-                select(TelephonyConfigurationModel).where(
-                    TelephonyConfigurationModel.id == config_id,
-                    TelephonyConfigurationModel.organization_id == organization_id,
-                )
+            query = select(TelephonyConfigurationModel).where(
+                TelephonyConfigurationModel.id == config_id,
+                TelephonyConfigurationModel.organization_id == organization_id,
             )
+            if active_only:
+                query = query.where(TelephonyConfigurationModel.inactive.is_(False))
+            result = await session.execute(query)
             return result.scalars().first()
 
     async def get_default_telephony_configuration(
-        self, organization_id: int
+        self, organization_id: int, active_only: bool = True
     ) -> Optional[TelephonyConfigurationModel]:
+        """Return the default outbound config, if it is usable for routing."""
         async with self.async_session() as session:
-            result = await session.execute(
-                select(TelephonyConfigurationModel).where(
-                    TelephonyConfigurationModel.organization_id == organization_id,
-                    TelephonyConfigurationModel.is_default_outbound.is_(True),
-                )
+            query = select(TelephonyConfigurationModel).where(
+                TelephonyConfigurationModel.organization_id == organization_id,
+                TelephonyConfigurationModel.is_default_outbound.is_(True),
             )
+            if active_only:
+                query = query.where(TelephonyConfigurationModel.inactive.is_(False))
+            result = await session.execute(query)
             return result.scalars().first()
 
     async def list_telephony_configurations_by_provider(
-        self, organization_id: int, provider: str
+        self, organization_id: int, provider: str, active_only: bool = True
     ) -> List[TelephonyConfigurationModel]:
-        """Used by inbound matching to enumerate candidates of a given provider."""
+        """List provider configs usable for inbound matching by default."""
         async with self.async_session() as session:
-            result = await session.execute(
-                select(TelephonyConfigurationModel).where(
-                    TelephonyConfigurationModel.organization_id == organization_id,
-                    TelephonyConfigurationModel.provider == provider,
-                )
+            query = select(TelephonyConfigurationModel).where(
+                TelephonyConfigurationModel.organization_id == organization_id,
+                TelephonyConfigurationModel.provider == provider,
             )
+            if active_only:
+                query = query.where(TelephonyConfigurationModel.inactive.is_(False))
+            result = await session.execute(query)
             return list(result.scalars().all())
 
     async def count_telnyx_configs_missing_webhook_public_key(

--- a/api/db/telephony_phone_number_client.py
+++ b/api/db/telephony_phone_number_client.py
@@ -105,8 +105,7 @@ class TelephonyPhoneNumberClient(BaseDBClient):
         provider: str,
         country_hint: Optional[str] = None,
     ) -> Optional[TelephonyPhoneNumberModel]:
-        """Inbound routing primary lookup: normalize the called address and find
-        the matching active row whose config is for the detected provider."""
+        """Inbound routing primary lookup for an active number and config."""
         normalized = normalize_telephony_address(address, country_hint=country_hint)
 
         async with self.async_session() as session:
@@ -123,6 +122,7 @@ class TelephonyPhoneNumberClient(BaseDBClient):
                     == normalized.canonical,
                     TelephonyPhoneNumberModel.is_active.is_(True),
                     TelephonyConfigurationModel.provider == provider,
+                    TelephonyConfigurationModel.inactive.is_(False),
                 )
             )
             return result.scalars().first()
@@ -142,9 +142,9 @@ class TelephonyPhoneNumberClient(BaseDBClient):
         ``telephony_phone_numbers`` and matches all of:
         provider, ``credentials[account_id_field] == account_id``,
         ``phone.address_normalized == canonical(to_number)``, and
-        ``phone.is_active``. Replaces the previous pattern of resolving the
-        config and the phone number in two separate queries with a Python-side
-        loop over candidate configs.
+        ``phone.is_active``, and a non-parked configuration. Replaces the
+        previous pattern of resolving the config and the phone number in two
+        separate queries with a Python-side loop over candidate configs.
 
         Returns ``(config, phone_number)`` or None when the primary path
         misses (e.g. legacy non-E.164 stored addresses); the caller should
@@ -170,6 +170,7 @@ class TelephonyPhoneNumberClient(BaseDBClient):
                     TelephonyPhoneNumberModel.address_normalized
                     == normalized.canonical,
                     TelephonyPhoneNumberModel.is_active.is_(True),
+                    TelephonyConfigurationModel.inactive.is_(False),
                 )
             )
             if organization_id is not None:

--- a/api/errors/failure.py
+++ b/api/errors/failure.py
@@ -67,6 +67,7 @@ _HTTP_STATUS_IN_MESSAGE_RE = re.compile(
 )
 _MAX_MESSAGE_LENGTH = 4000
 _FAILURE_METADATA_ATTR = "_dograh_failure_metadata"
+_FAILURE_REPORTED_ATTR = "_dograh_failure_reported"
 
 
 def _redact_quoted_secret_assignment(match: re.Match[str]) -> str:
@@ -113,11 +114,22 @@ def _normalize_code(code: str) -> str:
 def _resolve_error_owner(
     error_type: ErrorType, error_owner: ErrorOwner | str | None
 ) -> ErrorOwner:
-    """Route responsibility without treating an external provider as an owner."""
+    """Route responsibility without treating an external provider as an owner.
+
+    ``config_error`` and ``quota_error`` are user-owned by definition, so a
+    caller cannot argue its way out of them. Every other type defers to the
+    owner the seam declared: the seam knows whose credentials were in play,
+    which the shape of the exception cannot tell us. ``system_error`` used to
+    force operator here, which silently overrode seams that had correctly said
+    "user" and made every unclassifiable provider error look like a Dograh bug.
+
+    An unstated owner still falls back to operator — an unattributed failure is
+    Dograh's to investigate until a seam claims otherwise.
+    """
 
     if error_type in (ErrorType.CONFIG_ERROR, ErrorType.QUOTA_ERROR):
         return ErrorOwner.USER
-    if error_type == ErrorType.SYSTEM_ERROR or error_owner is None:
+    if error_owner is None:
         return ErrorOwner.OPERATOR
     if isinstance(error_owner, ErrorOwner):
         return error_owner
@@ -236,6 +248,12 @@ def _type_for_http_status(status_code: int) -> tuple[ErrorType, bool | None]:
     if status_code == 408 or 500 <= status_code <= 599:
         return ErrorType.PROVIDER_ERROR, True
     if 400 <= status_code <= 499:
+        return ErrorType.CONFIG_ERROR, False
+    # A redirect reaching a classifier means the caller does not follow them, so
+    # the configured URL is the wrong one to have given us. This is a protocol
+    # signal rather than a guess at intent, which is why it may name a config
+    # error where ambiguous evidence may not.
+    if 300 <= status_code <= 399:
         return ErrorType.CONFIG_ERROR, False
     return ErrorType.SYSTEM_ERROR, None
 
@@ -456,6 +474,29 @@ def classify_exception(
         retryable=True if transient_exception else None,
         context=failure_context,
     )
+
+
+def mark_failure_reported(exc: BaseException) -> None:
+    """Record that a seam has already reported this exception.
+
+    An exception propagating through several layers used to be logged by each
+    of them, so one failure arrived as several unrelated-looking records. Layers
+    that re-raise mark the exception instead, and any outer catch-all checks
+    :func:`failure_already_reported` before adding a report of its own.
+    """
+
+    try:
+        setattr(exc, _FAILURE_REPORTED_ATTR, True)
+    except Exception:
+        # Exceptions with __slots__ cannot carry the mark. Losing it costs a
+        # duplicate log line, which must never be worse than losing the error.
+        pass
+
+
+def failure_already_reported(exc: BaseException) -> bool:
+    """Whether an inner layer already reported this exception."""
+
+    return bool(getattr(exc, _FAILURE_REPORTED_ATTR, False))
 
 
 def annotate_failure_metadata(

--- a/api/routes/campaign.py
+++ b/api/routes/campaign.py
@@ -339,7 +339,7 @@ async def _get_telephony_configuration_name(
     if config_id is None:
         return None
     cfg = await db_client.get_telephony_configuration_for_org(
-        config_id, organization_id
+        config_id, organization_id, active_only=False
     )
     return cfg.name if cfg else None
 

--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -765,7 +765,7 @@ async def get_telephony_configuration_by_id(
         raise HTTPException(status_code=400, detail="No organization selected")
 
     row = await db_client.get_telephony_configuration_for_org(
-        config_id, user.selected_organization_id
+        config_id, user.selected_organization_id, active_only=False
     )
     if not row:
         raise HTTPException(status_code=404, detail="Telephony configuration not found")
@@ -784,7 +784,7 @@ async def update_telephony_configuration(
         raise HTTPException(status_code=400, detail="No organization selected")
 
     existing = await db_client.get_telephony_configuration_for_org(
-        config_id, user.selected_organization_id
+        config_id, user.selected_organization_id, active_only=False
     )
     if not existing:
         raise HTTPException(status_code=404, detail="Telephony configuration not found")
@@ -900,7 +900,7 @@ def _detail_response(row) -> TelephonyConfigurationDetail:
 
 async def _ensure_config_belongs_to_org(config_id: int, organization_id: int):
     cfg = await db_client.get_telephony_configuration_for_org(
-        config_id, organization_id
+        config_id, organization_id, active_only=False
     )
     if not cfg:
         raise HTTPException(status_code=404, detail="Telephony configuration not found")
@@ -1164,7 +1164,7 @@ async def get_telephony_configuration(user: UserModel = Depends(get_user)):
         raise HTTPException(status_code=400, detail="No organization selected")
 
     cfg = await db_client.get_default_telephony_configuration(
-        user.selected_organization_id
+        user.selected_organization_id, active_only=False
     )
     if not cfg:
         return TelephonyConfigurationResponse()
@@ -1197,7 +1197,7 @@ async def save_telephony_configuration(
     payload.pop("provider", None)
 
     default = await db_client.get_default_telephony_configuration(
-        user.selected_organization_id
+        user.selected_organization_id, active_only=False
     )
 
     if default and default.provider == request.provider:

--- a/api/routes/telephony.py
+++ b/api/routes/telephony.py
@@ -22,6 +22,7 @@ from starlette.websockets import WebSocketDisconnect
 from api.db import db_client
 from api.db.models import UserModel
 from api.enums import CallType, WorkflowRunMode, WorkflowRunState
+from api.errors.failure import failure_already_reported
 from api.errors.telephony_errors import TelephonyError
 from api.sdk_expose import sdk_expose
 from api.services.auth.depends import get_user
@@ -767,7 +768,12 @@ async def _handle_telephony_websocket(
     except WebSocketDisconnect as e:
         logger.info(f"WebSocket disconnected: code={e.code}, reason={e.reason}")
     except Exception as e:
-        logger.error(f"Error in WebSocket connection: {e}")
+        # This catch-all also covers setup before the pipeline starts, so it
+        # still reports anything no inner seam has claimed.
+        if failure_already_reported(e):
+            logger.warning(f"WebSocket connection ended on a reported failure: {e}")
+        else:
+            logger.error(f"Error in WebSocket connection: {e}")
         try:
             await websocket.close(1011, "Internal server error")
         except RuntimeError:

--- a/api/services/configuration/options/sarvam.py
+++ b/api/services/configuration/options/sarvam.py
@@ -94,7 +94,8 @@ SARVAM_STT_LANGUAGES_V3 = SARVAM_STT_LANGUAGES_V25 + (
     "mai-IN",
     "doi-IN",
 )
-SARVAM_LLM_MODELS = (
-    "sarvam-30b",
-    "sarvam-105b",
-)
+# Keep in step with SarvamLLMService._SUPPORTED_MODELS in pipecat: offering a
+# model the service rejects turns every call using it into a hard failure at
+# pipeline start. sarvam-30b was listed here after Sarvam withdrew it and was
+# the default, which is what broke those runs.
+SARVAM_LLM_MODELS = ("sarvam-105b",)

--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -639,11 +639,8 @@ class SarvamLLMConfiguration(BaseLLMConfiguration):
     model_config = SARVAM_PROVIDER_MODEL_CONFIG
     provider: Literal[ServiceProviders.SARVAM] = ServiceProviders.SARVAM
     model: str = Field(
-        default="sarvam-30b",
-        description=(
-            "Sarvam chat model. Use sarvam-30b for low-latency voice agents; "
-            "sarvam-105b for complex multi-step reasoning."
-        ),
+        default="sarvam-105b",
+        description="Sarvam chat model.",
         json_schema_extra={"examples": SARVAM_LLM_MODELS, "allow_custom_input": True},
     )
     temperature: float = Field(

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -6,6 +6,7 @@ from loguru import logger
 
 from api.db import db_client
 from api.enums import WorkflowRunMode
+from api.errors.failure import mark_failure_reported
 from api.schemas.workflow_configurations import (
     DEFAULT_MAX_CALL_DURATION_SECONDS,
     DEFAULT_MAX_USER_IDLE_TIMEOUT_SECONDS,
@@ -387,10 +388,13 @@ async def _run_pipeline_telephony_impl(
             organization_id=organization_id,
         )
     except Exception as e:
+        # Closest layer to the failure and the only one with the traceback, so
+        # it owns the report; outer handlers see the mark and stay quiet.
         logger.error(
             f"[run {workflow_run_id}] Error in {provider_name} pipeline: {e}",
             exc_info=True,
         )
+        mark_failure_reported(e)
         raise
 
 

--- a/api/services/telephony/ari_manager.py
+++ b/api/services/telephony/ari_manager.py
@@ -1465,11 +1465,47 @@ class ARIManager:
             return True
         return False
 
+    async def _deactivate_invalid_config(self, row, failure: DograhFailure) -> None:
+        """Park a config whose stored settings cannot work, and record why.
+
+        There is nothing to retry here, unlike a connection failure: the defect
+        is in the row itself, so re-reading it only ever reaches the same
+        verdict. Park on the first look rather than after a streak.
+        """
+        if self._should_log_validation_failure(row.id, failure.code):
+            _log_ari_failure(
+                failure,
+                organization_id=row.organization_id,
+                telephony_configuration_id=row.id,
+            )
+
+        try:
+            await db_client.set_telephony_configuration_inactive(
+                config_id=row.id,
+                organization_id=row.organization_id,
+                reason=f"{failure.code}: {failure.external_message}",
+            )
+        except Exception as e:
+            # Deliberately left active: the next refresh retries the write, which
+            # beats dropping the config on the floor with no record of why.
+            logger.error(
+                f"[ARI Manager] Failed to mark config {row.id} "
+                f"(org {row.organization_id}) inactive: {e}"
+            )
+            return
+
+        logger.warning(
+            f"[ARI Manager] Deactivated config {row.id} (org {row.organization_id}): "
+            f"{failure.internal_message}. It stays disabled until reactivated "
+            f"from the telephony settings."
+        )
+
     async def _load_ari_configs(self) -> list:
         """Load the ARI configurations the manager should be connected to now.
 
-        Rows parked by :meth:`ARIConnection._deactivate` are excluded until
-        someone reactivates them.
+        Rows parked by :meth:`ARIConnection._deactivate` or by
+        :meth:`_deactivate_invalid_config` are excluded until someone
+        reactivates them.
         """
         rows = await db_client.list_active_telephony_configurations_by_provider("ari")
 
@@ -1504,13 +1540,14 @@ class ARIManager:
                     )
                 continue
 
-            # A missing ws_client_name is not fatal to the connection itself —
-            # inbound events still arrive, only externalMedia audio is broken —
-            # so this stays a report rather than a reason to park the config.
-            if not ws_client_name and self._should_log_validation_failure(
-                row.id, "ari-missing-ws-client-name"
-            ):
-                _log_ari_failure(
+            # The websocket itself still connects without a ws_client_name, so
+            # this config looks healthy while externalMedia audio cannot be set
+            # up at all — calls are answered and the caller hears nothing. That
+            # silent half-working state is worse than being visibly off, so park
+            # it and tell the customer what to fill in.
+            if not ws_client_name:
+                await self._deactivate_invalid_config(
+                    row,
                     DograhFailure(
                         source=ErrorSource.TELEPHONY,
                         type=ErrorType.CONFIG_ERROR,
@@ -1521,9 +1558,8 @@ class ARIManager:
                         error_owner="user",
                         retryable=False,
                     ),
-                    organization_id=row.organization_id,
-                    telephony_configuration_id=row.id,
                 )
+                continue
 
             configs.append(
                 {

--- a/api/services/telephony/factory.py
+++ b/api/services/telephony/factory.py
@@ -3,13 +3,13 @@
 Resolves a provider instance from a stored telephony configuration. Three
 resolution paths exist:
 
-* by config id — the canonical path used by outbound (test calls, campaigns,
+* by active config id — the canonical path used by outbound (test calls, campaigns,
   API triggers) and by the websocket transport once a workflow run has
   ``initial_context.telephony_configuration_id`` stamped on it.
-* by org default — used as a fallback when no specific config is requested.
+* by active org default — used as a fallback when no config is requested.
 * for inbound — given a detected provider and an account-id from the webhook,
-  iterate the org's configs of that provider and return the one whose stored
-  account-id credential matches.
+  iterate the org's active configs of that provider and return the one whose
+  stored account-id credential matches.
 
 Provider classes don't need to know about the new storage shape. They still
 receive a normalized config dict containing credentials plus a
@@ -41,9 +41,9 @@ async def load_telephony_config_by_id(
 
     Returns a dict in the shape each provider class expects in its constructor
     (provider name + provider-specific credentials + ``from_numbers`` list of
-    raw address strings). Raises ``ValueError`` if the config doesn't exist
-    or doesn't belong to ``organization_id`` — the org scope is what makes
-    this safe to expose to user-driven request flows.
+    raw address strings). Raises ``ValueError`` if the config doesn't exist,
+    is parked, or doesn't belong to ``organization_id`` — the org scope is
+    what makes this safe to expose to user-driven request flows.
     """
     try:
         resolved_cfg_id = int(telephony_configuration_id)
@@ -53,25 +53,37 @@ async def load_telephony_config_by_id(
         raise ValueError("organization_id is required")
 
     row = await db_client.get_telephony_configuration_for_org(
-        resolved_cfg_id, organization_id
+        resolved_cfg_id, organization_id, active_only=True
     )
     if not row:
         raise ValueError(
             f"Telephony configuration {resolved_cfg_id} not found "
             f"for organization {organization_id}"
         )
+    if getattr(row, "inactive", False):
+        raise ValueError(
+            f"Telephony configuration {resolved_cfg_id} is inactive "
+            f"for organization {organization_id}"
+        )
     return await _normalize_with_phone_numbers(row)
 
 
 async def load_default_telephony_config(organization_id: int) -> Dict[str, Any]:
-    """Load the org's default outbound config."""
+    """Load the org's active default outbound config."""
     if not organization_id:
         raise ValueError("organization_id is required")
 
-    row = await db_client.get_default_telephony_configuration(organization_id)
+    row = await db_client.get_default_telephony_configuration(
+        organization_id, active_only=True
+    )
     if not row:
         raise ValueError(
             f"No default telephony configuration found for organization "
+            f"{organization_id}"
+        )
+    if getattr(row, "inactive", False):
+        raise ValueError(
+            f"Default telephony configuration is inactive for organization "
             f"{organization_id}"
         )
     return await _normalize_with_phone_numbers(row)
@@ -83,16 +95,21 @@ async def find_telephony_config_for_inbound(
     """Match an inbound webhook to one of the org's configs of the detected
     provider. Returns ``(config_id, normalized_config)`` or None.
 
-    Always scoped to ``organization_id`` — never matches across orgs even if
-    two orgs happen to have credentials with the same account_id.
+    Always scoped to ``organization_id`` and excludes parked rows — never
+    matches across orgs even if two orgs have credentials with the same
+    account_id.
     """
     spec = registry.get_optional(provider_name)
     if not spec:
         return None
 
     candidates = await db_client.list_telephony_configurations_by_provider(
-        organization_id, provider_name
+        organization_id, provider_name, active_only=True
     )
+    # Keep the runtime invariant at the factory boundary as well as in SQL.
+    # This protects callers backed by a stale/fake DB client and makes it
+    # impossible for normalization to turn a parked row into a live provider.
+    candidates = [c for c in candidates if not getattr(c, "inactive", False)]
     if not candidates:
         return None
 

--- a/api/services/telephony/providers/vobiz/provider.py
+++ b/api/services/telephony/providers/vobiz/provider.py
@@ -372,39 +372,34 @@ class VobizProvider(TelephonyProvider):
 
         logger.debug(f"Vobiz WebSocket connected for workflow_run {workflow_run_id}")
 
-        try:
-            # Extract stream_id and call_id from the start event
-            start_data = start_msg.get("start", {})
-            stream_id = start_data.get("streamId")
-            call_id = start_data.get("callId")
+        # Extract stream_id and call_id from the start event
+        start_data = start_msg.get("start", {})
+        stream_id = start_data.get("streamId")
+        call_id = start_data.get("callId")
 
-            if not stream_id or not call_id:
-                logger.error(f"Missing streamId or callId in start event: {start_data}")
-                await websocket.close(code=4400, reason="Missing streamId or callId")
-                return
+        if not stream_id or not call_id:
+            logger.error(f"Missing streamId or callId in start event: {start_data}")
+            await websocket.close(code=4400, reason="Missing streamId or callId")
+            return
 
-            logger.info(
-                f"[run {workflow_run_id}] Starting Vobiz WebSocket handler - "
-                f"stream_id: {stream_id}, call_id: {call_id}"
-            )
+        logger.info(
+            f"[run {workflow_run_id}] Starting Vobiz WebSocket handler - "
+            f"stream_id: {stream_id}, call_id: {call_id}"
+        )
 
-            await run_pipeline_telephony(
-                websocket,
-                provider_name=self.PROVIDER_NAME,
-                workflow_id=workflow_id,
-                workflow_run_id=workflow_run_id,
-                organization_id=organization_id,
-                call_id=call_id,
-                transport_kwargs={"stream_id": stream_id, "call_id": call_id},
-            )
+        # Failures propagate untouched: the pipeline reports them with the
+        # traceback, and catching to re-log here would split one failure in two.
+        await run_pipeline_telephony(
+            websocket,
+            provider_name=self.PROVIDER_NAME,
+            workflow_id=workflow_id,
+            workflow_run_id=workflow_run_id,
+            organization_id=organization_id,
+            call_id=call_id,
+            transport_kwargs={"stream_id": stream_id, "call_id": call_id},
+        )
 
-            logger.info(f"[run {workflow_run_id}] Vobiz pipeline completed")
-
-        except Exception as e:
-            logger.error(
-                f"[run {workflow_run_id}] Error in Vobiz WebSocket handler: {e}"
-            )
-            raise
+        logger.info(f"[run {workflow_run_id}] Vobiz pipeline completed")
 
     # ======== INBOUND CALL METHODS ========
 

--- a/api/tests/telephony/test_ari_deactivation.py
+++ b/api/tests/telephony/test_ari_deactivation.py
@@ -17,6 +17,10 @@ class _FakeDBClient:
     def __init__(self):
         self.deactivated = []
         self.reactivated = []
+        self.rows = []
+
+    async def list_active_telephony_configurations_by_provider(self, provider):
+        return self.rows
 
     async def set_telephony_configuration_inactive(
         self, config_id, organization_id, reason
@@ -226,6 +230,66 @@ async def test_immediate_clean_close_is_accounted_as_a_failure(
     assert logged[0][0].code == "ari-closed-immediately"
     # Backoff must have grown rather than spinning at the initial delay.
     assert conn._reconnect_delay > 1
+
+
+def _row(config_id: int, ws_client_name: str = "dograh_ws") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=config_id,
+        organization_id=100 + config_id,
+        credentials={
+            "ari_endpoint": "http://pbx.example.com:8088",
+            "app_name": "dograh",
+            "app_password": "secret",
+            "ws_client_name": ws_client_name,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_ws_client_name_parks_the_config(clock, db, logged):
+    """The socket would connect, but externalMedia audio can never be set up."""
+    db.rows = [_row(1, ws_client_name=""), _row(2)]
+    manager = ari_manager.ARIManager()
+
+    configs = await manager._load_ari_configs()
+
+    # The broken row is dropped from the active set; the healthy one survives.
+    assert [c["telephony_configuration_id"] for c in configs] == [2]
+    assert len(db.deactivated) == 1
+    config_id, organization_id, reason = db.deactivated[0]
+    assert (config_id, organization_id) == (1, 101)
+    assert reason.startswith("ari-missing-ws-client-name:")
+    assert logged[0][0].code == "ari-missing-ws-client-name"
+
+
+@pytest.mark.asyncio
+async def test_missing_ws_client_name_parks_on_the_first_look(clock, db, logged):
+    """No streak to build: re-reading the row can only reach the same verdict."""
+    db.rows = [_row(1, ws_client_name="")]
+    manager = ari_manager.ARIManager()
+
+    await manager._load_ari_configs()
+
+    assert len(db.deactivated) == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_park_write_leaves_the_row_for_the_next_refresh(
+    clock, logged, monkeypatch
+):
+    class _BrokenDBClient(_FakeDBClient):
+        async def set_telephony_configuration_inactive(self, *_args, **_kwargs):
+            raise RuntimeError("database unavailable")
+
+    broken = _BrokenDBClient()
+    broken.rows = [_row(1, ws_client_name="")]
+    monkeypatch.setattr(ari_manager, "db_client", broken)
+    manager = ari_manager.ARIManager()
+
+    # Still excluded, so no half-working connection is started meanwhile, and
+    # nothing was recorded — the row returns next refresh and the write retries.
+    assert await manager._load_ari_configs() == []
+    assert broken.deactivated == []
 
 
 def test_validation_failures_are_throttled_per_config(clock):

--- a/api/tests/telephony/test_inactive_config_routing.py
+++ b/api/tests/telephony/test_inactive_config_routing.py
@@ -1,0 +1,116 @@
+from uuid import uuid4
+
+import pytest
+
+from api.db.models import (
+    OrganizationModel,
+    TelephonyConfigurationModel,
+    TelephonyPhoneNumberModel,
+)
+
+
+@pytest.mark.asyncio
+async def test_runtime_configuration_queries_exclude_inactive_rows(
+    async_session, db_session
+):
+    organization = OrganizationModel(provider_id=f"inactive-routing-{uuid4()}")
+    async_session.add(organization)
+    await async_session.flush()
+
+    inactive = TelephonyConfigurationModel(
+        organization_id=organization.id,
+        name="Parked ARI",
+        provider="ari",
+        credentials={},
+        is_default_outbound=True,
+        inactive=True,
+    )
+    active = TelephonyConfigurationModel(
+        organization_id=organization.id,
+        name="Active ARI",
+        provider="ari",
+        credentials={},
+        is_default_outbound=False,
+        inactive=False,
+    )
+    async_session.add_all([inactive, active])
+    await async_session.flush()
+
+    assert (
+        await db_session.get_telephony_configuration_for_org(
+            inactive.id, organization.id
+        )
+        is None
+    )
+    assert (
+        await db_session.get_telephony_configuration_for_org(
+            inactive.id, organization.id, active_only=False
+        )
+    ).id == inactive.id
+
+    assert await db_session.get_default_telephony_configuration(organization.id) is None
+    assert (
+        await db_session.get_default_telephony_configuration(
+            organization.id, active_only=False
+        )
+    ).id == inactive.id
+
+    active_candidates = await db_session.list_telephony_configurations_by_provider(
+        organization.id, "ari"
+    )
+    assert [row.id for row in active_candidates] == [active.id]
+
+    all_candidates = await db_session.list_telephony_configurations_by_provider(
+        organization.id, "ari", active_only=False
+    )
+    assert {row.id for row in all_candidates} == {inactive.id, active.id}
+
+
+@pytest.mark.asyncio
+async def test_inbound_route_queries_exclude_inactive_configuration(
+    async_session, db_session
+):
+    organization = OrganizationModel(provider_id=f"inactive-inbound-{uuid4()}")
+    async_session.add(organization)
+    await async_session.flush()
+
+    config = TelephonyConfigurationModel(
+        organization_id=organization.id,
+        name="Parked Twilio",
+        provider="twilio",
+        credentials={"account_sid": "AC-parked"},
+        is_default_outbound=True,
+        inactive=True,
+    )
+    async_session.add(config)
+    await async_session.flush()
+
+    phone_number = TelephonyPhoneNumberModel(
+        organization_id=organization.id,
+        telephony_configuration_id=config.id,
+        address="+15551234567",
+        address_normalized="+15551234567",
+        address_type="phone",
+        is_active=True,
+    )
+    async_session.add(phone_number)
+    await async_session.flush()
+
+    assert (
+        await db_session.find_active_phone_number_for_inbound(
+            organization.id,
+            "+15551234567",
+            "twilio",
+        )
+        is None
+    )
+    assert (
+        await db_session.find_inbound_route_by_account(
+            provider="twilio",
+            account_id_field="account_sid",
+            account_id="AC-parked",
+            to_number="+15551234567",
+            organization_id=organization.id,
+        )
+        is None
+    )

--- a/api/tests/test_failure_classification.py
+++ b/api/tests/test_failure_classification.py
@@ -13,8 +13,10 @@ from api.errors.failure import (
     annotate_failure_metadata,
     classify_exception,
     classify_http_response,
+    failure_already_reported,
     failure_metadata_for_processor,
     log_failure,
+    mark_failure_reported,
     redact_failure_message,
 )
 from api.services.configuration.registry import REGISTRY, ServiceType
@@ -32,7 +34,10 @@ from api.services.configuration.registry import REGISTRY, ServiceType
         (408, ErrorType.PROVIDER_ERROR, True),
         (500, ErrorType.PROVIDER_ERROR, True),
         (503, ErrorType.PROVIDER_ERROR, True),
-        (302, ErrorType.SYSTEM_ERROR, None),
+        # A redirect means the configured URL was the wrong one to give us.
+        (301, ErrorType.CONFIG_ERROR, False),
+        (302, ErrorType.CONFIG_ERROR, False),
+        (307, ErrorType.CONFIG_ERROR, False),
     ],
 )
 def test_classify_http_response_status_bands(status_code, expected_type, retryable):
@@ -47,12 +52,8 @@ def test_classify_http_response_status_bands(status_code, expected_type, retryab
     assert failure.type == expected_type
     assert failure.code == f"deepgram-{status_code}"
     assert failure.retryable is retryable
-    expected_owner = (
-        ErrorOwner.OPERATOR
-        if expected_type == ErrorType.SYSTEM_ERROR
-        else ErrorOwner.USER
-    )
-    assert failure.error_owner == expected_owner
+    # The caller declared the user, and nothing here overrides that.
+    assert failure.error_owner == ErrorOwner.USER
 
 
 @pytest.mark.parametrize(
@@ -63,7 +64,14 @@ def test_classify_http_response_status_bands(status_code, expected_type, retryab
         (ErrorType.PROVIDER_ERROR, ErrorOwner.USER, ErrorOwner.USER),
         (ErrorType.PROVIDER_ERROR, ErrorOwner.OPERATOR, ErrorOwner.OPERATOR),
         (ErrorType.PROVIDER_ERROR, None, ErrorOwner.OPERATOR),
-        (ErrorType.SYSTEM_ERROR, ErrorOwner.USER, ErrorOwner.OPERATOR),
+        # A seam that knows whose credentials were in play outranks the type:
+        # an unclassifiable error from a customer's provider is still theirs.
+        (ErrorType.SYSTEM_ERROR, ErrorOwner.USER, ErrorOwner.USER),
+        (ErrorType.SYSTEM_ERROR, ErrorOwner.OPERATOR, ErrorOwner.OPERATOR),
+        (ErrorType.SYSTEM_ERROR, None, ErrorOwner.OPERATOR),
+        # config/quota stay user-owned however the caller argues.
+        (ErrorType.CONFIG_ERROR, ErrorOwner.OPERATOR, ErrorOwner.USER),
+        (ErrorType.QUOTA_ERROR, ErrorOwner.OPERATOR, ErrorOwner.USER),
     ],
 )
 def test_failure_resolves_binary_owner(error_type, requested_owner, expected_owner):
@@ -457,3 +465,45 @@ def test_http_status_embedded_in_exception_text_is_classified(
 
     assert failure.type == expected_type
     assert failure.code == expected_code
+
+
+def test_reported_mark_travels_with_the_exception():
+    """One failure gets one report, however many layers it passes through."""
+    exc = RuntimeError("pipeline blew up")
+    assert failure_already_reported(exc) is False
+
+    mark_failure_reported(exc)
+
+    assert failure_already_reported(exc) is True
+
+
+def test_reported_mark_survives_a_reraise():
+    inner = ValueError("boom")
+
+    def failing_layer():
+        raise inner
+
+    def reporting_layer():
+        try:
+            failing_layer()
+        except Exception as e:
+            mark_failure_reported(e)
+            raise
+
+    with pytest.raises(ValueError) as caught:
+        reporting_layer()
+
+    # The outer catch-all can tell this was already accounted for.
+    assert failure_already_reported(caught.value) is True
+
+
+def test_marking_an_exception_that_rejects_attributes_is_survivable():
+    class _Unsettable(Exception):
+        def __setattr__(self, name, value):
+            raise AttributeError("attributes are not accepted")
+
+    exc = _Unsettable("no attribute storage")
+    mark_failure_reported(exc)
+
+    # Losing the mark costs a duplicate line; it must never raise.
+    assert failure_already_reported(exc) is False

--- a/api/tests/test_sarvam_service_factory.py
+++ b/api/tests/test_sarvam_service_factory.py
@@ -23,12 +23,14 @@ class TestSarvamLLMConfiguration:
     def test_default_values(self):
         config = SarvamLLMConfiguration(api_key="test-key")
         assert config.provider == ServiceProviders.SARVAM
-        assert config.model == "sarvam-30b"
+        assert config.model == "sarvam-105b"
         assert config.temperature == 0.5
 
     def test_custom_model(self):
-        config = SarvamLLMConfiguration(api_key="test-key", model="sarvam-105b")
-        assert config.model == "sarvam-105b"
+        # allow_custom_input is set, so a model outside the catalog is accepted
+        # here and validated by the service instead.
+        config = SarvamLLMConfiguration(api_key="test-key", model="sarvam-future")
+        assert config.model == "sarvam-future"
 
 
 class TestSarvamLLMServiceFactory:
@@ -39,14 +41,14 @@ class TestSarvamLLMServiceFactory:
             mock_service.Settings = RealSarvamLLMService.Settings
             create_llm_service_from_provider(
                 provider=ServiceProviders.SARVAM.value,
-                model="sarvam-30b",
+                model="sarvam-105b",
                 api_key="test-key",
             )
 
         assert mock_service.call_count == 1
         kwargs = mock_service.call_args.kwargs
         assert kwargs["api_key"] == "test-key"
-        assert kwargs["settings"].model == "sarvam-30b"
+        assert kwargs["settings"].model == "sarvam-105b"
         assert kwargs["settings"].temperature == 0.5
 
     def test_create_sarvam_llm_service_passes_user_temperature(self):
@@ -56,7 +58,7 @@ class TestSarvamLLMServiceFactory:
             mock_service.Settings = RealSarvamLLMService.Settings
             create_llm_service_from_provider(
                 provider=ServiceProviders.SARVAM.value,
-                model="sarvam-30b",
+                model="sarvam-105b",
                 api_key="test-key",
                 temperature=0.8,
             )
@@ -68,7 +70,7 @@ class TestSarvamLLMServiceFactory:
         user_config = SimpleNamespace(
             llm=SimpleNamespace(
                 provider=ServiceProviders.SARVAM.value,
-                model="sarvam-30b",
+                model="sarvam-105b",
                 api_key="test-key",
                 temperature=0.7,
             )

--- a/api/tests/test_telephony_factory.py
+++ b/api/tests/test_telephony_factory.py
@@ -5,8 +5,10 @@ import pytest
 
 from api.services.telephony.factory import (
     _normalize_with_phone_numbers,
+    find_telephony_config_for_inbound,
     get_telephony_provider_for_run,
     load_credentials_for_transport,
+    load_default_telephony_config,
     load_telephony_config_by_id,
 )
 
@@ -76,7 +78,7 @@ async def test_load_credentials_for_transport_casts_numeric_string_config_id():
 
 @pytest.mark.asyncio
 async def test_load_telephony_config_by_id_casts_numeric_string_before_db_lookup():
-    row = SimpleNamespace(id=213)
+    row = SimpleNamespace(id=213, inactive=False)
 
     with (
         patch(
@@ -93,8 +95,84 @@ async def test_load_telephony_config_by_id_casts_numeric_string_before_db_lookup
         result = await load_telephony_config_by_id("213", 2617)
 
     assert result == {"provider": "twilio"}
-    get_config.assert_awaited_once_with(213, 2617)
+    get_config.assert_awaited_once_with(213, 2617, active_only=True)
     normalize.assert_awaited_once_with(row)
+
+
+@pytest.mark.asyncio
+async def test_load_telephony_config_by_id_rejects_inactive_row():
+    row = SimpleNamespace(id=213, inactive=True)
+
+    with (
+        patch(
+            "api.services.telephony.factory.db_client.get_telephony_configuration_for_org",
+            new_callable=AsyncMock,
+            return_value=row,
+        ) as get_config,
+        patch(
+            "api.services.telephony.factory._normalize_with_phone_numbers",
+            new_callable=AsyncMock,
+        ) as normalize,
+        pytest.raises(ValueError, match="configuration 213 is inactive"),
+    ):
+        await load_telephony_config_by_id(213, 2617)
+
+    get_config.assert_awaited_once_with(213, 2617, active_only=True)
+    normalize.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_load_default_telephony_config_rejects_inactive_row():
+    row = SimpleNamespace(id=213, inactive=True)
+
+    with (
+        patch(
+            "api.services.telephony.factory.db_client.get_default_telephony_configuration",
+            new_callable=AsyncMock,
+            return_value=row,
+        ) as get_default,
+        patch(
+            "api.services.telephony.factory._normalize_with_phone_numbers",
+            new_callable=AsyncMock,
+        ) as normalize,
+        pytest.raises(ValueError, match="configuration is inactive"),
+    ):
+        await load_default_telephony_config(2617)
+
+    get_default.assert_awaited_once_with(2617, active_only=True)
+    normalize.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_find_telephony_config_for_inbound_excludes_inactive_ari_row():
+    row = SimpleNamespace(
+        id=213,
+        inactive=True,
+        is_default_outbound=True,
+        credentials={"provider": "ari"},
+    )
+    spec = SimpleNamespace(account_id_credential_field="")
+
+    with (
+        patch(
+            "api.services.telephony.factory.registry.get_optional",
+            return_value=spec,
+        ),
+        patch(
+            "api.services.telephony.factory.db_client.list_telephony_configurations_by_provider",
+            new_callable=AsyncMock,
+            return_value=[row],
+        ) as list_configs,
+        patch(
+            "api.services.telephony.factory._normalize_with_phone_numbers",
+            new_callable=AsyncMock,
+        ) as normalize,
+    ):
+        match = await find_telephony_config_for_inbound(2617, "ari", None)
+
+    assert match is None
+    list_configs.assert_awaited_once_with(2617, "ari", active_only=True)
+    normalize.assert_not_awaited()
 
 
 def _config_row() -> SimpleNamespace:


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve failure triage and routing by parking invalid ARI configs and excluding inactive configs from runtime selection. Suppress duplicate logs, clarify owners, update `pipecat`, and remove Sarvam `sarvam-30b` to prevent broken runs.

- **Bug Fixes**
  - Ownership: `config_error` and `quota_error` are user-owned; respect seam-declared owners for others; fall back to operator only when unset.
  - HTTP classification: 3xx mapped to `CONFIG_ERROR` (non-retryable).
  - Duplicate logging: `mark_failure_reported`/`failure_already_reported`; pipeline logs once (with traceback); telephony websocket and Vobiz stop re-logging.
  - Runtime routing: inactive configs are excluded by default; added `active_only` filters to DB lookups; factory rejects parked rows for load-by-id/default; inbound phone/account lookups skip parked configs; management endpoints opt in with `active_only=false`.
  - Sarvam: align with `pipecat`; default to `sarvam-105b`; remove `sarvam-30b`; allow custom model input (validated by the service).

- **New Features**
  - ARI Manager: deactivates configs missing `ws_client_name`, logs `ari-missing-ws-client-name`, records the reason, and keeps them out of active connections until reactivated. If the DB write fails, the config stays active and is retried on the next refresh.

<sup>Written for commit 155ce4b02997448e0043b99b03345311456879a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The update changes telephony configuration handling and updates Sarvam defaults to `sarvam-105b`. Existing saved V2 BYOK configurations can still retain `sarvam-30b`, which is forwarded to a Sarvam service that no longer accepts it and can prevent calls from starting.

## T-Rex validation blocked

The focused reproduction could not complete because the required Python package `docstring_parser` is missing. Importing the real Pipecat-backed LLM factory stopped with `ModuleNotFoundError` before service initialization could be exercised.

<h3>Confidence Score: 4/5</h3>

Existing saved Sarvam configurations using the retired model can fail when a call starts.

One non-security blocking failure remains: persisted `sarvam-30b` values are still accepted and reach a runtime service that supports only `sarvam-105b`.

**Files Needing Attention:** api/services/configuration/registry.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to reproduce the persisted Sarvam configuration by running the reproduction script from the repository with the specified database URL and Redis URL.
- The reproduction terminated with exit code 1 due to a ModuleNotFoundError: No module named 'docstring\_parser' when importing the real service factory.
- Artifacts for review were generated: the Persisted V2 Sarvam reproduction source and the Blocked reproduction terminal output.

<a href="https://app.greptile.com/trex/runs/17654045/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["chore: incorporate review comment"](https://github.com/dograh-hq/dograh/commit/155ce4b02997448e0043b99b03345311456879a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50814013)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->