### PR TITLE
fix(qa): prevent grader truncation

### DIFF
--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -948,6 +948,7 @@ def create_llm_service_from_provider(
     location: str | None = None,
     credentials: str | None = None,
     temperature: float | None = None,
+    max_tokens: int | None = None,
     bill_to: str | None = None,
     usage_context: str | None = None,
 ):
@@ -1000,9 +1001,18 @@ def create_llm_service_from_provider(
         )
     elif provider == ServiceProviders.GOOGLE.value:
         model = _migrate_deprecated_google_model(model)
+        google_settings_kwargs: dict = {"model": model, "temperature": 0.1}
+        if max_tokens is not None:
+            # Give the grader a large explicit output ceiling and cap "thinking"
+            # so the reasoning budget can't crowd out the answer. Gemini's default
+            # (4096, shared with dynamic thinking) truncated long QA-grader JSON.
+            google_settings_kwargs["max_tokens"] = max_tokens
+            google_settings_kwargs["thinking"] = GoogleLLMService.ThinkingConfig(
+                thinking_budget=4096
+            )
         return DograhGoogleLLMService(
             api_key=api_key,
-            settings=GoogleLLMSettings(model=model, temperature=0.1),
+            settings=GoogleLLMSettings(**google_settings_kwargs),
         )
     elif provider == ServiceProviders.GOOGLE_VERTEX.value:
         return DograhGoogleVertexLLMService(
@@ -1282,6 +1292,7 @@ def create_llm_service(
     user_config,
     correlation_id: str | None = None,
     usage_context: str | None = None,
+    max_tokens: int | None = None,
 ):
     """Create and return appropriate LLM service based on user configuration."""
     provider = user_config.llm.provider
@@ -1323,6 +1334,7 @@ def create_llm_service(
         api_key,
         correlation_id=correlation_id,
         usage_context=usage_context,
+        max_tokens=max_tokens,
         **kwargs,
     )
 
@@ -1332,6 +1344,7 @@ def create_llm_service_with_model_override(
     model_override: str | None,
     correlation_id: str | None = None,
     usage_context: str | None = None,
+    max_tokens: int | None = None,
 ):
     """Create an LLM service with an optional model override.
 
@@ -1343,6 +1356,7 @@ def create_llm_service_with_model_override(
             user_config,
             correlation_id=correlation_id,
             usage_context=usage_context,
+            max_tokens=max_tokens,
         )
 
     if user_config.llm is None:
@@ -1354,4 +1368,5 @@ def create_llm_service_with_model_override(
         overridden_config,
         correlation_id=correlation_id,
         usage_context=usage_context,
+        max_tokens=max_tokens,
     )

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -937,14 +937,16 @@ def _google_thinking_for_model(model: str):
     """Return a thinking config compatible with the resolved Google model.
 
     Gemini 2.5 uses ``thinking_budget``; Gemini 3 uses ``thinking_level`` — the
-    two must not be mixed. For unknown/legacy/custom model identifiers we return
-    ``None`` so no (possibly unsupported) thinking config is sent, and the raised
-    ``max_tokens`` ceiling alone protects the grader output from truncation.
+    two must not be mixed. We match on the model-family *prefix* and return
+    ``None`` for any id that isn't a recognized Gemini 2.5/3 family (custom,
+    legacy, or future, including ids that merely embed the family name), so an
+    unsupported thinking config is never sent; the raised ``max_tokens`` ceiling
+    alone then guards against truncation.
     """
-    ml = (model or "").lower()
-    if "gemini-2.5" in ml or "gemini-2-5" in ml:
+    ml = (model or "").strip().lower()
+    if ml.startswith("gemini-2.5") or ml.startswith("gemini-2-5"):
         return GoogleLLMService.ThinkingConfig(thinking_budget=4096)
-    if "gemini-3" in ml:
+    if ml.startswith("gemini-3"):
         return GoogleLLMService.ThinkingConfig(thinking_level="low")
     return None
 

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -933,6 +933,22 @@ def _migrate_deprecated_google_model(model: str) -> str:
 
 
 @_report_service_factory_failures(ErrorSource.LLM, provider_argument=0)
+def _google_thinking_for_model(model: str):
+    """Return a thinking config compatible with the resolved Google model.
+
+    Gemini 2.5 uses ``thinking_budget``; Gemini 3 uses ``thinking_level`` — the
+    two must not be mixed. For unknown/legacy/custom model identifiers we return
+    ``None`` so no (possibly unsupported) thinking config is sent, and the raised
+    ``max_tokens`` ceiling alone protects the grader output from truncation.
+    """
+    ml = (model or "").lower()
+    if "gemini-2.5" in ml or "gemini-2-5" in ml:
+        return GoogleLLMService.ThinkingConfig(thinking_budget=4096)
+    if "gemini-3" in ml:
+        return GoogleLLMService.ThinkingConfig(thinking_level="low")
+    return None
+
+
 def create_llm_service_from_provider(
     provider: str,
     model: str,
@@ -1003,23 +1019,33 @@ def create_llm_service_from_provider(
         model = _migrate_deprecated_google_model(model)
         google_settings_kwargs: dict = {"model": model, "temperature": 0.1}
         if max_tokens is not None:
-            # Give the grader a large explicit output ceiling and cap "thinking"
-            # so the reasoning budget can't crowd out the answer. Gemini's default
-            # (4096, shared with dynamic thinking) truncated long QA-grader JSON.
+            # Give the grader a large explicit output ceiling and bound "thinking"
+            # so the reasoning budget can't crowd out the answer (Gemini's default
+            # 4096, shared with dynamic thinking, truncated long QA-grader JSON).
+            # Pick the thinking knob that matches the model family (2.5 -> budget,
+            # 3 -> level; omit for unknown/legacy) via _google_thinking_for_model.
             google_settings_kwargs["max_tokens"] = max_tokens
-            google_settings_kwargs["thinking"] = GoogleLLMService.ThinkingConfig(
-                thinking_budget=4096
-            )
+            thinking = _google_thinking_for_model(model)
+            if thinking is not None:
+                google_settings_kwargs["thinking"] = thinking
         return DograhGoogleLLMService(
             api_key=api_key,
             settings=GoogleLLMSettings(**google_settings_kwargs),
         )
     elif provider == ServiceProviders.GOOGLE_VERTEX.value:
+        vertex_settings_kwargs: dict = {"model": model, "temperature": 0.1}
+        if max_tokens is not None:
+            # Same truncation guard as the Google branch: raise the output
+            # ceiling and bound thinking with the model-family-appropriate knob.
+            vertex_settings_kwargs["max_tokens"] = max_tokens
+            thinking = _google_thinking_for_model(model)
+            if thinking is not None:
+                vertex_settings_kwargs["thinking"] = thinking
         return DograhGoogleVertexLLMService(
             credentials=credentials,
             project_id=project_id,
             location=location or "us-east4",
-            settings=GoogleVertexLLMSettings(model=model, temperature=0.1),
+            settings=GoogleVertexLLMSettings(**vertex_settings_kwargs),
         )
     elif provider == ServiceProviders.AZURE.value:
         if endpoint:

--- a/api/services/workflow/qa/llm_config.py
+++ b/api/services/workflow/qa/llm_config.py
@@ -14,6 +14,10 @@ from api.services.pipecat.service_factory import (
 from api.services.workflow.dto import QANodeData
 
 QA_USAGE_CONTEXT = "qa_analysis"
+# Explicit output ceiling for QA grader inference. Google/Anthropic default to
+# 4096 output tokens (shared with dynamic thinking on Gemini), truncating long
+# grading JSON. A generous ceiling + bounded thinking lets a full grade complete.
+QA_MAX_OUTPUT_TOKENS = 16384
 
 
 async def create_qa_llm_service(
@@ -47,6 +51,7 @@ async def create_qa_llm_service(
             api_key,
             correlation_id=correlation_id,
             usage_context=QA_USAGE_CONTEXT,
+            max_tokens=QA_MAX_OUTPUT_TOKENS,
             **kwargs,
         )
         return llm, model
@@ -75,6 +80,7 @@ async def create_qa_llm_service(
         model_override,
         correlation_id=correlation_id,
         usage_context=QA_USAGE_CONTEXT,
+        max_tokens=QA_MAX_OUTPUT_TOKENS,
     )
     return llm, model
 

--- a/api/tests/test_google_thinking_config.py
+++ b/api/tests/test_google_thinking_config.py
@@ -1,0 +1,29 @@
+"""Regression test: QA-grader thinking config must match the Google model family.
+
+``thinking_budget`` is only valid for Gemini 2.5; Gemini 3 uses ``thinking_level``,
+and the two must not be mixed. Unknown/legacy/custom models must get no thinking
+config at all, so an unsupported setting can't make the grader reject the request
+(the raised ``max_tokens`` ceiling alone still guards against truncation).
+"""
+
+from api.services.pipecat.service_factory import _google_thinking_for_model
+
+
+def test_gemini_25_uses_thinking_budget():
+    tc = _google_thinking_for_model("gemini-2.5-flash")
+    assert tc is not None
+    assert tc.thinking_budget == 4096
+    assert getattr(tc, "thinking_level", None) is None
+
+
+def test_gemini_3_uses_thinking_level():
+    tc = _google_thinking_for_model("gemini-3-pro-preview")
+    assert tc is not None
+    assert tc.thinking_level == "low"
+    assert tc.thinking_budget is None
+
+
+def test_unknown_or_legacy_model_omits_thinking():
+    assert _google_thinking_for_model("gemini-1.5-pro") is None
+    assert _google_thinking_for_model("some-custom-model") is None
+    assert _google_thinking_for_model("") is None

--- a/api/tests/test_google_thinking_config.py
+++ b/api/tests/test_google_thinking_config.py
@@ -1,12 +1,22 @@
 """Regression test: QA-grader thinking config must match the Google model family.
 
 ``thinking_budget`` is only valid for Gemini 2.5; Gemini 3 uses ``thinking_level``,
-and the two must not be mixed. Unknown/legacy/custom models must get no thinking
-config at all, so an unsupported setting can't make the grader reject the request
-(the raised ``max_tokens`` ceiling alone still guards against truncation).
+and the two must not be mixed. Any id that isn't a recognized 2.5/3 family (custom,
+legacy, future, or one that merely embeds the family name) must get no thinking
+config, so an unsupported setting can't make the grader reject the request — the
+raised ``max_tokens`` ceiling alone still guards against truncation.
+
+The last test exercises the real wiring: the QA ``max_tokens`` plus the guarded
+thinking config must build valid Google *and* Vertex settings.
 """
 
-from api.services.pipecat.service_factory import _google_thinking_for_model
+from api.services.pipecat.service_factory import (
+    GoogleLLMSettings,
+    GoogleVertexLLMSettings,
+    _google_thinking_for_model,
+)
+
+QA_MAX_TOKENS = 16384
 
 
 def test_gemini_25_uses_thinking_budget():
@@ -16,6 +26,11 @@ def test_gemini_25_uses_thinking_budget():
     assert getattr(tc, "thinking_level", None) is None
 
 
+def test_gemini_25_revision_still_matches():
+    # dated/preview revisions still start with the family prefix
+    assert _google_thinking_for_model("gemini-2.5-flash-002").thinking_budget == 4096
+
+
 def test_gemini_3_uses_thinking_level():
     tc = _google_thinking_for_model("gemini-3-pro-preview")
     assert tc is not None
@@ -23,7 +38,37 @@ def test_gemini_3_uses_thinking_level():
     assert tc.thinking_budget is None
 
 
-def test_unknown_or_legacy_model_omits_thinking():
-    assert _google_thinking_for_model("gemini-1.5-pro") is None
-    assert _google_thinking_for_model("some-custom-model") is None
-    assert _google_thinking_for_model("") is None
+def test_unknown_legacy_or_embedded_substring_omits_thinking():
+    # legacy family, a custom id, ids that only *contain* the family name, empty
+    for m in (
+        "gemini-1.5-pro",
+        "some-custom-model",
+        "acme-gemini-2.5-wrapper",
+        "x-gemini-3-y",
+        "",
+    ):
+        assert _google_thinking_for_model(m) is None, m
+
+
+def test_qa_settings_accept_max_tokens_and_family_thinking():
+    """The real wiring: QA max_tokens + guarded thinking build valid settings."""
+    for Settings in (GoogleLLMSettings, GoogleVertexLLMSettings):
+        tc = _google_thinking_for_model("gemini-2.5-flash")
+        s = Settings(
+            model="gemini-2.5-flash",
+            temperature=0.1,
+            max_tokens=QA_MAX_TOKENS,
+            thinking=tc,
+        )
+        assert s.max_tokens == QA_MAX_TOKENS
+        assert s.thinking is not None and s.thinking.thinking_budget == 4096
+
+        # legacy model: max_tokens still applied, no thinking config attached
+        legacy = Settings(
+            model="gemini-1.5-pro",
+            temperature=0.1,
+            max_tokens=QA_MAX_TOKENS,
+            thinking=_google_thinking_for_model("gemini-1.5-pro"),
+        )
+        assert legacy.max_tokens == QA_MAX_TOKENS
+        assert legacy.thinking is None


### PR DESCRIPTION
The QA grader inherits the default 4096 output-token ceiling, which on Gemini is shared with dynamic thinking, so long grading JSON is cut off mid-object, fails to parse, and score/summary come back empty. 

Thread an optional max_tokens through the LLM factory and have the QA path request a generous ceiling (16384) with a bounded thinking budget on the Google branch, so a full grade completes. The param is optional; non-QA callers are unaffected.

Fixes #636

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes QA grader truncation on Gemini by raising the output token limit and using model-compatible thinking settings, now applied to both Google and Vertex paths. Adds stricter prefix-based model matching to avoid unsupported configs; only the QA path opts in.

- **Bug Fixes**
  - Thread optional `max_tokens` through LLM factory methods.
  - For Google and Google Vertex, apply `max_tokens` and choose thinking by model-family prefix (2.5 -> `thinking_budget=4096`, 3 -> `thinking_level="low"`, others omit); covered by tests, including settings wiring for `GoogleLLMSettings` and `GoogleVertexLLMSettings`.
  - QA workflow sets `QA_MAX_OUTPUT_TOKENS=16384` and passes it with `usage_context="qa_analysis"`.

<sup>Written for commit 2464dd28d07f03f8046ac89c0da899f089379291. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

QA grading now carries an explicit output-token limit through the LLM factory and uses thinking configuration only for supported Gemini model families. The previously reported custom-model failure was disproved: Google and Vertex requests for legacy or custom model IDs retain the output limit while omitting unsupported thinking settings.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

Runtime checks exercised Google and Vertex factory behavior for supported, legacy, and custom model identifiers, confirming that incompatible thinking configuration is not attached.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed a controlled runtime harness against predecessor and current Google and Vertex factory branches using Gemini 2.5 and 3 identifiers, legacy Gemini 1.5, and the acme-gemini-2.5-wrapper.
- Validated the thinking configuration changes so that the custom-model request no longer receives an unsupported thinking configuration, with Gemini 2.5 applying thinking\_budget and Gemini 3 applying thinking\_level while legacy and custom identifiers omit thinking.
- Compared pre- and post-fix behavior and confirmed that after the prefix-match fix Gemini 2.5 uses thinking\_budget=4096, Gemini 3 uses thinking\_level=low, and Gemini 1.5 omits thinking, with the authored runtime script and paired log outputs documenting the results.

<a href="https://app.greptile.com/trex/runs/18049658/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(qa): tighten Google model-family mat..."](https://github.com/dograh-hq/dograh/commit/2464dd28d07f03f8046ac89c0da899f089379291) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51566097)</sub>

<!-- /greptile_comment -->