### PR TITLE
feat(files): add support for uploading Markdown (.md) documents

### DIFF
--- a/api/tests/test_md_document_upload.py
+++ b/api/tests/test_md_document_upload.py
@@ -1,0 +1,9 @@
+"""Tests for Markdown (.md) document upload and MIME type detection."""
+
+from api.db.knowledge_base_client import KnowledgeBaseClient
+
+
+def test_markdown_file_mime_type_resolution():
+    assert KnowledgeBaseClient.get_mime_type("document.md") == "text/markdown"
+    assert KnowledgeBaseClient.get_mime_type("README.MD") == "text/markdown"
+    assert KnowledgeBaseClient.get_mime_type("/path/to/notes.md") == "text/markdown"

--- a/ui/src/app/files/DocumentUpload.tsx
+++ b/ui/src/app/files/DocumentUpload.tsx
@@ -21,7 +21,7 @@ interface DocumentUploadProps {
 }
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
-const ACCEPTED_FILE_TYPES = ['.pdf', '.docx', '.doc', '.txt', '.json'];
+const ACCEPTED_FILE_TYPES = ['.pdf', '.docx', '.doc', '.txt', '.json', '.md'];
 
 export default function DocumentUpload({ onUploadSuccess }: DocumentUploadProps) {
   const { config } = useAppConfig();


### PR DESCRIPTION
## Summary
Adds support for uploading Markdown (`.md`) files in the Files / Knowledge Base section of Dograh AI (`/files`), allowing developers to upload markdown documentation and notes to their organization's knowledge base for AI voice workflow retrieval.

## Key Changes

### 1. Frontend File Upload (`ui/src/app/files/DocumentUpload.tsx`)
- Added `.md` extension to `ACCEPTED_FILE_TYPES`:
  ```typescript
  const ACCEPTED_FILE_TYPES = ['.pdf', '.docx', '.doc', '.txt', '.json', '.md'];


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for uploading Markdown (.md) files in Files / Knowledge Base (/files). Updated accepted file types in `ui/src/app/files/DocumentUpload.tsx` and added tests to verify `.md` resolves to `text/markdown` via `KnowledgeBaseClient`.

<sup>Written for commit 05dceae69537bb46bddec76e8bce50cca77dee97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change allows Markdown files in the document upload interface and adds backend checks for Markdown MIME resolution. The upload component was rendered successfully and shows Markdown in both its supported-format text and its file chooser filter, so the report that Markdown is undocumented was disproved.

The added API test does not protect the user-facing upload behavior: removing `.md` from the UI allowlist makes Markdown selection fail while `api/tests/test_md_document_upload.py` still passes. Add a UI-level regression test for selecting a Markdown file before merging.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until the Markdown upload behavior is covered by a UI regression test.

The reproduced issue is limited to test coverage, but it leaves the newly enabled user-facing Markdown selection behavior unprotected against regression. The visible-format documentation concern was directly disproved by rendering the component.

**Files Needing Attention:** Add UI coverage for `ui/src/app/files/DocumentUpload.tsx`; the existing assertions in `api/tests/test_md_document_upload.py` only verify backend MIME resolution.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Created a reversible UI and API comparison harness to validate Markdown file handling in the document upload flow.
- Observed that baseline Markdown selection was accepted by the document upload UI, and after the allowlist was removed, Markdown was rejected while the API test still passed.
- Posted an additional P1 finding comment for another review.
- Summarized baseline vs modified allowlist results and recommended adding a UI component test to cover Markdown file selection instead of relying solely on backend MIME mapping.
- Executed a Vitest run to verify that Markdown is included in the user-visible upload documentation, and confirmed the relevant assertions passed.

<a href="https://app.greptile.com/trex/runs/17872339/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Markdown upload UI behavior has no regression test**

   - **Bug**
     - `api/tests/test_md_document_upload.py` only calls `KnowledgeBaseClient.get_mime_type`; it does not render or exercise `DocumentUpload`. The focused modified run removed `.md` from the UI allowlist, rejected `notes.md` in the UI, and still passed the API test.
   - **Cause**
     - The new test is located in `api/tests/` and asserts backend MIME resolution only, while the feature change is the UI `ACCEPTED_FILE_TYPES` allowlist.
   - **Fix**
     - Add a Vitest component test for `DocumentUpload` that selects a `File` named `notes.md` and asserts it is accepted/rendered (and optionally assert the hidden input has an `accept` value containing `.md`).

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(files): add support for uploading M..."](https://github.com/dograh-hq/dograh/commit/05dceae69537bb46bddec76e8bce50cca77dee97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51319968)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->