### PR TITLE
feat: add pre all fetch condition

### DIFF
--- a/api/routes/public_agent.py
+++ b/api/routes/public_agent.py
@@ -235,6 +235,7 @@ async def _execute_resolved_target(
     workflow_run_name = f"WR-{mode_label}-{random.randint(1000, 9999)}"
     initial_context = {
         "provider": provider.PROVIDER_NAME,
+        "direction": "outbound",
         "phone_number": request.phone_number,
         "trigger_mode": "test" if use_draft else "production",
         "telephony_configuration_id": resolved_cfg_id,

--- a/api/routes/public_embed.py
+++ b/api/routes/public_embed.py
@@ -22,7 +22,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from api.constants import ENABLE_COTURN, FORCE_TURN_RELAY
 from api.db import db_client
-from api.enums import WorkflowRunMode
+from api.enums import CallType, WorkflowRunMode
 from api.routes.turn_credentials import (
     TURN_SECRET,
     TurnCredentialsResponse,
@@ -356,6 +356,8 @@ async def initialize_embed_session(
             initial_context = {
                 **context_variables,
                 "provider": WorkflowRunMode.SMALLWEBRTC.value,
+                # Embed visitors initiate the voice call into the workflow.
+                "direction": CallType.INBOUND.value,
             }
         workflow_run = await db_client.create_workflow_run(
             name=name,
@@ -363,6 +365,7 @@ async def initialize_embed_session(
             mode=mode,
             user_id=embed_token.created_by,  # Use token creator as run owner
             organization_id=embed_token.organization_id,
+            call_type=CallType.INBOUND,
             initial_context=initial_context,
             definition_id=run_inputs.definition_id,
         )

--- a/api/routes/telephony.py
+++ b/api/routes/telephony.py
@@ -185,6 +185,7 @@ async def initiate_call(
                 initial_context={
                     "phone_number": phone_number,
                     "called_number": phone_number,
+                    "direction": "outbound",
                     "provider": provider.PROVIDER_NAME,
                     "telephony_configuration_id": telephony_configuration_id,
                 },
@@ -280,6 +281,7 @@ async def initiate_call(
     updated_initial_context = {
         **(workflow_run.initial_context or {}),
         "called_number": phone_number,
+        "direction": "outbound",
         "telephony_configuration_id": telephony_configuration_id,
     }
     if result.caller_number:

--- a/api/routes/workflow.py
+++ b/api/routes/workflow.py
@@ -15,7 +15,13 @@ from api.db import db_client
 from api.db.agent_trigger_client import TriggerPathConflictError
 from api.db.models import UserModel
 from api.db.workflow_template_client import WorkflowTemplateClient
-from api.enums import CallType, PostHogEvent, StorageBackend, WorkflowStatus
+from api.enums import (
+    CallType,
+    PostHogEvent,
+    StorageBackend,
+    WorkflowRunMode,
+    WorkflowStatus,
+)
 from api.schemas.ai_model_configuration import OrganizationAIModelConfigurationV2
 from api.schemas.workflow import WorkflowRunResponseSchema
 from api.schemas.workflow_configurations import WorkflowConfigurationDefaults
@@ -1397,14 +1403,33 @@ async def create_workflow_run(
         include_template_context=True,
     )
 
+    initial_context = dict(run_inputs.initial_context or {})
+    call_type = CallType.OUTBOUND
+    if request.mode == WorkflowRunMode.SMALLWEBRTC.value:
+        configured_direction = initial_context.get("direction")
+        normalized_direction = (
+            configured_direction.strip().lower()
+            if isinstance(configured_direction, str)
+            else None
+        )
+        # Browser voice tests are inbound by default. A workflow author can set
+        # the template-context variable `direction=outbound` to test that path.
+        call_type = (
+            CallType.OUTBOUND
+            if normalized_direction == CallType.OUTBOUND.value
+            else CallType.INBOUND
+        )
+        initial_context["direction"] = call_type.value
+
     run = await db_client.create_workflow_run(
         request.name,
         workflow_id,
         request.mode,
         user.id,
+        call_type=call_type,
         organization_id=user.selected_organization_id,
         definition_id=run_inputs.definition_id,
-        initial_context=run_inputs.initial_context,
+        initial_context=initial_context,
     )
     return {
         "id": run.id,

--- a/api/services/campaign/campaign_call_dispatcher.py
+++ b/api/services/campaign/campaign_call_dispatcher.py
@@ -278,6 +278,7 @@ class CampaignCallDispatcher:
                 "source_uuid": queued_run.source_uuid,
                 "caller_number": from_number,
                 "called_number": phone_number,
+                "direction": "outbound",
                 "telephony_configuration_id": campaign.telephony_configuration_id,
             }
 

--- a/api/services/campaign/sources/csv.py
+++ b/api/services/campaign/sources/csv.py
@@ -1,7 +1,7 @@
 import csv
 import hashlib
 from io import StringIO
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 from loguru import logger
@@ -17,6 +17,39 @@ from api.services.storage import storage_fs
 
 class CSVSyncService(CampaignSourceSyncService):
     """Implementation for CSV file synchronization"""
+
+    GREETING_OVERRIDE_TYPE_COLUMN = "greeting_override_type"
+    GREETING_OVERRIDE_TEXT_COLUMN = "greeting_override_text"
+    GREETING_OVERRIDE_RECORDING_ID_COLUMN = "greeting_override_recording_id"
+
+    @classmethod
+    def _build_context_variables(
+        cls, headers: List[str], row_values: List[str]
+    ) -> Dict[str, Any]:
+        """Convert a flat CSV row into the initial context used by a campaign call."""
+        padded_row = row_values + [""] * (len(headers) - len(row_values))
+        context_vars: Dict[str, Any] = dict(zip(headers, padded_row))
+
+        override_type = (
+            context_vars.pop(cls.GREETING_OVERRIDE_TYPE_COLUMN, "").strip().lower()
+        )
+        override_text = context_vars.pop(cls.GREETING_OVERRIDE_TEXT_COLUMN, "")
+        recording_id = context_vars.pop(
+            cls.GREETING_OVERRIDE_RECORDING_ID_COLUMN, ""
+        ).strip()
+
+        if override_type == "text" and override_text.strip():
+            context_vars["greeting_override"] = {
+                "type": "text",
+                "text": override_text,
+            }
+        elif override_type == "audio" and recording_id:
+            context_vars["greeting_override"] = {
+                "type": "audio",
+                "recording_id": recording_id,
+            }
+
+        return context_vars
 
     async def _fetch_csv_data(self, file_key: str) -> List[List[str]]:
         """Download and parse CSV file from storage. Returns all rows including header."""
@@ -88,11 +121,7 @@ class CSVSyncService(CampaignSourceSyncService):
         # Convert to queued_runs
         queued_runs = []
         for idx, row_values in enumerate(rows, 1):
-            # Pad row to match headers length
-            padded_row = row_values + [""] * (len(headers) - len(row_values))
-
-            # Create context variables dict
-            context_vars = dict(zip(headers, padded_row))
+            context_vars = self._build_context_variables(headers, row_values)
 
             # Skip if no phone number
             if not context_vars.get("phone_number"):

--- a/api/services/pipecat/pre_call_fetch.py
+++ b/api/services/pipecat/pre_call_fetch.py
@@ -19,7 +19,10 @@ from api.errors.failure import (
     log_failure,
     redact_failure_message,
 )
-from api.services.workflow.initial_context import merge_external_initial_context
+from api.services.workflow.initial_context import (
+    GREETING_OVERRIDE_CONTEXT_KEY,
+    merge_external_initial_context,
+)
 from api.utils.credential_auth import build_auth_header
 
 PRE_CALL_FETCH_TIMEOUT_SECONDS = 10
@@ -43,7 +46,16 @@ def _extract_initial_context(response_data: Dict[str, Any]) -> Dict[str, Any]:
     for key in ("initial_context", "dynamic_variables"):
         value = container.get(key)
         if isinstance(value, dict):
-            return merge_external_initial_context({}, value)
+            # A call-level greeting override is an explicit trigger instruction,
+            # not CRM enrichment. A later fetch must not replace it.
+            return merge_external_initial_context(
+                {},
+                {
+                    context_key: context_value
+                    for context_key, context_value in value.items()
+                    if context_key != GREETING_OVERRIDE_CONTEXT_KEY
+                },
+            )
 
     return {}
 

--- a/api/services/pipecat/pre_call_fetch.py
+++ b/api/services/pipecat/pre_call_fetch.py
@@ -19,10 +19,7 @@ from api.errors.failure import (
     log_failure,
     redact_failure_message,
 )
-from api.services.workflow.initial_context import (
-    GREETING_OVERRIDE_CONTEXT_KEY,
-    merge_external_initial_context,
-)
+from api.services.workflow.initial_context import merge_external_initial_context
 from api.utils.credential_auth import build_auth_header
 
 PRE_CALL_FETCH_TIMEOUT_SECONDS = 10
@@ -46,16 +43,9 @@ def _extract_initial_context(response_data: Dict[str, Any]) -> Dict[str, Any]:
     for key in ("initial_context", "dynamic_variables"):
         value = container.get(key)
         if isinstance(value, dict):
-            # A call-level greeting override is an explicit trigger instruction,
-            # not CRM enrichment. A later fetch must not replace it.
-            return merge_external_initial_context(
-                {},
-                {
-                    context_key: context_value
-                    for context_key, context_value in value.items()
-                    if context_key != GREETING_OVERRIDE_CONTEXT_KEY
-                },
-            )
+            # Pre-call fetch may enrich or override call-level context, including
+            # the greeting. Only reserved run-owned metadata is discarded.
+            return merge_external_initial_context({}, value)
 
     return {}
 

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -743,13 +743,18 @@ async def _run_pipeline_impl(
     # Pre-call fetch: fire early so it runs concurrently with remaining setup
     pre_call_fetch_task = None
     start_node = workflow_graph.nodes.get(workflow_graph.start_node_id)
+    call_direction = getattr(workflow_run, "call_type", None)
+    if hasattr(call_direction, "value"):
+        call_direction = call_direction.value
+    call_direction = call_direction or merged_call_context_vars.get("direction")
     if (
         start_node
-        and start_node.pre_call_fetch_enabled
+        and start_node.should_run_pre_call_fetch(call_direction)
         and start_node.pre_call_fetch_url
     ):
         logger.info(
-            f"Pre-call fetch enabled for workflow run {workflow_run_id}, "
+            f"Pre-call fetch enabled for {call_direction or 'unknown'} workflow "
+            f"run {workflow_run_id}, "
             f"firing request to {start_node.pre_call_fetch_url}"
         )
         pre_call_fetch_task = asyncio.create_task(

--- a/api/services/workflow/dto.py
+++ b/api/services/workflow/dto.py
@@ -43,6 +43,13 @@ class VariableType(str, Enum):
     boolean = "boolean"
 
 
+class PreCallFetchMode(str, Enum):
+    disabled = "disabled"
+    always = "always"
+    inbound = "inbound"
+    outbound = "outbound"
+
+
 class ExtractionVariableDTO(BaseModel):
     name: str = spec_field(
         ...,
@@ -217,7 +224,7 @@ class _ToolDocumentRefsMixin(BaseModel):
         "extraction_variables",
         "tool_uuids",
         "document_uuids",
-        "pre_call_fetch_enabled",
+        "pre_call_fetch_mode",
         "pre_call_fetch_url",
         "pre_call_fetch_credential_uuid",
     ),
@@ -289,13 +296,19 @@ class _ToolDocumentRefsMixin(BaseModel):
             "max_value": 10.0,
             "display_options": DisplayOptions(show={"delayed_start": [True]}),
         },
-        "pre_call_fetch_enabled": {
+        "pre_call_fetch_mode": {
             "display_name": "Pre-Call Data Fetch",
             "description": (
-                "When true, makes a POST request to an external API before the "
-                "call starts and merges the JSON response into the call context "
-                "as template variables."
+                "Controls when a POST request is made to enrich the call context "
+                "before the Start node opens."
             ),
+            "options": [
+                PropertyOption(value="disabled", label="Disabled"),
+                PropertyOption(value="always", label="Always"),
+                PropertyOption(value="inbound", label="Inbound calls only"),
+                PropertyOption(value="outbound", label="Outbound calls only"),
+            ],
+            "spec_default": "disabled",
         },
         "pre_call_fetch_url": {
             "display_name": "Endpoint URL",
@@ -304,7 +317,9 @@ class _ToolDocumentRefsMixin(BaseModel):
                 "includes caller and called numbers."
             ),
             "ui_type": PropertyType.url,
-            "display_options": DisplayOptions(show={"pre_call_fetch_enabled": [True]}),
+            "display_options": DisplayOptions(
+                show={"pre_call_fetch_mode": ["always", "inbound", "outbound"]}
+            ),
             "placeholder": "https://api.example.com/customer-lookup",
         },
         "pre_call_fetch_credential_uuid": {
@@ -312,7 +327,9 @@ class _ToolDocumentRefsMixin(BaseModel):
             "description": "Optional credential attached to the pre-call request.",
             "ui_type": PropertyType.credential_ref,
             "llm_hint": "Credential UUID from `list_credentials`.",
-            "display_options": DisplayOptions(show={"pre_call_fetch_enabled": [True]}),
+            "display_options": DisplayOptions(
+                show={"pre_call_fetch_mode": ["always", "inbound", "outbound"]}
+            ),
         },
     },
 )
@@ -334,8 +351,11 @@ class StartCallNodeData(
     delayed_start_duration: Optional[float] = spec_field(
         default=None, ui_type=PropertyType.number
     )
-    pre_call_fetch_enabled: bool = spec_field(
-        default=False, ui_type=PropertyType.boolean
+    # Kept in the wire model so previously published workflows remain readable.
+    # New definitions use ``pre_call_fetch_mode`` exclusively.
+    pre_call_fetch_enabled: bool = spec_field(default=False, spec_exclude=True)
+    pre_call_fetch_mode: Optional[PreCallFetchMode] = spec_field(
+        default=None, ui_type=PropertyType.options
     )
     pre_call_fetch_url: Optional[str] = spec_field(
         default=None, ui_type=PropertyType.url
@@ -343,6 +363,16 @@ class StartCallNodeData(
     pre_call_fetch_credential_uuid: Optional[str] = spec_field(
         default=None, ui_type=PropertyType.credential_ref
     )
+
+    @model_validator(mode="after")
+    def migrate_legacy_pre_call_fetch_toggle(self):
+        if self.pre_call_fetch_mode is None:
+            self.pre_call_fetch_mode = (
+                PreCallFetchMode.always
+                if self.pre_call_fetch_enabled
+                else PreCallFetchMode.disabled
+            )
+        return self
 
 
 @node_spec(
@@ -593,6 +623,11 @@ class GlobalNodeData(BaseNodeData, _PromptedNodeDataMixin):
         "Request body fields:\n"
         "  • `phone_number` (string, required) — destination to dial.\n"
         "  • `initial_context` (object, optional) — merged into the run's initial context.\n"
+        "    To override the Start-node greeting for one call, provide "
+        "`greeting_override`: either "
+        '`{"type": "text", "text": "Hi {{name}}"}` or '
+        '`{"type": "audio", "recording_id": "welcome-message"}`. '
+        "A valid override takes precedence over the saved Start-node greeting.\n"
         "  • `telephony_configuration_id` (int, optional) — pick a specific telephony "
         "configuration for the call. Must belong to the same organization as the "
         "trigger. When omitted, the org's default outbound configuration is used."

--- a/api/services/workflow/initial_context.py
+++ b/api/services/workflow/initial_context.py
@@ -11,6 +11,8 @@ RESERVED_INITIAL_CONTEXT_KEYS = frozenset(
     {"provider", "runtime_configuration", MPS_CORRELATION_ID_CONTEXT_KEY}
 )
 
+GREETING_OVERRIDE_CONTEXT_KEY = "greeting_override"
+
 
 def merge_external_initial_context(
     initial_context: Mapping[str, Any] | None,

--- a/api/services/workflow/pipecat_engine.py
+++ b/api/services/workflow/pipecat_engine.py
@@ -41,6 +41,7 @@ from loguru import logger
 
 from api.services.managed_model_services import MPS_CORRELATION_ID_CONTEXT_KEY
 from api.services.workflow import pipecat_engine_callbacks as engine_callbacks
+from api.services.workflow.initial_context import GREETING_OVERRIDE_CONTEXT_KEY
 from api.services.workflow.mcp_tool_session import McpToolSession
 from api.services.workflow.pipecat_engine_context_composer import (
     compose_functions_for_node,
@@ -666,12 +667,31 @@ class PipecatEngine:
         Returns:
             A tuple of (greeting_type, value) where:
             - ("text", rendered_text) for text greetings spoken via TTS
-            - ("audio", recording_id) for pre-recorded audio greetings
+            - ("audio", recording primary key) for configured audio greetings
+            - ("audio_recording_id", recording ID) for call-level audio overrides
             Or None if no greeting is configured.
         """
         node = self.workflow.nodes.get(node_id)
         if not node:
             return None
+
+        # A programmatic override applies only to the workflow entry greeting;
+        # greetings on later nodes continue to use their saved configuration.
+        if node.is_start:
+            override = self._call_context_vars.get(GREETING_OVERRIDE_CONTEXT_KEY)
+            if isinstance(override, dict):
+                override_type = override.get("type")
+                if override_type == "text":
+                    text = override.get("text")
+                    if isinstance(text, str) and text.strip():
+                        return ("text", self._format_prompt(text))
+                elif override_type == "audio":
+                    recording_id = override.get("recording_id")
+                    if isinstance(recording_id, str) and recording_id.strip():
+                        return ("audio_recording_id", recording_id.strip())
+                logger.warning(
+                    "Ignoring invalid greeting_override; using Start-node greeting"
+                )
 
         greeting_type = node.greeting_type or "text"
 
@@ -709,15 +729,18 @@ class PipecatEngine:
             if greeting_info:
                 greeting_type, greeting_value = greeting_info
                 if (
-                    greeting_type == "audio"
+                    greeting_type in {"audio", "audio_recording_id"}
                     and greeting_value
                     and self._fetch_recording_audio
                     and self._transport_output is not None
                 ):
                     logger.debug(f"Playing audio greeting recording: {greeting_value}")
-                    result = await self._fetch_recording_audio(
-                        recording_pk=int(greeting_value)
+                    fetch_kwargs = (
+                        {"recording_id": greeting_value}
+                        if greeting_type == "audio_recording_id"
+                        else {"recording_pk": int(greeting_value)}
                     )
+                    result = await self._fetch_recording_audio(**fetch_kwargs)
                     if result:
                         await play_audio(
                             result.audio,

--- a/api/services/workflow/text_chat_runner.py
+++ b/api/services/workflow/text_chat_runner.py
@@ -522,7 +522,7 @@ async def execute_text_chat_pending_turn(
     if (
         is_initial_node_opening
         and start_node
-        and start_node.pre_call_fetch_enabled
+        and start_node.should_run_pre_call_fetch(None)
         and start_node.pre_call_fetch_url
     ):
         fetch_result = await execute_pre_call_fetch(

--- a/api/services/workflow/workflow_graph.py
+++ b/api/services/workflow/workflow_graph.py
@@ -130,12 +130,22 @@ class Node:
         self.document_uuids = getattr(data, "document_uuids", None)
         self.mcp_tool_filters = getattr(data, "mcp_tool_filters", None)
         self.pre_call_fetch_enabled = getattr(data, "pre_call_fetch_enabled", False)
+        mode = getattr(data, "pre_call_fetch_mode", None)
+        self.pre_call_fetch_mode = (mode.value if hasattr(mode, "value") else mode) or (
+            "always" if self.pre_call_fetch_enabled else "disabled"
+        )
         self.pre_call_fetch_url = getattr(data, "pre_call_fetch_url", None)
         self.pre_call_fetch_credential_uuid = getattr(
             data, "pre_call_fetch_credential_uuid", None
         )
 
         self.data = data
+
+    def should_run_pre_call_fetch(self, direction: str | None) -> bool:
+        """Return whether the Start-node fetch applies to this execution."""
+        if self.pre_call_fetch_mode == "always":
+            return True
+        return self.pre_call_fetch_mode == direction
 
 
 def _instance_constraint_message(

--- a/api/tests/test_campaign_greeting_override.py
+++ b/api/tests/test_campaign_greeting_override.py
@@ -1,0 +1,121 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.services.campaign.sources.csv import CSVSyncService
+from api.services.workflow.dto import (
+    EdgeDataDTO,
+    EndCallNodeData,
+    Position,
+    ReactFlowDTO,
+    RFEdgeDTO,
+    RFNodeDTO,
+    StartCallNodeData,
+)
+from api.services.workflow.pipecat_engine import PipecatEngine
+from api.services.workflow.workflow_graph import WorkflowGraph
+
+
+def _workflow() -> WorkflowGraph:
+    return WorkflowGraph(
+        ReactFlowDTO(
+            nodes=[
+                RFNodeDTO(
+                    id="start",
+                    type="startCall",
+                    position=Position(x=0, y=0),
+                    data=StartCallNodeData(
+                        name="Start",
+                        prompt="Open the call",
+                        greeting_type="text",
+                        greeting="Saved greeting",
+                    ),
+                ),
+                RFNodeDTO(
+                    id="end",
+                    type="endCall",
+                    position=Position(x=0, y=100),
+                    data=EndCallNodeData(name="End", prompt="End the call"),
+                ),
+            ],
+            edges=[
+                RFEdgeDTO(
+                    id="edge",
+                    source="start",
+                    target="end",
+                    data=EdgeDataDTO(label="End", condition="The call is complete"),
+                )
+            ],
+        )
+    )
+
+
+def test_campaign_csv_text_override_is_rendered_with_row_context():
+    headers = [
+        "phone_number",
+        "first_name",
+        "greeting_override_type",
+        "greeting_override_text",
+    ]
+    context = CSVSyncService._build_context_variables(
+        headers,
+        ["+14155550100", "Jane", "text", "Hello {{first_name}}"],
+    )
+
+    engine = PipecatEngine(workflow=_workflow(), call_context_vars=context)
+
+    assert context["greeting_override"] == {
+        "type": "text",
+        "text": "Hello {{first_name}}",
+    }
+    assert engine.get_start_greeting() == ("text", "Hello Jane")
+
+
+def test_campaign_csv_audio_override_uses_recording_id():
+    context = CSVSyncService._build_context_variables(
+        [
+            "phone_number",
+            "greeting_override_type",
+            "greeting_override_recording_id",
+        ],
+        ["+14155550100", "audio", "campaign-welcome"],
+    )
+
+    assert context["greeting_override"] == {
+        "type": "audio",
+        "recording_id": "campaign-welcome",
+    }
+
+
+@pytest.mark.asyncio
+async def test_campaign_sync_stores_nested_greeting_override():
+    service = CSVSyncService()
+    service._fetch_csv_data = AsyncMock(
+        return_value=[
+            [
+                "phone_number",
+                "first_name",
+                "greeting_override_type",
+                "greeting_override_text",
+            ],
+            ["+14155550100", "Jane", "text", "Hello {{first_name}}"],
+        ]
+    )
+    campaign = MagicMock(source_id="campaigns/contacts.csv")
+
+    with patch("api.services.campaign.sources.csv.db_client") as db:
+        db.get_campaign_by_id = AsyncMock(return_value=campaign)
+        db.bulk_create_queued_runs = AsyncMock()
+        db.update_campaign = AsyncMock()
+
+        assert await service.sync_source_data(campaign_id=42) == 1
+
+        queued_runs = db.bulk_create_queued_runs.await_args.args[0]
+        assert queued_runs[0]["context_variables"] == {
+            "phone_number": "+14155550100",
+            "first_name": "Jane",
+            "greeting_override": {
+                "type": "text",
+                "text": "Hello {{first_name}}",
+            },
+        }

--- a/api/tests/test_greeting_override.py
+++ b/api/tests/test_greeting_override.py
@@ -1,0 +1,92 @@
+from api.services.workflow.dto import (
+    EdgeDataDTO,
+    EndCallNodeData,
+    Position,
+    ReactFlowDTO,
+    RFEdgeDTO,
+    RFNodeDTO,
+    StartCallNodeData,
+)
+from api.services.workflow.pipecat_engine import PipecatEngine
+from api.services.workflow.workflow_graph import WorkflowGraph
+
+
+def _workflow() -> WorkflowGraph:
+    return WorkflowGraph(
+        ReactFlowDTO(
+            nodes=[
+                RFNodeDTO(
+                    id="start",
+                    type="startCall",
+                    position=Position(x=0, y=0),
+                    data=StartCallNodeData(
+                        name="Start",
+                        prompt="Open the call",
+                        greeting_type="text",
+                        greeting="Saved greeting",
+                    ),
+                ),
+                RFNodeDTO(
+                    id="end",
+                    type="endCall",
+                    position=Position(x=0, y=100),
+                    data=EndCallNodeData(name="End", prompt="End the call"),
+                ),
+            ],
+            edges=[
+                RFEdgeDTO(
+                    id="edge",
+                    source="start",
+                    target="end",
+                    data=EdgeDataDTO(label="End", condition="The call is complete"),
+                )
+            ],
+        )
+    )
+
+
+def test_text_override_wins_and_renders_hydrated_context():
+    workflow = _workflow()
+    engine = PipecatEngine(
+        workflow=workflow,
+        call_context_vars={
+            "account_id": "ACC-123",
+            "greeting_override": {
+                "type": "text",
+                "text": "Please confirm account {{account_id}}.",
+            },
+        },
+    )
+
+    assert engine.get_start_greeting() == (
+        "text",
+        "Please confirm account ACC-123.",
+    )
+
+
+def test_audio_override_uses_public_recording_id():
+    workflow = _workflow()
+    engine = PipecatEngine(
+        workflow=workflow,
+        call_context_vars={
+            "greeting_override": {
+                "type": "audio",
+                "recording_id": "callback-welcome",
+            }
+        },
+    )
+
+    assert engine.get_start_greeting() == (
+        "audio_recording_id",
+        "callback-welcome",
+    )
+
+
+def test_invalid_override_falls_back_to_saved_greeting():
+    workflow = _workflow()
+    engine = PipecatEngine(
+        workflow=workflow,
+        call_context_vars={"greeting_override": {"type": "text"}},
+    )
+
+    assert engine.get_start_greeting() == ("text", "Saved greeting")

--- a/api/tests/test_node_specs.py
+++ b/api/tests/test_node_specs.py
@@ -16,7 +16,9 @@ import pytest
 from pydantic import ValidationError
 
 from api.services.workflow.dto import (
+    PreCallFetchMode,
     ReactFlowDTO,
+    StartCallNodeData,
     all_node_type_names,
     get_node_data_model,
 )
@@ -28,11 +30,76 @@ from api.services.workflow.node_specs import (
     PropertyType,
     all_specs,
 )
+from api.services.workflow.workflow_graph import Node
 
 PLACEHOLDER_DESCRIPTION_PATTERN = re.compile(
     r"^\s*(todo|fixme|tbd|xxx|\.\.\.|placeholder|description|n/?a|\?)\s*\.?\s*$",
     re.IGNORECASE,
 )
+
+
+def test_start_call_migrates_legacy_pre_call_fetch_toggle():
+    enabled = StartCallNodeData.model_validate(
+        {"name": "Start", "prompt": "Open", "pre_call_fetch_enabled": True}
+    )
+    disabled = StartCallNodeData.model_validate(
+        {"name": "Start", "prompt": "Open", "pre_call_fetch_enabled": False}
+    )
+
+    assert enabled.pre_call_fetch_mode == PreCallFetchMode.always
+    assert disabled.pre_call_fetch_mode == PreCallFetchMode.disabled
+
+
+@pytest.mark.parametrize("direction", ["inbound", "outbound", None])
+def test_legacy_pre_call_fetch_toggle_preserves_runtime_behavior(direction):
+    enabled_data = StartCallNodeData.model_validate(
+        {"name": "Start", "prompt": "Open", "pre_call_fetch_enabled": True}
+    )
+    disabled_data = StartCallNodeData.model_validate(
+        {"name": "Start", "prompt": "Open", "pre_call_fetch_enabled": False}
+    )
+
+    assert Node("enabled", "startCall", enabled_data).should_run_pre_call_fetch(
+        direction
+    )
+    assert not Node("disabled", "startCall", disabled_data).should_run_pre_call_fetch(
+        direction
+    )
+
+
+def test_explicit_pre_call_fetch_mode_wins_over_legacy_toggle():
+    data = StartCallNodeData.model_validate(
+        {
+            "name": "Start",
+            "prompt": "Open",
+            "pre_call_fetch_enabled": True,
+            "pre_call_fetch_mode": "inbound",
+        }
+    )
+
+    assert data.pre_call_fetch_mode == PreCallFetchMode.inbound
+
+
+@pytest.mark.parametrize(
+    ("mode", "direction", "expected"),
+    [
+        ("disabled", "inbound", False),
+        ("always", "inbound", True),
+        ("always", None, True),
+        ("inbound", "inbound", True),
+        ("inbound", "outbound", False),
+        ("outbound", "outbound", True),
+        ("outbound", "inbound", False),
+        ("outbound", None, False),
+    ],
+)
+def test_pre_call_fetch_mode_matches_call_direction(mode, direction, expected):
+    data = StartCallNodeData.model_validate(
+        {"name": "Start", "prompt": "Open", "pre_call_fetch_mode": mode}
+    )
+    node = Node("start", "startCall", data)
+
+    assert node.should_run_pre_call_fetch(direction) is expected
 
 
 def _walk_properties(props: list[PropertySpec], path: str = ""):
@@ -230,7 +297,7 @@ def test_all_registered_node_models_inherit_base_node_data():
                 "extraction_variables",
                 "tool_uuids",
                 "document_uuids",
-                "pre_call_fetch_enabled",
+                "pre_call_fetch_mode",
                 "pre_call_fetch_url",
                 "pre_call_fetch_credential_uuid",
             ],
@@ -446,6 +513,12 @@ def test_to_mcp_dict_retains_authoring_signal_startcall():
 
     # Enum options project to bare values, dropping the UI label.
     assert props["greeting_type"]["options"] == [{"value": "text"}, {"value": "audio"}]
+    assert props["pre_call_fetch_mode"]["options"] == [
+        {"value": "disabled"},
+        {"value": "always"},
+        {"value": "inbound"},
+        {"value": "outbound"},
+    ]
 
     # Validation bounds survive (they constrain valid authored values).
     assert props["delayed_start_duration"]["min_value"] == 0.1

--- a/api/tests/test_pre_call_fetch.py
+++ b/api/tests/test_pre_call_fetch.py
@@ -65,18 +65,18 @@ class TestExtractInitialContext:
 
         assert _extract_initial_context(response) == {"customer_name": "Jane"}
 
-    def test_greeting_override_is_not_accepted_from_pre_call_fetch(self):
+    def test_greeting_override_is_accepted_from_pre_call_fetch(self):
         response = {
             "initial_context": {
                 "account_id": "ACC-123",
                 "greeting_override": {
                     "type": "text",
-                    "text": "This must not replace the trigger greeting",
+                    "text": "Welcome back to account {{account_id}}",
                 },
             }
         }
 
-        assert _extract_initial_context(response) == {"account_id": "ACC-123"}
+        assert _extract_initial_context(response) == response["initial_context"]
 
     def test_empty_when_no_known_keys(self):
         """A response with neither key yields an empty dict."""

--- a/api/tests/test_pre_call_fetch.py
+++ b/api/tests/test_pre_call_fetch.py
@@ -65,6 +65,19 @@ class TestExtractInitialContext:
 
         assert _extract_initial_context(response) == {"customer_name": "Jane"}
 
+    def test_greeting_override_is_not_accepted_from_pre_call_fetch(self):
+        response = {
+            "initial_context": {
+                "account_id": "ACC-123",
+                "greeting_override": {
+                    "type": "text",
+                    "text": "This must not replace the trigger greeting",
+                },
+            }
+        }
+
+        assert _extract_initial_context(response) == {"account_id": "ACC-123"}
+
     def test_empty_when_no_known_keys(self):
         """A response with neither key yields an empty dict."""
         assert _extract_initial_context({"call_inbound": {"agent_id": 1}}) == {}

--- a/api/tests/test_public_embed_chat.py
+++ b/api/tests/test_public_embed_chat.py
@@ -14,6 +14,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.testclient import TestClient
 
+from api.enums import CallType
 from api.routes.public_embed import PublicEmbedCORSMiddleware
 from api.routes.public_embed import router as public_embed_router
 from api.routes.public_embed_chat import router as public_embed_chat_router
@@ -308,6 +309,7 @@ def test_init_chat_token_creates_textchat_run(_patch_db):
     assert len(_patch_db.created_runs) == 1
     kwargs = _patch_db.created_runs[0]
     assert kwargs["mode"] == "textchat"
+    assert kwargs["call_type"] == CallType.INBOUND
     # Text-chat runs must not carry a webrtc transport provider.
     assert "provider" not in kwargs["initial_context"]
     assert kwargs["initial_context"]["name"] == "Ada"
@@ -331,7 +333,9 @@ def test_init_voice_token_keeps_smallwebrtc(_patch_db):
 
     kwargs = _patch_db.created_runs[0]
     assert kwargs["mode"] == "smallwebrtc"
+    assert kwargs["call_type"] == CallType.INBOUND
     assert kwargs["initial_context"]["provider"] == "smallwebrtc"
+    assert kwargs["initial_context"]["direction"] == "inbound"
 
     body = resp.json()
     assert body["widget_type"] == "voice"
@@ -347,6 +351,7 @@ def test_init_sanitizes_context_variables(_patch_db):
             "context_variables": {
                 "  customer_name  ": "Abhishek",
                 "provider": "twilio",
+                "direction": "outbound",
                 "bio": "a" * (MAX_VALUE_LENGTH + 500),
             },
         },
@@ -357,6 +362,8 @@ def test_init_sanitizes_context_variables(_patch_db):
     assert initial_context["customer_name"] == "Abhishek"
     # The host page can't rewrite the transport the backend picked.
     assert initial_context["provider"] == "smallwebrtc"
+    # Nor can visitor context reclassify an embedded voice call as outbound.
+    assert initial_context["direction"] == "inbound"
     assert len(initial_context["bio"]) == MAX_VALUE_LENGTH
 
 

--- a/api/tests/test_text_and_audio_playback.py
+++ b/api/tests/test_text_and_audio_playback.py
@@ -374,6 +374,67 @@ class TestStartGreeting:
         result = engine.get_start_greeting()
         assert result == ("text", "Hello Alice!")
 
+    def test_trigger_text_greeting_override_wins_and_renders_context(
+        self, text_workflow: WorkflowGraph
+    ):
+        engine = PipecatEngine(
+            workflow=text_workflow,
+            call_context_vars={
+                "account_id": "ACC-123",
+                "greeting_override": {
+                    "type": "text",
+                    "text": "Please confirm account {{account_id}}.",
+                },
+            },
+            workflow_run_id=1,
+        )
+
+        assert engine.get_start_greeting() == (
+            "text",
+            "Please confirm account ACC-123.",
+        )
+
+    def test_invalid_trigger_greeting_override_uses_node_greeting(
+        self, text_workflow: WorkflowGraph
+    ):
+        engine = PipecatEngine(
+            workflow=text_workflow,
+            call_context_vars={"greeting_override": {"type": "text"}},
+            workflow_run_id=1,
+        )
+
+        assert engine.get_start_greeting() == ("text", TEXT_GREETING)
+
+    @pytest.mark.asyncio
+    async def test_audio_greeting_override_resolves_public_recording_id(
+        self, text_workflow: WorkflowGraph
+    ):
+        engine = PipecatEngine(
+            workflow=text_workflow,
+            call_context_vars={
+                "greeting_override": {
+                    "type": "audio",
+                    "recording_id": "callback-welcome",
+                }
+            },
+            workflow_run_id=1,
+        )
+        engine.set_transport_output(Mock(queue_frame=AsyncMock()))
+        engine.set_fetch_recording_audio(
+            AsyncMock(return_value=RecordingAudio(FAKE_PCM_AUDIO, "Welcome back"))
+        )
+
+        result = await engine.queue_node_opening(
+            node_id=text_workflow.start_node_id,
+            previous_node_id=None,
+            generate_if_no_greeting=True,
+        )
+
+        assert result == "greeting"
+        engine._fetch_recording_audio.assert_awaited_once_with(
+            recording_id="callback-welcome"
+        )
+
     @pytest.mark.asyncio
     async def test_queue_node_opening_queues_text_greeting(
         self, text_workflow: WorkflowGraph

--- a/api/tests/test_workflow_create_route.py
+++ b/api/tests/test_workflow_create_route.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from api.enums import CallType
 from api.routes.workflow import router
 from api.services.auth.depends import get_user
 
@@ -241,4 +242,42 @@ def test_create_workflow_run_uses_draft_and_template_context():
     assert create_kwargs["initial_context"] == {
         "name": "draft",
         "draft_only": "kept",
+        "direction": "inbound",
     }
+    assert create_kwargs["call_type"] == CallType.INBOUND
+
+
+def test_create_workflow_webrtc_run_can_simulate_outbound_from_template_context():
+    app = _make_test_app()
+    client = TestClient(app)
+
+    workflow = SimpleNamespace(id=33, current_definition=None)
+    draft = SimpleNamespace(
+        id=88,
+        template_context_variables={"direction": " OUTBOUND "},
+    )
+    run = SimpleNamespace(
+        id=501,
+        workflow_id=workflow.id,
+        name="WR-test",
+        mode="smallwebrtc",
+        created_at=datetime.now(UTC),
+        definition_id=draft.id,
+        initial_context={"direction": "outbound"},
+        gathered_context={},
+    )
+
+    with patch("api.routes.workflow.db_client") as mock_db:
+        mock_db.get_workflow = AsyncMock(return_value=workflow)
+        mock_db.get_draft_version = AsyncMock(return_value=draft)
+        mock_db.create_workflow_run = AsyncMock(return_value=run)
+
+        response = client.post(
+            f"/workflow/{workflow.id}/runs",
+            json={"name": "WR-test", "mode": "smallwebrtc"},
+        )
+
+    assert response.status_code == 200
+    create_kwargs = mock_db.create_workflow_run.await_args.kwargs
+    assert create_kwargs["call_type"] == CallType.OUTBOUND
+    assert create_kwargs["initial_context"]["direction"] == "outbound"

--- a/docs/api-reference/campaigns/upload-contacts.mdx
+++ b/docs/api-reference/campaigns/upload-contacts.mdx
@@ -27,7 +27,14 @@ Use the `s3_key` from the response as the `source_url` when [creating a campaign
 The CSV must include a `phone_number` column. Any additional columns are passed as `initial_context` to each call, making them available as template variables in the workflow.
 
 ```csv
-phone_number,customer_name,plan
-+14155550100,Jane Smith,premium
-+14155550101,Bob Jones,basic
+phone_number,customer_name,plan,greeting_override_type,greeting_override_text
++14155550100,Jane Smith,premium,text,Hello {{customer_name}}
++14155550101,Bob Jones,basic,text,Welcome back {{customer_name}}
 ```
+
+To override the Start node greeting for a row, use these optional columns:
+
+- Text: set `greeting_override_type` to `text` and put the message in `greeting_override_text`.
+- Recording: set `greeting_override_type` to `audio` and put the public recording ID in `greeting_override_recording_id`.
+
+Greeting text can reference other CSV columns, such as `Hello {{customer_name}}`. Empty override columns preserve the greeting configured in the Start node.

--- a/docs/core-concepts/campaigns.mdx
+++ b/docs/core-concepts/campaigns.mdx
@@ -29,12 +29,14 @@ flowchart LR
 The CSV drives the campaign. Each row is one contact.
 
 ```csv
-phone_number,customer_name,account_id,plan
-+14155550100,Jane Smith,acc_001,premium
-+14155550101,Bob Jones,acc_002,basic
+phone_number,customer_name,account_id,plan,greeting_override_type,greeting_override_text
++14155550100,Jane Smith,acc_001,premium,text,Hello {{customer_name}}
++14155550101,Bob Jones,acc_002,basic,text,Welcome back {{customer_name}}
 ```
 
 Columns beyond `phone_number` are automatically passed as `initial_context` to each call, making them available as template variables in your agent's prompt — so each call can feel personalised at scale.
+
+To override the Start node greeting for a row, set `greeting_override_type` to `text` and provide `greeting_override_text`. The text can use other columns as template variables. For a recorded greeting, set the type to `audio` and provide its public ID in `greeting_override_recording_id`. Leave the override columns empty to use the greeting configured in the Start node.
 
 ## Scheduling and concurrency
 

--- a/docs/voice-agent/api-trigger.mdx
+++ b/docs/voice-agent/api-trigger.mdx
@@ -156,7 +156,7 @@ For a pre-recorded greeting, pass the recording's string ID from the Recordings 
 
 Dograh renders a text override after Pre-Call Data Fetch completes, so the override can reference variables returned by the fetch. The override follows the same playback restrictions as a saved greeting. In particular, static text greetings are not spoken by realtime speech-to-speech models; use an audio override for those configurations.
 
-Pre-Call Data Fetch cannot replace `greeting_override`. If the override shape is invalid, Dograh logs a warning and uses the saved Start-node greeting.
+Pre-Call Data Fetch can also return `greeting_override`. Because fetched context is applied after trigger context, a valid fetched override replaces one supplied by the trigger.
 
 ## Choosing a telephony configuration
 

--- a/docs/voice-agent/api-trigger.mdx
+++ b/docs/voice-agent/api-trigger.mdx
@@ -122,6 +122,42 @@ You can reference the user's name in your agent prompt as `{{user.name}}` — in
 
 See [Context & Variables](/core-concepts/context-and-variables) for more on how data flows through a call.
 
+### Override the greeting for one call
+
+Pass `greeting_override` inside `initial_context` to replace the Start Call node's saved greeting for one API-triggered call. A valid override takes precedence over the saved greeting. If you omit it, Dograh uses the saved greeting; if neither exists, the Start node follows its normal no-greeting behavior.
+
+For a text greeting:
+
+```json
+{
+  "phone_number": "+14155550100",
+  "initial_context": {
+    "greeting_override": {
+      "type": "text",
+      "text": "Hi, please confirm account {{account_id}}."
+    }
+  }
+}
+```
+
+For a pre-recorded greeting, pass the recording's string ID from the Recordings page:
+
+```json
+{
+  "phone_number": "+14155550100",
+  "initial_context": {
+    "greeting_override": {
+      "type": "audio",
+      "recording_id": "callback-welcome"
+    }
+  }
+}
+```
+
+Dograh renders a text override after Pre-Call Data Fetch completes, so the override can reference variables returned by the fetch. The override follows the same playback restrictions as a saved greeting. In particular, static text greetings are not spoken by realtime speech-to-speech models; use an audio override for those configurations.
+
+Pre-Call Data Fetch cannot replace `greeting_override`. If the override shape is invalid, Dograh logs a warning and uses the saved Start-node greeting.
+
 ## Choosing a telephony configuration
 
 By default, calls are placed through your organization's default outbound [telephony configuration](/integrations/telephony/overview). To route a specific call through a different configuration — for example, to dial out from a regional number — pass `telephony_configuration_id` in the request body.

--- a/docs/voice-agent/pre-call-data-fetch.mdx
+++ b/docs/voice-agent/pre-call-data-fetch.mdx
@@ -3,7 +3,7 @@ title: "Pre-Call Data Fetch"
 description: "Fetch customer data from your CRM or ERP before the call starts, so your voice agent can greet callers by name and reference their account details."
 ---
 
-Pre-Call Data Fetch allows you to enrich the call context with external data before the voice agent starts speaking. When enabled on the [**Start Call**](/voice-agent/start-call) node, Dograh sends an HTTP request to your API as soon as a call is initiated. While the response is loading, the caller hears a ring-back tone. Once the data arrives, it is merged into the call's [initial context](/core-concepts/context-and-variables#initial_context) and becomes available as template variables in your prompts and greetings.
+Pre-Call Data Fetch allows you to enrich the call context with external data before the voice agent starts speaking. Configure it on the [**Start Call**](/voice-agent/start-call) node for every call, inbound calls only, or outbound calls only. While the response is loading, the caller hears a ring-back tone. Once the data arrives, it is merged into the call's [initial context](/core-concepts/context-and-variables#initial_context) and becomes available as template variables in your prompts and greetings.
 
 
 ## How It Works
@@ -17,10 +17,11 @@ Pre-Call Data Fetch allows you to enrich the call context with external data bef
 
 ## Configuration
 
-Open the [**Start Call**](/voice-agent/start-call) node editor and expand **Advanced Settings**. Toggle **Pre-Call Data Fetch** and configure:
+Open the [**Start Call**](/voice-agent/start-call) node editor and expand **Advanced Settings**. Choose a **Pre-Call Data Fetch** mode and configure the endpoint when the mode is not disabled:
 
 | Field | Description |
 | --- | --- |
+| **Pre-Call Data Fetch** | **Disabled**, **Always**, **Inbound calls only**, or **Outbound calls only**. Calls without an inbound or outbound direction run the fetch only in **Always** mode. |
 | **Endpoint URL** | The URL Dograh will send the POST request to. |
 | **Authentication** | Optional credential for authenticating the request. Supports API key, bearer token, basic auth, and custom header. |
 

--- a/docs/voice-agent/start-call.mdx
+++ b/docs/voice-agent/start-call.mdx
@@ -94,7 +94,7 @@ Documents the agent can reference during this step. Attach via "Manage Documents
 
 **Pre-Call Data Fetch**
 
-When on, Dograh makes a POST request to an external API before the call starts and merges the JSON response into the call context as template variables.
+Choose whether Dograh makes a POST request before **all**, **inbound**, or **outbound** calls, or leave the fetch **disabled**. Dograh merges the JSON response into the call context as template variables before rendering the greeting and Start-node prompt.
 
 ## Outgoing edges
 

--- a/docs/voice-agent/template-variables.mdx
+++ b/docs/voice-agent/template-variables.mdx
@@ -52,6 +52,8 @@ Template variables defined in your workflow **Settings > Context Variables** are
 
 For example, you can set `caller_number` and `called_number` as context variables to test [Pre-Call Data Fetch](/voice-agent/pre-call-data-fetch#testing-with-test-calls) without needing a real inbound call.
 
+Browser voice tests are treated as inbound calls by default. To simulate an outbound call with web, set the `direction` template-context variable to `outbound`.
+
 <Note>
 These context variables are only used during test calls from the workflow editor. On production inbound calls and campaign outbound calls, the actual telephony data is used and these values are ignored.
 </Note>

--- a/sdk/python/src/dograh_sdk/typed/start_call.py
+++ b/sdk/python/src/dograh_sdk/typed/start_call.py
@@ -121,11 +121,10 @@ class StartCall(TypedNode):
     Documents the agent can reference.
     """
 
-    pre_call_fetch_enabled: bool = False
+    pre_call_fetch_mode: Literal['disabled', 'always', 'inbound', 'outbound'] = 'disabled'
     """
-    When true, makes a POST request to an external API before the call
-    starts and merges the JSON response into the call context as template
-    variables.
+    Controls when a POST request is made to enrich the call context before
+    the Start node opens.
     """
 
     pre_call_fetch_url: Optional[str] = None

--- a/sdk/python/src/dograh_sdk/typed/trigger.py
+++ b/sdk/python/src/dograh_sdk/typed/trigger.py
@@ -26,10 +26,14 @@ class Trigger(TypedNode):
     published agent when no draft exists. Both require an API key in the
     `X-API-Key` header. Request body fields:   • `phone_number` (string,
     required) — destination to dial.   • `initial_context` (object,
-    optional) — merged into the run's initial context.   •
-    `telephony_configuration_id` (int, optional) — pick a specific telephony
-    configuration for the call. Must belong to the same organization as the
-    trigger. When omitted, the org's default outbound configuration is used.
+    optional) — merged into the run's initial context.     To override the
+    Start-node greeting for one call, provide `greeting_override`: either
+    `{"type": "text", "text": "Hi {{name}}"}` or `{"type": "audio",
+    "recording_id": "welcome-message"}`. A valid override takes precedence
+    over the saved Start-node greeting.   • `telephony_configuration_id`
+    (int, optional) — pick a specific telephony configuration for the call.
+    Must belong to the same organization as the trigger. When omitted, the
+    org's default outbound configuration is used.
     """
 
     type: ClassVar[str] = 'trigger'

--- a/sdk/typescript/src/typed/start-call.ts
+++ b/sdk/typescript/src/typed/start-call.ts
@@ -92,9 +92,9 @@ export interface StartCall {
      */
     document_uuids?: string[];
     /**
-     * When true, makes a POST request to an external API before the call starts and merges the JSON response into the call context as template variables.
+     * Controls when a POST request is made to enrich the call context before the Start node opens.
      */
-    pre_call_fetch_enabled?: boolean;
+    pre_call_fetch_mode?: "disabled" | "always" | "inbound" | "outbound";
     /**
      * URL the pre-call POST request is sent to. The request body includes caller and called numbers.
      */

--- a/sdk/typescript/src/typed/trigger.ts
+++ b/sdk/typescript/src/typed/trigger.ts
@@ -15,6 +15,7 @@
  * Request body fields:
  *   • `phone_number` (string, required) — destination to dial.
  *   • `initial_context` (object, optional) — merged into the run's initial context.
+ *     To override the Start-node greeting for one call, provide `greeting_override`: either `{"type": "text", "text": "Hi {{name}}"}` or `{"type": "audio", "recording_id": "welcome-message"}`. A valid override takes precedence over the saved Start-node greeting.
  *   • `telephony_configuration_id` (int, optional) — pick a specific telephony configuration for the call. Must belong to the same organization as the trigger. When omitted, the org's default outbound configuration is used.
  */
 export interface Trigger {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "1.42.0",
+  "version": "1.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "1.42.0",
+      "version": "1.44.0",
       "dependencies": {
         "@calcom/embed-react": "^1.5.3",
         "@dagrejs/dagre": "^1.1.4",

--- a/ui/src/components/flow/nodes/GenericNode.tsx
+++ b/ui/src/components/flow/nodes/GenericNode.tsx
@@ -83,6 +83,17 @@ function seedValues(
     const d = data as unknown as Record<string, unknown>;
     const out: Record<string, unknown> = {};
     for (const prop of spec.properties) {
+        if (
+            spec.name === "startCall" &&
+            prop.name === "pre_call_fetch_mode" &&
+            d.pre_call_fetch_mode == null
+        ) {
+            // Old workflow definitions stored only the enable switch. Present
+            // those as Always so opening and resaving an existing node cannot
+            // silently disable its fetch.
+            out[prop.name] = d.pre_call_fetch_enabled === true ? "always" : "disabled";
+            continue;
+        }
         out[prop.name] = d[prop.name] ?? prop.default ?? undefined;
     }
     return out;

--- a/ui/src/components/flow/types.ts
+++ b/ui/src/components/flow/types.ts
@@ -29,7 +29,8 @@ export type FlowNodeData = {
     delayed_start?: boolean;
     delayed_start_duration?: number;
     // Pre-call data fetch (StartCall only)
-    pre_call_fetch_enabled?: boolean;
+    pre_call_fetch_enabled?: boolean; // Legacy published definitions only
+    pre_call_fetch_mode?: 'disabled' | 'always' | 'inbound' | 'outbound';
     pre_call_fetch_url?: string;
     pre_call_fetch_credential_uuid?: string;
     // Trigger node specific


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds direction-aware Pre-Call Data Fetch (disabled/always/inbound/outbound) and per-call greeting overrides. WebRTC voice runs default to inbound, with an option to simulate outbound via a template-context `direction`.

- **New Features**
  - Start node uses `pre_call_fetch_mode` to run fetch for all, inbound, or outbound calls based on call direction.
  - `greeting_override` supports text (`{ type: "text", text }`) and audio (`{ type: "audio", recording_id }`); text renders with context, audio uses the public recording ID. Applies only to the Start node.
  - Pre-Call Fetch can supply or replace `greeting_override`; other variables are merged as before.
  - Web voice (`smallwebrtc`) runs are marked inbound and set `direction: "inbound"`; authors can set template-context `direction=outbound` to test outbound on web. Outbound API/campaign/telephony runs set `direction: "outbound"` and persist `call_type`.
  - Campaign CSV adds `greeting_override_type`, `greeting_override_text`, `greeting_override_recording_id` to set per-row greetings.

- **Migration**
  - `pre_call_fetch_enabled` migrates to `pre_call_fetch_mode` (`always` when previously enabled, else `disabled`). Update SDKs to use `pre_call_fetch_mode` (`sdk/python`, `sdk/typescript`).
  - UI seeds legacy nodes so opening/saving preserves prior behavior.
  - No client changes needed for direction defaults; to test outbound with web, set the template-context variable `direction=outbound`.

<sup>Written for commit ae1629ef8021afcbecffaf2e40d14faaef732d28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds direction-aware pre-call data-fetch settings and configurable Start greetings across API-triggered, campaign, WebRTC, and fetched-call workflows.

One P1 call-behavior defect remains: when an audio greeting override points to an unavailable recording, the saved Start-node greeting is skipped and the call begins with LLM generation instead.

## T-Rex validation blocked

The focused runtime check could not import the workflow engine because the installed Pipecat package is missing the project-required `pipecat.utils.enums` module.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until unavailable audio greeting overrides fall back to the configured Start greeting.

One non-security P1 finding remains: an unavailable audio greeting override bypasses the deterministic Start greeting. With one non-security P1 and no P0 findings, the score is 4.

**Files Needing Attention:** api/services/workflow/pipecat_engine.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to run the focused greeting-override fallback validation script in the repository environment.
- The run failed with a ModuleNotFoundError for pipecat.utils.enums, blocking the focused validation path.
- Artifacts documenting the attempt were prepared and uploaded for reviewer access.

<a href="https://app.greptile.com/trex/runs/18097444/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `api/services/workflow/pipecat_engine.py`, line 755-758 ([link](https://github.com/dograh-hq/dograh/blob/ae1629ef8021afcbecffaf2e40d14faaef732d28/api/services/workflow/pipecat_engine.py#L755-L758)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unavailable audio override suppresses the saved Start greeting**

   A nonempty audio override is selected before checking whether its recording can actually be played. When the recording is missing, inactive, or otherwise unavailable, `queue_node_opening` logs the failure and queues initial LLM generation instead of falling back to the Start node's configured greeting. API-triggered and campaign calls with an unavailable recording therefore begin without their intended deterministic greeting. Re-resolve the saved Start-node greeting after an `audio_recording_id` fetch fails, before using the LLM fallback.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat: set webrtc calls are inbound, allo..."](https://github.com/dograh-hq/dograh/commit/ae1629ef8021afcbecffaf2e40d14faaef732d28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51710079)</sub>

<!-- /greptile_comment -->