### PR TITLE
feat(qa): add whole-call grading toggle

### DIFF
--- a/api/services/workflow/dto.py
+++ b/api/services/workflow/dto.py
@@ -787,6 +787,7 @@ class WebhookNodeData(BaseNodeData):
         "qa_min_call_duration",
         "qa_voicemail_calls",
         "qa_sample_rate",
+        "qa_grade_whole_call",
         "qa_use_workflow_llm",
         "qa_provider",
         "qa_model",
@@ -829,6 +830,14 @@ class WebhookNodeData(BaseNodeData):
             ),
             "min_value": 1,
             "max_value": 100,
+        },
+        "qa_grade_whole_call": {
+            "display_name": "Grade Whole Call",
+            "description": (
+                "When true, the QA pass grades the entire transcript as one "
+                "segment (a single verdict) instead of node-by-node. Use when "
+                "scored content spans multiple nodes."
+            ),
         },
         "qa_use_workflow_llm": {
             "display_name": "Use Workflow's LLM",
@@ -885,6 +894,9 @@ class QANodeData(BaseNodeData):
     qa_min_call_duration: int = spec_field(default=15, ui_type=PropertyType.number)
     qa_voicemail_calls: bool = spec_field(default=False, ui_type=PropertyType.boolean)
     qa_sample_rate: int = spec_field(default=100, ui_type=PropertyType.number)
+    qa_grade_whole_call: bool = spec_field(
+        default=False, ui_type=PropertyType.boolean
+    )
 
 
 # Union of every per-type data class — useful as a type annotation on

--- a/api/services/workflow/qa/analysis.py
+++ b/api/services/workflow/qa/analysis.py
@@ -99,6 +99,17 @@ async def run_per_node_qa_analysis(
         logger.warning(f"No realtime_feedback_events for run {workflow_run_id}")
         return {"error": "no_transcript", "node_results": {}}
 
+    # Whole-call grading: when enabled, grade the entire transcript as a single
+    # segment (one verdict) instead of node-by-node. Use when a workflow's scored
+    # content spans multiple nodes (e.g. gated questions in a later closing node),
+    # so per-node grading can't produce one authoritative result.
+    if getattr(qa_data, "qa_grade_whole_call", False):
+        logger.info(
+            f"Whole-call QA grading enabled for run {workflow_run_id}; "
+            "grading transcript as a single segment"
+        )
+        return await _run_whole_call_qa_analysis(qa_data, workflow_run, workflow_run_id)
+
     # Try to split by node
     node_splits = split_events_by_node(rtf_events)
     if not node_splits:

--- a/api/tests/test_node_specs.py
+++ b/api/tests/test_node_specs.py
@@ -283,6 +283,7 @@ def test_all_registered_node_models_inherit_base_node_data():
                 "qa_min_call_duration",
                 "qa_voicemail_calls",
                 "qa_sample_rate",
+                "qa_grade_whole_call",
                 "qa_use_workflow_llm",
                 "qa_provider",
                 "qa_model",

--- a/api/tests/test_qa_whole_call_routing.py
+++ b/api/tests/test_qa_whole_call_routing.py
@@ -1,0 +1,92 @@
+"""Regression test for the whole-call QA grading toggle routing.
+
+When ``qa_grade_whole_call`` is set on the QA node, ``run_per_node_qa_analysis``
+must short-circuit to ``_run_whole_call_qa_analysis`` and return its result
+*without* splitting the transcript by node. Existing tests cover the per-node
+flow and the whole-call helper in isolation, but not this routing decision — so
+a change that skipped the branch, altered its arguments, or fell through to node
+splitting would go undetected.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.services.workflow.qa import analysis as qa_analysis
+
+
+@pytest.mark.asyncio
+async def test_whole_call_toggle_routes_and_bypasses_node_splitting():
+    """qa_grade_whole_call -> whole-call helper is returned, node splitting skipped."""
+    qa_data = SimpleNamespace(
+        qa_grade_whole_call=True,
+        qa_system_prompt="grade: {transcript}",
+    )
+    workflow_run = SimpleNamespace(
+        logs={
+            "realtime_feedback_events": [
+                {"role": "user", "content": "hello", "node_id": "1"},
+                {"role": "assistant", "content": "hi there", "node_id": "1"},
+            ]
+        },
+    )
+    sentinel = {"node_results": {"whole_call": {"summary": "ok"}}, "model": "test-model"}
+
+    with (
+        patch.object(
+            qa_analysis,
+            "_run_whole_call_qa_analysis",
+            new=AsyncMock(return_value=sentinel),
+        ) as whole_call_mock,
+        patch.object(qa_analysis, "split_events_by_node") as split_mock,
+    ):
+        result = await qa_analysis.run_per_node_qa_analysis(
+            qa_data,
+            workflow_run,
+            workflow_run_id=123,
+            workflow_definition={"nodes": []},
+            definition_id=7,
+        )
+
+    # the whole-call result is returned verbatim ...
+    assert result is sentinel
+    whole_call_mock.assert_awaited_once_with(qa_data, workflow_run, 123)
+    # ... and node splitting never ran
+    split_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_default_reaches_node_splitting():
+    """Without the toggle, the per-node path calls node splitting (not the toggle route)."""
+    qa_data = SimpleNamespace(
+        qa_grade_whole_call=False,
+        qa_system_prompt="grade: {transcript}",
+    )
+    workflow_run = SimpleNamespace(
+        logs={
+            "realtime_feedback_events": [
+                {"role": "user", "content": "hello", "node_id": "1"},
+            ]
+        },
+    )
+
+    # Return no splits: node splitting IS reached (proving the toggle branch was
+    # skipped), and the documented "no node_id -> whole-call" fallback then runs.
+    with patch.object(
+        qa_analysis, "split_events_by_node", return_value=[]
+    ) as split_mock:
+        with patch.object(
+            qa_analysis,
+            "_run_whole_call_qa_analysis",
+            new=AsyncMock(return_value={"node_results": {}}),
+        ):
+            await qa_analysis.run_per_node_qa_analysis(
+                qa_data,
+                workflow_run,
+                workflow_run_id=124,
+                workflow_definition={"nodes": []},
+                definition_id=8,
+            )
+
+    split_mock.assert_called_once()


### PR DESCRIPTION
Add qa_grade_whole_call on the QA node; when set, grade the whole transcript as one segment (a single verdict) instead of node-by-node. Needed when the scored content spans multiple nodes (e.g. gated questions in a later closing node), where per-node grading can't produce one authoritative result.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `qa_grade_whole_call` toggle to grade the entire transcript as one segment, returning a single verdict. Also adds regression tests that verify the toggle short-circuits to whole-call grading and skips node splitting.

- **New Features**
  - Added `qa_grade_whole_call` (default false) to the QA node spec; appears in the UI as “Grade Whole Call.”
  - When enabled, `run_per_node_qa_analysis` routes to `_run_whole_call_qa_analysis` to grade the full transcript once; existing per-node grading remains the default.

<sup>Written for commit 65d18218050ca3be76c5f554565db5c7648274d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an opt-in QA-node setting for grading an entire transcript as one segment, while preserving node-by-node grading as the default. The enabled path forwards the expected inputs to whole-call grading and bypasses node splitting; the default path still reaches node splitting.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on focused runtime coverage of both routing paths.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification and reported that local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(qa): cover whole-call grading toggl..."](https://github.com/dograh-hq/dograh/commit/65d18218050ca3be76c5f554565db5c7648274d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51566143)</sub>

<!-- /greptile_comment -->