### PR TITLE
feat: refine deployment for vici server

### DIFF
--- a/api/constants.py
+++ b/api/constants.py
@@ -79,6 +79,15 @@ DOGRAH_MPS_SECRET_KEY = os.getenv("DOGRAH_MPS_SECRET_KEY", None)
 MPS_API_URL = os.getenv("MPS_API_URL", "https://services.dograh.com")
 DOGRAH_DEVOPS_SECRET = os.getenv("DOGRAH_DEVOPS_SECRET") or None
 
+# Log which external-PBX lead headers an inbound INVITE actually carries, so an
+# integrator can see what the PBX attaches before listing fields under the
+# workflow's "Lead Fields To Capture" setting. Costs one extra ARI request per
+# inbound call — it reads header *names* only, not values — so turn this on
+# during integration setup and off again afterwards.
+LOG_EXTERNAL_PBX_AVAILABLE_HEADERS = (
+    os.getenv("LOG_EXTERNAL_PBX_AVAILABLE_HEADERS", "false").lower() == "true"
+)
+
 # Storage Configuration
 ENABLE_AWS_S3 = os.getenv("ENABLE_AWS_S3", "false").lower() == "true"
 

--- a/api/db/workflow_client.py
+++ b/api/db/workflow_client.py
@@ -297,6 +297,24 @@ class WorkflowClient(BaseDBClient):
             )
             return result.scalars().first()
 
+    async def get_definition_configurations(self, definition_id: int | None) -> dict:
+        """Load the configuration document for one workflow definition.
+
+        Callers that need configuration *before* a run row exists must read the
+        definition the run will bind to. ``WorkflowModel.workflow_configurations``
+        is a legacy column kept in sync with the draft, so reading it here would
+        let unpublished edits change live call behaviour.
+        """
+        if definition_id is None:
+            return {}
+        async with self.async_session() as session:
+            result = await session.execute(
+                select(WorkflowDefinitionModel.workflow_configurations).where(
+                    WorkflowDefinitionModel.id == definition_id
+                )
+            )
+            return result.scalar_one_or_none() or {}
+
     async def get_workflow_versions(
         self,
         workflow_id: int,

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -116,6 +116,7 @@ def setup_logging():
 
         patched.add(
             actual_log_path,
+            format=log_format,
             level=log_level,
             serialize=SERIALIZE_LOG_OUTPUT,  # Use JSON serialization for structured logs
             enqueue=True,  # Thread-safe writing

--- a/api/schemas/workflow_configurations.py
+++ b/api/schemas/workflow_configurations.py
@@ -1,6 +1,13 @@
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
 
 from api.constants import (
     MAX_TEXT_CHAT_INACTIVITY_TIMEOUT_SECONDS,
@@ -37,6 +44,17 @@ class ExternalPBXFieldMapping(BaseModel):
     @classmethod
     def strip_destination_field(cls, value: object) -> object:
         return value.strip() if isinstance(value, str) else value
+
+
+# Extra lead fields to capture from the inbound INVITE, named without the
+# provider's header prefix (``first_name`` -> ``X-VICIDIAL-first_name``). Each
+# entry costs one ARI round trip during call setup, so the set is configured
+# explicitly per workflow rather than enumerated off the INVITE.
+MAX_EXTERNAL_PBX_LEAD_HEADERS = 50
+
+ExternalPBXLeadHeader = Annotated[
+    str, StringConstraints(pattern=r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+]
 
 
 class AmbientNoiseConfigurationDefaults(BaseModel):
@@ -88,6 +106,23 @@ class WorkflowConfigurationDefaults(BaseModel):
         default_factory=list,
         max_length=100,
     )
+    external_pbx_lead_headers: list[ExternalPBXLeadHeader] = Field(
+        default_factory=list,
+        max_length=MAX_EXTERNAL_PBX_LEAD_HEADERS,
+    )
+
+    @field_validator("external_pbx_lead_headers", mode="before")
+    @classmethod
+    def strip_lead_headers(cls, value: object) -> object:
+        """Trim and de-duplicate while preserving the configured order."""
+        if not isinstance(value, list):
+            return value
+        cleaned: list[str] = []
+        for item in value:
+            name = item.strip() if isinstance(item, str) else item
+            if name and name not in cleaned:
+                cleaned.append(name)
+        return cleaned
 
 
 class TextChatInactivityTimeoutConstraints(BaseModel):

--- a/api/services/telephony/ari_manager.py
+++ b/api/services/telephony/ari_manager.py
@@ -24,7 +24,7 @@ import redis.asyncio as aioredis
 import websockets
 from loguru import logger
 
-from api.constants import REDIS_URL
+from api.constants import LOG_EXTERNAL_PBX_AVAILABLE_HEADERS, REDIS_URL
 from api.db import db_client
 from api.enums import CallType, WorkflowRunMode
 from api.errors.failure import (
@@ -633,7 +633,10 @@ class ARIConnection:
         return (result or {}).get("value", "") or ""
 
     async def _capture_external_pbx_call(
-        self, channel_id: str, channel_name: str = ""
+        self,
+        channel_id: str,
+        channel_name: str = "",
+        lead_fields: Optional[list] = None,
     ) -> Optional[dict]:
         """Capture adapter-defined identity from inbound SIP headers."""
         if self.external_pbx_adapter is None:
@@ -649,14 +652,47 @@ class ARIConnection:
             )
             return None
 
-        async def read_header(name: str) -> str:
-            return await self._get_channel_var(channel_id, f"PJSIP_HEADER(read,{name})")
+        # Adapters batch header reads with asyncio.gather; each read is one
+        # ARI request, so bound the fan-out against the Asterisk HTTP server.
+        read_semaphore = asyncio.Semaphore(8)
 
-        identity = await self.external_pbx_adapter.capture_call_identity(read_header)
+        async def read_header(name: str) -> str:
+            async with read_semaphore:
+                return await self._get_channel_var(
+                    channel_id, f"PJSIP_HEADER(read,{name})"
+                )
+
+        # Discovery aid: PJSIP_HEADERS() returns header *names* in a single
+        # request, so listing what the PBX attaches costs one round trip no
+        # matter how many headers there are. Reading their values is what costs
+        # one request each, which is why this stays names-only and opt-in.
+        if LOG_EXTERNAL_PBX_AVAILABLE_HEADERS and self.external_pbx_adapter.header_prefix:
+            prefix = self.external_pbx_adapter.header_prefix
+            raw = await self._get_channel_var(channel_id, f"PJSIP_HEADERS({prefix})")
+            available = sorted(
+                name.strip()[len(prefix) :]
+                for name in raw.split(",")
+                if name.strip()[len(prefix) :]
+            )
+            logger.info(
+                f"[ARI org={self.organization_id}] Available "
+                f"{self.external_pbx_adapter.type} lead fields on channel "
+                f"{channel_id}: {available or 'none'} — add the ones you need "
+                f"under the workflow's Lead Fields To Capture setting"
+            )
+
+        identity = await self.external_pbx_adapter.capture_call_identity(
+            read_header, lead_fields or ()
+        )
         if identity:
+            # The lead payload can carry PII (name, address, DOB) — log only
+            # which fields were captured, not their values.
+            summary = {k: v for k, v in identity.items() if k != "lead"}
+            lead_fields = sorted((identity.get("lead") or {}).keys())
             logger.info(
                 f"[ARI org={self.organization_id}] Captured "
-                f"{self.external_pbx_adapter.type} call identity for channel {channel_id} identity: {identity}"
+                f"{self.external_pbx_adapter.type} call identity for channel {channel_id} "
+                f"identity: {summary} lead_fields: {lead_fields}"
             )
         return identity
 
@@ -820,8 +856,20 @@ class ARIConnection:
             call_id = channel_id
             run_inputs = await prepare_workflow_run_inputs(db_client, workflow)
             # Capture the configured external PBX identity from SIP headers.
+            # Lead fields come from the definition this run binds to, not from
+            # the workflow's draft-synced legacy column.
+            lead_fields = []
+            if self.external_pbx_adapter is not None:
+                workflow_configurations = (
+                    await db_client.get_definition_configurations(
+                        run_inputs.definition_id
+                    )
+                )
+                lead_fields = (
+                    workflow_configurations.get("external_pbx_lead_headers") or []
+                )
             external_pbx_call = await self._capture_external_pbx_call(
-                channel_id, channel.get("name", "")
+                channel_id, channel.get("name", ""), lead_fields
             )
             workflow_run = await db_client.create_workflow_run(
                 name=f"ARI Inbound {caller_number}",

--- a/api/services/telephony/providers/ari/external_pbx/base.py
+++ b/api/services/telephony/providers/ari/external_pbx/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Mapping
+from typing import Any, Awaitable, Callable, Mapping, Sequence
 
 HeaderReader = Callable[[str], Awaitable[str]]
 
@@ -20,25 +20,34 @@ class ExternalPBXAdapter(ABC):
     """PBX-specific operations; ARI continues to own only Dograh's local leg."""
 
     type: str
+    # SIP header namespace this PBX attaches call identity and lead data under.
+    # Enumerating it lists the fields a deployment actually sends, which is what
+    # the "Lead Fields To Capture" setting is populated from.
+    header_prefix: str = ""
 
     @abstractmethod
     async def capture_call_identity(
-        self, read_header: HeaderReader
-    ) -> dict[str, str] | None:
-        """Read a stable upstream-call identity from inbound SIP headers."""
+        self, read_header: HeaderReader, lead_fields: Sequence[str] = ()
+    ) -> dict[str, Any] | None:
+        """Read a stable upstream-call identity from inbound SIP headers.
+
+        Every header costs one ARI round trip on the inbound call-setup path,
+        so the caller passes the exact ``lead_fields`` the workflow configured
+        instead of the adapter enumerating whatever the PBX happens to attach.
+        """
 
     @abstractmethod
-    async def hangup(self, identity: Mapping[str, str]) -> ExternalPBXResult:
+    async def hangup(self, identity: Mapping[str, Any]) -> ExternalPBXResult:
         """Hang up the customer leg owned by the external PBX."""
 
     @abstractmethod
     async def transfer(
-        self, identity: Mapping[str, str], destination: str
+        self, identity: Mapping[str, Any], destination: str
     ) -> ExternalPBXResult:
         """Transfer the customer leg to a PBX-native destination."""
 
     @abstractmethod
     async def update_fields(
-        self, identity: Mapping[str, str], fields: Mapping[str, str]
+        self, identity: Mapping[str, Any], fields: Mapping[str, str]
     ) -> ExternalPBXResult:
         """Update provider-native fields associated with the call."""

--- a/api/services/telephony/providers/ari/external_pbx/vicidial.py
+++ b/api/services/telephony/providers/ari/external_pbx/vicidial.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 import aiohttp
 from loguru import logger
@@ -13,9 +14,13 @@ from .base import ExternalPBXAdapter, ExternalPBXResult, HeaderReader
 _LEAD_FIELD_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
 _RESERVED_LEAD_FIELDS = frozenset({"source", "user", "pass", "function", "lead_id"})
 
+_HEADER_PREFIX = "X-VICIDIAL-"
+_IDENTITY_HEADER_FIELDS = ("callerid", "user", "lead_id", "campaign_id", "ingroup_id")
+
 
 class VicidialAdapter(ExternalPBXAdapter):
     type = "vicidial"
+    header_prefix = _HEADER_PREFIX
 
     def __init__(self, config: dict[str, Any]):
         agent_api = config.get("agent_api") or {}
@@ -33,22 +38,41 @@ class VicidialAdapter(ExternalPBXAdapter):
         )
 
     async def capture_call_identity(
-        self, read_header: HeaderReader
-    ) -> dict[str, str] | None:
-        callerid = (await read_header("X-VICIDIAL-callerid")).strip()
+        self, read_header: HeaderReader, lead_fields: Sequence[str] = ()
+    ) -> dict[str, Any] | None:
+        # Each header is its own ARI request, so read a fixed set: the identity
+        # fields the transfer/hangup paths need, plus whatever lead fields the
+        # workflow configured. Enumerating X-VICIDIAL-* instead would cost an
+        # extra request up front and one more per header VICIdial happens to
+        # attach — all on the latency-sensitive inbound setup path.
+        names = list(_IDENTITY_HEADER_FIELDS) + [
+            field
+            for field in dict.fromkeys(
+                value.strip() for value in lead_fields if isinstance(value, str)
+            )
+            if field
+            and field not in _IDENTITY_HEADER_FIELDS
+            and _LEAD_FIELD_RE.match(field)
+        ]
+        values = await asyncio.gather(
+            *(read_header(_HEADER_PREFIX + field) for field in names)
+        )
+        headers = {field: value.strip() for field, value in zip(names, values)}
+        callerid = headers.get("callerid", "")
         if not callerid:
             return None
         return {
             "type": self.type,
             "callerid": callerid,
-            "agent_user": (await read_header("X-VICIDIAL-user")).strip(),
-            "lead_id": (await read_header("X-VICIDIAL-lead_id")).strip(),
-            "campaign_id": (await read_header("X-VICIDIAL-campaign_id")).strip(),
-            "ingroup_id": (await read_header("X-VICIDIAL-ingroup_id")).strip(),
+            "agent_user": headers.get("user", ""),
+            "lead_id": headers.get("lead_id", ""),
+            "campaign_id": headers.get("campaign_id", ""),
+            "ingroup_id": headers.get("ingroup_id", ""),
+            "lead": {field: value for field, value in headers.items() if value},
         }
 
     async def _agent_call_control(
-        self, identity: Mapping[str, str], stage: str, **extra: str
+        self, identity: Mapping[str, Any], stage: str, **extra: str
     ) -> ExternalPBXResult:
         if not all([self._agent_url, self._agent_user, self._agent_password]):
             return ExternalPBXResult(
@@ -90,11 +114,11 @@ class VicidialAdapter(ExternalPBXAdapter):
                 False, stage.lower(), "VICIdial API request failed"
             )
 
-    async def hangup(self, identity: Mapping[str, str]) -> ExternalPBXResult:
+    async def hangup(self, identity: Mapping[str, Any]) -> ExternalPBXResult:
         return await self._agent_call_control(identity, "HANGUP")
 
     async def transfer(
-        self, identity: Mapping[str, str], destination: str
+        self, identity: Mapping[str, Any], destination: str
     ) -> ExternalPBXResult:
         choice = destination.strip()
         if choice.lower() == "source":
@@ -108,7 +132,7 @@ class VicidialAdapter(ExternalPBXAdapter):
         )
 
     async def update_fields(
-        self, identity: Mapping[str, str], fields: Mapping[str, str]
+        self, identity: Mapping[str, Any], fields: Mapping[str, str]
     ) -> ExternalPBXResult:
         if not fields:
             return ExternalPBXResult(True, "update_lead", "No lead fields configured")

--- a/api/services/workflow/configuration_policy.py
+++ b/api/services/workflow/configuration_policy.py
@@ -9,6 +9,15 @@ from api.db import db_client
 from api.services.organization_preferences import external_pbx_integrations_enabled
 
 
+# Configuration keys owned by the External PBX UI section. All of them vanish
+# from the request payload while that section is hidden, so all of them must be
+# preserved from storage rather than silently reset to their defaults.
+_EXTERNAL_PBX_CONFIGURATION_KEYS = (
+    "external_pbx_field_mappings",
+    "external_pbx_lead_headers",
+)
+
+
 class WorkflowConfigurationNotFoundError(LookupError):
     """Raised when configuration policy cannot resolve the target workflow."""
 
@@ -23,11 +32,11 @@ async def apply_external_pbx_mapping_policy(
     workflow_id: int,
     organization_id: int,
 ) -> dict[str, Any] | None:
-    """Preserve hidden mappings and reject edits while external PBX is disabled.
+    """Preserve hidden settings and reject edits while external PBX is disabled.
 
     Workflow configuration updates replace the stored configuration document. When
-    the External PBX UI is hidden, its field mappings are absent from the request,
-    so they must be copied from the active draft or published definition before the
+    the External PBX UI is hidden, its settings are absent from the request, so
+    they must be copied from the active draft or published definition before the
     update is persisted.
     """
     if workflow_configurations is None or await external_pbx_integrations_enabled(
@@ -49,22 +58,23 @@ async def apply_external_pbx_mapping_policy(
         if draft
         else workflow.released_definition.workflow_configurations
     )
-    stored_mappings = (stored_configurations or {}).get(
-        "external_pbx_field_mappings", []
-    )
-    incoming_mappings = workflow_configurations.get(
-        "external_pbx_field_mappings", stored_mappings
-    )
-
-    if incoming_mappings != stored_mappings:
-        raise ExternalPBXConfigurationDisabledError(
-            "External PBX integrations are disabled for this organization. "
-            "Enable them in Platform Settings before changing field mappings."
-        )
-
-    if not stored_mappings:
-        return workflow_configurations
-
     prepared_configurations = dict(workflow_configurations)
-    prepared_configurations["external_pbx_field_mappings"] = deepcopy(stored_mappings)
+    preserved_any = False
+    for key in _EXTERNAL_PBX_CONFIGURATION_KEYS:
+        stored_value = (stored_configurations or {}).get(key, [])
+        incoming_value = workflow_configurations.get(key, stored_value)
+
+        if incoming_value != stored_value:
+            raise ExternalPBXConfigurationDisabledError(
+                "External PBX integrations are disabled for this organization. "
+                "Enable them in Platform Settings before changing external PBX "
+                "settings."
+            )
+
+        if stored_value:
+            prepared_configurations[key] = deepcopy(stored_value)
+            preserved_any = True
+
+    if not preserved_any:
+        return workflow_configurations
     return prepared_configurations

--- a/api/tests/telephony/providers/ari/test_external_pbx.py
+++ b/api/tests/telephony/providers/ari/test_external_pbx.py
@@ -32,8 +32,19 @@ def _vicidial_config() -> dict:
     }
 
 
+def _header_access(headers: dict[str, str]):
+    """Return a reader plus the list of header names it was asked for."""
+    requested: list[str] = []
+
+    async def read_header(name: str) -> str:
+        requested.append(name)
+        return headers.get(name, "")
+
+    return read_header, requested
+
+
 @pytest.mark.asyncio
-async def test_vicidial_adapter_captures_call_identity_from_headers():
+async def test_vicidial_adapter_captures_identity_and_configured_lead_fields():
     adapter = create_adapter(_vicidial_config())
     headers = {
         "X-VICIDIAL-callerid": "M123",
@@ -41,12 +52,15 @@ async def test_vicidial_adapter_captures_call_identity_from_headers():
         "X-VICIDIAL-lead_id": "42",
         "X-VICIDIAL-campaign_id": "campaign",
         "X-VICIDIAL-ingroup_id": "source-group",
+        "X-VICIDIAL-first_name": "Ada",
+        "X-VICIDIAL-comments": "  prefers mornings  ",
+        "X-VICIDIAL-address2": "",
     }
+    read_header, requested = _header_access(headers)
 
-    async def read_header(name: str) -> str:
-        return headers.get(name, "")
-
-    identity = await adapter.capture_call_identity(read_header)
+    identity = await adapter.capture_call_identity(
+        read_header, ["first_name", "comments", "address2"]
+    )
 
     assert identity == {
         "type": "vicidial",
@@ -55,7 +69,150 @@ async def test_vicidial_adapter_captures_call_identity_from_headers():
         "lead_id": "42",
         "campaign_id": "campaign",
         "ingroup_id": "source-group",
+        "lead": {
+            "callerid": "M123",
+            "user": "remote-agent",
+            "lead_id": "42",
+            "campaign_id": "campaign",
+            "ingroup_id": "source-group",
+            "first_name": "Ada",
+            "comments": "prefers mornings",
+        },
     }
+    # Exactly one read per configured field, and no enumeration request.
+    assert requested == [
+        "X-VICIDIAL-callerid",
+        "X-VICIDIAL-user",
+        "X-VICIDIAL-lead_id",
+        "X-VICIDIAL-campaign_id",
+        "X-VICIDIAL-ingroup_id",
+        "X-VICIDIAL-first_name",
+        "X-VICIDIAL-comments",
+        "X-VICIDIAL-address2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_vicidial_adapter_reads_only_identity_fields_when_unconfigured():
+    adapter = create_adapter(_vicidial_config())
+    headers = {
+        "X-VICIDIAL-callerid": "M123",
+        "X-VICIDIAL-user": "remote-agent",
+        "X-VICIDIAL-lead_id": "42",
+        "X-VICIDIAL-first_name": "Ada",
+    }
+    read_header, requested = _header_access(headers)
+
+    identity = await adapter.capture_call_identity(read_header)
+
+    assert identity == {
+        "type": "vicidial",
+        "callerid": "M123",
+        "agent_user": "remote-agent",
+        "lead_id": "42",
+        "campaign_id": "",
+        "ingroup_id": "",
+        "lead": {
+            "callerid": "M123",
+            "user": "remote-agent",
+            "lead_id": "42",
+        },
+    }
+    # The unconfigured lead field is never fetched.
+    assert "X-VICIDIAL-first_name" not in requested
+    assert len(requested) == 5
+
+
+@pytest.mark.asyncio
+async def test_vicidial_adapter_ignores_duplicate_and_invalid_lead_fields():
+    adapter = create_adapter(_vicidial_config())
+    headers = {
+        "X-VICIDIAL-callerid": "M123",
+        "X-VICIDIAL-user": "remote-agent",
+        "X-VICIDIAL-first_name": "Ada",
+    }
+    read_header, requested = _header_access(headers)
+
+    await adapter.capture_call_identity(
+        read_header,
+        # duplicate, identity field, whitespace, empty, and injection-shaped
+        ["first_name", " first_name ", "callerid", "", "bad name)"],
+    )
+
+    assert requested.count("X-VICIDIAL-first_name") == 1
+    assert requested.count("X-VICIDIAL-callerid") == 1
+    assert len(requested) == 6
+
+
+@pytest.mark.asyncio
+async def test_vicidial_adapter_returns_none_without_callerid():
+    adapter = create_adapter(_vicidial_config())
+    read_header, _ = _header_access({"X-VICIDIAL-first_name": "Ada"})
+
+    identity = await adapter.capture_call_identity(read_header, ["first_name"])
+
+    assert identity is None
+
+
+def _ari_connection(monkeypatch, variables: dict[str, str]):
+    """An ARIConnection whose ARI variable reads are recorded, not sent."""
+    from api.services.telephony import ari_manager
+
+    connection = ari_manager.ARIConnection(
+        organization_id=7,
+        telephony_configuration_id=1,
+        ari_endpoint="http://asterisk.example.com",
+        app_name="dograh",
+        app_password="secret",
+        external_pbx_config=_vicidial_config(),
+    )
+    requested: list[str] = []
+
+    async def fake_get_channel_var(channel_id: str, variable: str) -> str:
+        requested.append(variable)
+        return variables.get(variable, "")
+
+    monkeypatch.setattr(connection, "_get_channel_var", fake_get_channel_var)
+    return connection, requested
+
+
+@pytest.mark.asyncio
+async def test_available_headers_are_listed_in_one_request(monkeypatch):
+    from api.services.telephony import ari_manager
+
+    monkeypatch.setattr(ari_manager, "LOG_EXTERNAL_PBX_AVAILABLE_HEADERS", True)
+    connection, requested = _ari_connection(
+        monkeypatch,
+        {
+            "PJSIP_HEADERS(X-VICIDIAL-)": (
+                "X-VICIDIAL-callerid,X-VICIDIAL-user,X-VICIDIAL-first_name"
+            ),
+            "PJSIP_HEADER(read,X-VICIDIAL-callerid)": "M123",
+            "PJSIP_HEADER(read,X-VICIDIAL-user)": "remote-agent",
+        },
+    )
+
+    await connection._capture_external_pbx_call("chan-1", "PJSIP/inbound-0001")
+
+    # Enumeration is a single request regardless of how many headers exist.
+    assert requested.count("PJSIP_HEADERS(X-VICIDIAL-)") == 1
+    # ...and it does not pull the values of the fields it merely lists.
+    assert "PJSIP_HEADER(read,X-VICIDIAL-first_name)" not in requested
+
+
+@pytest.mark.asyncio
+async def test_available_header_listing_is_skipped_when_disabled(monkeypatch):
+    from api.services.telephony import ari_manager
+
+    monkeypatch.setattr(ari_manager, "LOG_EXTERNAL_PBX_AVAILABLE_HEADERS", False)
+    connection, requested = _ari_connection(
+        monkeypatch, {"PJSIP_HEADER(read,X-VICIDIAL-callerid)": "M123"}
+    )
+
+    await connection._capture_external_pbx_call("chan-1", "PJSIP/inbound-0001")
+
+    assert not any(name.startswith("PJSIP_HEADERS(") for name in requested)
+    assert len(requested) == 5
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_workflow_configuration_policy.py
+++ b/api/tests/test_workflow_configuration_policy.py
@@ -6,10 +6,13 @@ import pytest
 from api.services.workflow import configuration_policy
 
 
-def _stored_workflow(mappings: list[dict]):
+def _stored_workflow(mappings: list[dict], lead_headers: list[str] | None = None):
     return SimpleNamespace(
         released_definition=SimpleNamespace(
-            workflow_configurations={"external_pbx_field_mappings": mappings}
+            workflow_configurations={
+                "external_pbx_field_mappings": mappings,
+                "external_pbx_lead_headers": lead_headers or [],
+            }
         )
     )
 
@@ -69,6 +72,65 @@ async def test_disabled_external_pbx_policy_rejects_mapping_changes(monkeypatch)
                     {"context_path": "qualified", "destination_field": "comments"}
                 ]
             },
+            workflow_id=12,
+            organization_id=7,
+        )
+
+
+@pytest.mark.asyncio
+async def test_disabled_external_pbx_policy_preserves_hidden_lead_headers(monkeypatch):
+    mappings = [{"context_path": "qualified", "destination_field": "address3"}]
+    lead_headers = ["first_name", "address1"]
+    monkeypatch.setattr(
+        configuration_policy,
+        "external_pbx_integrations_enabled",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        configuration_policy.db_client,
+        "get_workflow",
+        AsyncMock(return_value=_stored_workflow(mappings, lead_headers)),
+    )
+    monkeypatch.setattr(
+        configuration_policy.db_client,
+        "get_draft_version",
+        AsyncMock(return_value=None),
+    )
+
+    prepared = await configuration_policy.apply_external_pbx_mapping_policy(
+        {"max_call_duration": 600},
+        workflow_id=12,
+        organization_id=7,
+    )
+
+    assert prepared == {
+        "max_call_duration": 600,
+        "external_pbx_field_mappings": mappings,
+        "external_pbx_lead_headers": lead_headers,
+    }
+
+
+@pytest.mark.asyncio
+async def test_disabled_external_pbx_policy_rejects_lead_header_changes(monkeypatch):
+    monkeypatch.setattr(
+        configuration_policy,
+        "external_pbx_integrations_enabled",
+        AsyncMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        configuration_policy.db_client,
+        "get_workflow",
+        AsyncMock(return_value=_stored_workflow([], ["first_name"])),
+    )
+    monkeypatch.setattr(
+        configuration_policy.db_client,
+        "get_draft_version",
+        AsyncMock(return_value=None),
+    )
+
+    with pytest.raises(configuration_policy.ExternalPBXConfigurationDisabledError):
+        await configuration_policy.apply_external_pbx_mapping_policy(
+            {"external_pbx_lead_headers": ["first_name", "address1"]},
             workflow_id=12,
             organization_id=7,
         )

--- a/api/tests/test_workflow_configurations_schema.py
+++ b/api/tests/test_workflow_configurations_schema.py
@@ -9,6 +9,7 @@ from api.constants import (
 from api.schemas.workflow_configurations import (
     DEFAULT_MAX_CALL_DURATION_SECONDS,
     MAX_CALL_DURATION_SECONDS,
+    MAX_EXTERNAL_PBX_LEAD_HEADERS,
     TextChatInactivityTimeoutConstraints,
     WorkflowConfigurationDefaults,
 )
@@ -144,3 +145,45 @@ def test_external_pbx_field_mapping_rejects_invalid_field_names():
                 {"context_path": "qualified", "destination_field": "invalid-field"}
             ]
         )
+
+
+def test_external_pbx_lead_headers_default_to_empty():
+    assert WorkflowConfigurationDefaults().external_pbx_lead_headers == []
+
+
+def test_external_pbx_lead_headers_are_stripped_and_deduplicated_in_order():
+    config = WorkflowConfigurationDefaults(
+        external_pbx_lead_headers=["  first_name  ", "address1", "first_name", "", "  "]
+    )
+
+    assert config.external_pbx_lead_headers == ["first_name", "address1"]
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "1first_name",  # must start with a letter
+        "first name",  # no spaces
+        "first-name",  # no dashes
+        "PJSIP_HEADER(read,x))",  # function-injection shaped
+        "a" * 65,  # over the length cap
+    ],
+)
+def test_external_pbx_lead_headers_reject_unsafe_field_names(field):
+    with pytest.raises(ValidationError, match="external_pbx_lead_headers"):
+        WorkflowConfigurationDefaults(external_pbx_lead_headers=[field])
+
+
+def test_external_pbx_lead_headers_reject_oversized_list():
+    fields = [f"field_{index}" for index in range(MAX_EXTERNAL_PBX_LEAD_HEADERS + 1)]
+
+    with pytest.raises(ValidationError, match="external_pbx_lead_headers"):
+        WorkflowConfigurationDefaults(external_pbx_lead_headers=fields)
+
+
+def test_external_pbx_lead_headers_treat_null_as_unset():
+    config = WorkflowConfigurationDefaults.model_validate(
+        {"external_pbx_lead_headers": None}
+    )
+
+    assert config.external_pbx_lead_headers == []

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -207,6 +207,20 @@ services:
       # from this value and nginx load-balances across them with least_conn.
       FASTAPI_WORKERS: "${FASTAPI_WORKERS:-1}"
 
+      # Optional singleton background services started by the container CMD
+      # (scripts/start_services_docker.sh). Both default to on; set either to
+      # "false" in .env to run this container as an API/worker node only — e.g. a
+      # scale-out replica that must not also run the telephony ARI bridge
+      # (ari_manager) or the outbound campaign loop (campaign_orchestrator).
+      ENABLE_ARI_MANAGER: "${ENABLE_ARI_MANAGER:-true}"
+      ENABLE_CAMPAIGN_ORCHESTRATOR: "${ENABLE_CAMPAIGN_ORCHESTRATOR:-true}"
+
+      # Log which external-PBX lead headers each inbound call carries, to
+      # discover what the PBX attaches. Adds one ARI request per inbound call
+      # (header names only), so enable it during integration setup, not steady
+      # state.
+      LOG_EXTERNAL_PBX_AVAILABLE_HEADERS: "${LOG_EXTERNAL_PBX_AVAILABLE_HEADERS:-false}"
+
       # Trust X-Forwarded-* headers from any peer so uvicorn honors nginx's
       # `X-Forwarded-Proto: https`. nginx runs as its own container and reaches
       # uvicorn from a Docker-network IP (not loopback), but uvicorn trusts only

--- a/docs/integrations/telephony/vicidial.mdx
+++ b/docs/integrations/telephony/vicidial.mdx
@@ -76,6 +76,49 @@ Hangup and transfer require the call-control identifier and remote-agent user.
 Lead updates additionally require the lead ID. The source in-group header is
 only required when a transfer mapping uses the `source` fallback.
 
+### Pass lead data in additional headers
+
+Configure VICIdial or the dialplan to attach lead fields as headers, for example
+`X-VICIDIAL-first_name`, `X-VICIDIAL-city`, or `X-VICIDIAL-vendor_lead_code`.
+Headers with empty values are ignored.
+
+Each lead field is then read individually during call setup, so Dograh captures
+only the fields you list:
+
+1. Open the workflow's **General Settings**.
+2. Under **External PBX Field Updates**, find **Lead Fields To Capture**.
+3. Add one entry per field, named **without** the `X-VICIDIAL-` prefix — enter
+   `first_name` to capture `X-VICIDIAL-first_name`.
+
+<Note>
+  Every field you add costs one extra request to Asterisk while the call is being
+  set up, which delays the agent's first response. List only the fields your
+  prompts actually use.
+</Note>
+
+#### Discover which fields your PBX sends
+
+To see what a call actually carries, set `LOG_EXTERNAL_PBX_AVAILABLE_HEADERS=true`
+and place a test call. Each inbound call then logs the available field names:
+
+```text
+[ARI org=7] Available vicidial lead fields on channel 1712...: ['callerid',
+'city', 'first_name', 'lead_id', 'user'] — add the ones you need under the
+workflow's Lead Fields To Capture setting
+```
+
+Listing the names costs a single request no matter how many headers are present,
+because it reads names only — never values. Turn the flag off once you have
+configured the fields you need.
+
+Captured fields are available to workflow prompts through template variables
+named after the header suffix:
+
+```text
+Hello {{external_pbx_call.lead.first_name | there}}, I see you're calling
+from {{external_pbx_call.lead.city}}.
+```
+
 ## Configure in-group transfers
 
 In-group mappings select a VICIdial destination from information gathered by

--- a/scripts/start_services.sh
+++ b/scripts/start_services.sh
@@ -46,6 +46,18 @@ UVICORN_BASE_PORT=${UVICORN_BASE_PORT:-8000}
 CPU_CORES=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
 FASTAPI_WORKERS=${FASTAPI_WORKERS:-$CPU_CORES}
 
+# Interface uvicorn binds to. Defaults to loopback for single-box installs where
+# a local nginx proxies to it. In a cluster where nginx runs on a separate host,
+# set UVICORN_HOST=0.0.0.0 (or this node's reachable IP) in api/.env so the
+# remote nginx can reach these workers.
+UVICORN_HOST=${UVICORN_HOST:-127.0.0.1}
+
+# Whether this node manages a local nginx (renders the upstream config and
+# reloads nginx). Defaults to "true" for single-box installs. In a cluster where
+# nginx lives on a separate host, set MANAGE_NGINX=false in api/.env so this
+# API/worker node never touches nginx.
+MANAGE_NGINX=${MANAGE_NGINX:-true}
+
 ###############################################################################
 ### 1b) Safety check — refuse to start over running services
 ###############################################################################
@@ -95,21 +107,36 @@ echo "Node $NODE_VERSION detected (>= 22.6 required)"
 
 # Map "service name" → "command to run"
 # Using arrays for bash 3.2 compatibility
-SERVICE_NAMES=(
-  "ari_manager"
-  "campaign_orchestrator"
-)
+SERVICE_NAMES=()
+SERVICE_COMMANDS=()
 
-SERVICE_COMMANDS=(
-  "python -m api.services.telephony.ari_manager"
-  "python -m api.services.campaign.campaign_orchestrator"
-)
+# ari_manager (telephony ARI bridge) and campaign_orchestrator (outbound
+# campaign loop) are optional. Each is gated behind an env flag that defaults to
+# "true" so existing installs are unchanged; set the flag to "false" in api/.env
+# to run this node as an API/worker tier only (e.g. a scale-out replica that must
+# not also run these singleton services).
+ENABLE_ARI_MANAGER=${ENABLE_ARI_MANAGER:-true}
+ENABLE_CAMPAIGN_ORCHESTRATOR=${ENABLE_CAMPAIGN_ORCHESTRATOR:-true}
+
+if [[ "$ENABLE_ARI_MANAGER" == "true" ]]; then
+  SERVICE_NAMES+=("ari_manager")
+  SERVICE_COMMANDS+=("python -m api.services.telephony.ari_manager")
+else
+  echo "ari_manager disabled (ENABLE_ARI_MANAGER=$ENABLE_ARI_MANAGER)"
+fi
+
+if [[ "$ENABLE_CAMPAIGN_ORCHESTRATOR" == "true" ]]; then
+  SERVICE_NAMES+=("campaign_orchestrator")
+  SERVICE_COMMANDS+=("python -m api.services.campaign.campaign_orchestrator")
+else
+  echo "campaign_orchestrator disabled (ENABLE_CAMPAIGN_ORCHESTRATOR=$ENABLE_CAMPAIGN_ORCHESTRATOR)"
+fi
 
 # Add uvicorn workers on separate ports (behind nginx least_conn)
 for ((w=0; w<FASTAPI_WORKERS; w++)); do
   port=$((UVICORN_BASE_PORT + w))
   SERVICE_NAMES+=("uvicorn_$port")
-  SERVICE_COMMANDS+=("uvicorn api.app:app --host 127.0.0.1 --port $port")
+  SERVICE_COMMANDS+=("uvicorn api.app:app --host $UVICORN_HOST --port $port")
 done
 
 # Add ARQ workers dynamically
@@ -198,7 +225,9 @@ echo "A" > "$RUN_DIR/active_band"
 ### 8) Generate nginx upstream config & reload
 ###############################################################################
 
-if [[ -f "$NGINX_UPSTREAM_TEMPLATE" ]]; then
+if [[ "$MANAGE_NGINX" != "true" ]]; then
+  echo "Skipping nginx config (MANAGE_NGINX=$MANAGE_NGINX) — nginx managed off-node."
+elif [[ -f "$NGINX_UPSTREAM_TEMPLATE" ]]; then
   # Build upstream server list from worker ports
   UPSTREAM_SERVERS=""
   for ((w=0; w<FASTAPI_WORKERS; w++)); do

--- a/scripts/start_services_docker.sh
+++ b/scripts/start_services_docker.sh
@@ -59,8 +59,23 @@ start() {
 ### 4) Start services (logs go to stdout for `docker logs`)
 ###############################################################################
 
-start ari_manager           python -m api.services.telephony.ari_manager
-start campaign_orchestrator python -m api.services.campaign.campaign_orchestrator
+# ari_manager and campaign_orchestrator are optional; each defaults to on and
+# can be turned off (e.g. for an API/worker-only replica) by setting the flag to
+# "false" in the container env / docker-compose .env.
+ENABLE_ARI_MANAGER=${ENABLE_ARI_MANAGER:-true}
+ENABLE_CAMPAIGN_ORCHESTRATOR=${ENABLE_CAMPAIGN_ORCHESTRATOR:-true}
+
+if [[ "$ENABLE_ARI_MANAGER" == "true" ]]; then
+  start ari_manager           python -m api.services.telephony.ari_manager
+else
+  echo "ari_manager disabled (ENABLE_ARI_MANAGER=$ENABLE_ARI_MANAGER)"
+fi
+
+if [[ "$ENABLE_CAMPAIGN_ORCHESTRATOR" == "true" ]]; then
+  start campaign_orchestrator python -m api.services.campaign.campaign_orchestrator
+else
+  echo "campaign_orchestrator disabled (ENABLE_CAMPAIGN_ORCHESTRATOR=$ENABLE_CAMPAIGN_ORCHESTRATOR)"
+fi
 
 # Spawn FASTAPI_WORKERS independent uvicorn processes on consecutive ports
 # starting at UVICORN_BASE_PORT. nginx upstream (configured in setup_remote.sh)

--- a/ui/src/app/workflow/[workflowId]/settings/page.tsx
+++ b/ui/src/app/workflow/[workflowId]/settings/page.tsx
@@ -307,6 +307,9 @@ function GeneralSection({
     const [externalPbxFieldMappings, setExternalPbxFieldMappings] = useState<ExternalPBXFieldMapping[]>(
         workflowConfigurations.external_pbx_field_mappings,
     );
+    const [externalPbxLeadHeaders, setExternalPbxLeadHeaders] = useState<string[]>(
+        workflowConfigurations.external_pbx_lead_headers,
+    );
     const [isSaving, setIsSaving] = useState(false);
     const [isUploadingAudio, setIsUploadingAudio] = useState(false);
     const [audioUploadError, setAudioUploadError] = useState<string | null>(null);
@@ -320,6 +323,11 @@ function GeneralSection({
             Boolean(mapping.context_path.trim()) &&
             /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(mapping.destination_field.trim()),
     );
+    const externalPbxLeadHeadersValid = externalPbxLeadHeaders.every((field) =>
+        /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(field.trim()),
+    );
+    const externalPbxSettingsValid =
+        externalPbxFieldMappingsValid && externalPbxLeadHeadersValid;
 
     const isDirty = useMemo(() => {
         const initAmbient = workflowConfigurations.ambient_noise_configuration;
@@ -337,9 +345,11 @@ function GeneralSection({
             includeTranscriptEndTimestamps !==
             (workflowConfigurations.transcript_configuration?.include_end_timestamps ?? false) ||
             JSON.stringify(externalPbxFieldMappings) !==
-            JSON.stringify(workflowConfigurations.external_pbx_field_mappings)
+            JSON.stringify(workflowConfigurations.external_pbx_field_mappings) ||
+            JSON.stringify(externalPbxLeadHeaders) !==
+            JSON.stringify(workflowConfigurations.external_pbx_lead_headers)
         );
-    }, [name, workflowName, ambientNoiseConfig, maxCallDuration, maxUserIdleTimeout, smartTurnStopSecs, turnStartStrategy, turnStartMinWords, provisionalVadPauseSecs, turnStopStrategy, contextCompactionEnabled, includeTranscriptEndTimestamps, externalPbxFieldMappings, workflowConfigurations]);
+    }, [name, workflowName, ambientNoiseConfig, maxCallDuration, maxUserIdleTimeout, smartTurnStopSecs, turnStartStrategy, turnStartMinWords, provisionalVadPauseSecs, turnStopStrategy, contextCompactionEnabled, includeTranscriptEndTimestamps, externalPbxFieldMappings, externalPbxLeadHeaders, workflowConfigurations]);
 
     useUnsavedChanges("general", isDirty);
 
@@ -421,6 +431,7 @@ function GeneralSection({
                         include_end_timestamps: includeTranscriptEndTimestamps,
                     },
                     external_pbx_field_mappings: externalPbxFieldMappings,
+                    external_pbx_lead_headers: externalPbxLeadHeaders.map((field) => field.trim()),
                 },
                 name,
             );
@@ -889,6 +900,66 @@ function GeneralSection({
                                     </p>
                                 )}
                             </div>
+
+                            <div className="space-y-4 border-t pt-4">
+                                <div>
+                                    <h3 className="text-sm font-medium">Lead Fields To Capture</h3>
+                                    <p className="text-xs text-muted-foreground mt-0.5">
+                                        Extra lead fields to read from the inbound call, named without the header prefix
+                                        (<code>first_name</code> reads <code>X-VICIDIAL-first_name</code>). Captured values are
+                                        addressable in prompts as <code>{"{{initial_context.external_pbx_call.lead.<field>}}"}</code>.
+                                        Each field adds one request during call setup, so list only what the agent uses.
+                                    </p>
+                                </div>
+                                <div className="flex items-center justify-between">
+                                    <Label className="text-sm">Lead Fields</Label>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => setExternalPbxLeadHeaders((current) => [...current, ""])}
+                                    >
+                                        <Plus className="mr-1 h-4 w-4" /> Add field
+                                    </Button>
+                                </div>
+                                <div className="space-y-2">
+                                    {externalPbxLeadHeaders.map((field, index) => (
+                                        <div key={index} className="grid grid-cols-[1fr_auto] gap-2">
+                                            <Input
+                                                aria-label={`External PBX lead field ${index + 1}`}
+                                                value={field}
+                                                onChange={(event) => setExternalPbxLeadHeaders((current) =>
+                                                    current.map((item, itemIndex) =>
+                                                        itemIndex === index ? event.target.value : item,
+                                                    )
+                                                )}
+                                                placeholder="first_name"
+                                            />
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="icon"
+                                                aria-label={`Remove external PBX lead field ${index + 1}`}
+                                                onClick={() => setExternalPbxLeadHeaders((current) =>
+                                                    current.filter((_, itemIndex) => itemIndex !== index)
+                                                )}
+                                            >
+                                                <Trash2Icon className="h-4 w-4" />
+                                            </Button>
+                                        </div>
+                                    ))}
+                                    {externalPbxLeadHeaders.length === 0 && (
+                                        <p className="text-xs text-muted-foreground">
+                                            Only the identity fields needed to transfer or hang up the call are captured.
+                                        </p>
+                                    )}
+                                    {!externalPbxLeadHeadersValid && (
+                                        <p className="text-xs text-destructive">
+                                            Each lead field must start with a letter and contain only letters, numbers, and underscores.
+                                        </p>
+                                    )}
+                                </div>
+                            </div>
                         </div>
                     </>
                 )}
@@ -897,7 +968,7 @@ function GeneralSection({
                 {isDirty && <span className="text-xs text-muted-foreground">Unsaved changes</span>}
                 <Button
                     onClick={handleSave}
-                    disabled={isSaving || !isDirty || (externalPbxIntegrationsEnabled && !externalPbxFieldMappingsValid)}
+                    disabled={isSaving || !isDirty || (externalPbxIntegrationsEnabled && !externalPbxSettingsValid)}
                 >
                     {isSaving ? "Saving..." : "Save General Settings"}
                 </Button>

--- a/ui/src/types/workflow-configurations.ts
+++ b/ui/src/types/workflow-configurations.ts
@@ -117,6 +117,7 @@ type WorkflowConfigurationBase = Omit<
     | "context_compaction_enabled"
     | "text_chat_inactivity_timeout_seconds"
     | "external_pbx_field_mappings"
+    | "external_pbx_lead_headers"
 >;
 
 export type WorkflowConfigurations = WorkflowConfigurationBase & {
@@ -134,6 +135,7 @@ export type WorkflowConfigurations = WorkflowConfigurationBase & {
     context_compaction_enabled: boolean;  // Summarize context on node transitions to remove stale tool calls
     text_chat_inactivity_timeout_seconds?: number;  // End inactive text chats after this many seconds
     external_pbx_field_mappings: ExternalPBXFieldMapping[];
+    external_pbx_lead_headers: string[];  // Extra lead fields to capture from the inbound INVITE
     model_overrides?: ModelOverrides;  // Per-workflow model configuration overrides
     model_configuration_v2_override?: OrganizationAiModelConfigurationV2;  // Full v2 model configuration override
     [key: string]: unknown;  // Allow additional properties for future configurations
@@ -155,6 +157,7 @@ const FALLBACK_WORKFLOW_CONFIGURATIONS: WorkflowConfigurations = {
     transcript_configuration: DEFAULT_TRANSCRIPT_CONFIGURATION,
     context_compaction_enabled: false,
     external_pbx_field_mappings: [],
+    external_pbx_lead_headers: [],
 };
 
 export function resolveWorkflowConfigurations(
@@ -213,6 +216,12 @@ export function resolveWorkflowConfigurations(
             configurations?.external_pbx_field_mappings
             ?? defaults?.external_pbx_field_mappings
             ?? FALLBACK_WORKFLOW_CONFIGURATIONS.external_pbx_field_mappings,
+        external_pbx_lead_headers:
+            configurations?.external_pbx_lead_headers
+            // Cast until `npm run generate-client` runs against a backend
+            // carrying this field; the generated defaults type predates it.
+            ?? (defaults?.external_pbx_lead_headers as string[] | undefined)
+            ?? FALLBACK_WORKFLOW_CONFIGURATIONS.external_pbx_lead_headers,
         transcript_configuration: {
             ...DEFAULT_TRANSCRIPT_CONFIGURATION,
             ...(defaults?.transcript_configuration as Partial<TranscriptConfiguration> | undefined),


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make VICIdial lead capture explicit and faster. Workflows now list the lead headers to read, cutting ARI requests during inbound call setup and preventing draft edits from changing live behavior.

- **New Features**
  - Lead capture: add `external_pbx_lead_headers` to workflow config. The VICIdial adapter reads only the identity fields plus these names. Values come from the bound definition, not the draft.
  - Discovery: `LOG_EXTERNAL_PBX_AVAILABLE_HEADERS=true` logs available VICIdial header names via a single `PJSIP_HEADERS()` call (names only, no values).
  - UI/schema: settings page adds “Lead Fields To Capture”; API schema/types validate, trim, and dedupe; policy preserves these settings and rejects edits when external PBX is disabled.
  - Deployment: optional services via `ENABLE_ARI_MANAGER`, `ENABLE_CAMPAIGN_ORCHESTRATOR`; control bind host with `UVICORN_HOST`; skip local nginx with `MANAGE_NGINX`. Docker Compose exposes these.
  - Misc: cap concurrent ARI header reads; fix file sink to use the configured log format.

- **Migration**
  - Breaking: automatic lead capture is removed. For each workflow, add the needed fields under General Settings → External PBX → Lead Fields To Capture (e.g. first_name → X-VICIDIAL-first_name).
  - Prompts continue to use {{initial_context.external_pbx_call.lead.<field>}} once configured.
  - During setup, optionally enable `LOG_EXTERNAL_PBX_AVAILABLE_HEADERS` to see which fields your PBX sends, then turn it off.
  - In multi-node deployments, set `ENABLE_ARI_MANAGER`/`ENABLE_CAMPAIGN_ORCHESTRATOR` per node to avoid running singleton services on API-only replicas.

<sup>Written for commit 90d2409a88045c336b60d90a5d0a863fdd983057. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds VICIdial lead-header capture controls and deployment-role settings for nginx and singleton services. The rolling-update path was exercised with an API/worker-only configuration and does not honor those settings: it fails when local nginx is intentionally absent, and with nginx present it reloads nginx and starts disabled singleton services. Update the deployment script before merging so role-specific nodes can be updated safely.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until rolling updates respect the configured nginx and singleton-service roles.

An isolated execution of the production update script reproduced one independent, non-security deployment failure and confirmed both the nginx and singleton-service consequences.

**Files Needing Attention:** scripts/rolling_update.sh must apply MANAGE_NGINX, ENABLE_ARI_MANAGER, and ENABLE_CAMPAIGN_ORCHESTRATOR consistently with scripts/start_services.sh.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex published a proof for the posted P1 finding and attached artifacts showing the isolated rolling-update role-flags harness and related logs.
- T-Rex published another proof for the posted P1 finding.
- The general-contract-validation-proof documents pre- and post-capture behavior and proposes changes to rolling\_update.sh to skip nginx preflight when MANAGE\_NGINX is not true.

<a href="https://app.greptile.com/trex/runs/18127689/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `scripts/rolling_update.sh`, line 226-231 ([link](https://github.com/dograh-hq/dograh/blob/90d2409a88045c336b60d90a5d0a863fdd983057/scripts/rolling_update.sh#L226-L231)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Rolling updates ignore deployment-role settings**

   `start_services.sh` allows API/worker-only nodes to set `MANAGE_NGINX=false`, `ENABLE_ARI_MANAGER=false`, and `ENABLE_CAMPAIGN_ORCHESTRATOR=false`, but this update script does not honor any of those settings. It aborts when local nginx is intentionally absent and, if nginx is available, reloads it and starts both singleton services regardless of the flags. This prevents scale-out API/worker replicas from using the update path and can create duplicate ARI manager or campaign orchestrator processes. Load and apply the same flags here: skip the local nginx transition for off-node-nginx deployments and only restart singleton services that are enabled.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Isolated rolling-update role-flags harness](https://app.greptile.com/trex/artifacts/6d792073-5c7c-4645-881d-a9d300bba225)**

   - Executable harness copies the production script to a temporary directory and replaces every service-facing executable with mocks, proving no production service can run.

   **[Rolling update with nginx absent and all role flags disabled](https://app.greptile.com/trex/artifacts/c820bc4d-1911-4edf-80ac-9f4f729615d3)**

   - The isolated run sets MANAGE\_NGINX and both singleton flags to false, mocks nginx as absent, and exits 1 at the nginx preflight check, proving the off-node role fails.

   **[Rolling update with mocked nginx and all role flags disabled](https://app.greptile.com/trex/artifacts/2d0ba46d-9787-49bd-b11b-758c4e3c64f8)**

   - The same isolated configuration completes only with mocked nginx and records nginx reload plus starts of both disabled singleton commands, proving the flags are ignored.

   **[Relevant rolling-update source locations](https://app.greptile.com/trex/artifacts/e37f6863-63c8-46b8-adc2-4a2df63e2da2)**

   - Captured numbered source excerpts identify the unconditional nginx preflight, reload path, and hard-coded singleton restart arrays responsible for the defect.

   **[Shell syntax validation](https://app.greptile.com/trex/artifacts/ebe8282d-1301-4a14-b041-726479e38003)**

   - Bash parsed both the production rolling-update script and the executable isolated harness successfully, confirming the exercised scripts are syntactically valid.

   <a href="https://app.greptile.com/trex/runs/18127689/artifacts?artifact=6d792073-5c7c-4645-881d-a9d300bba225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Rolling update ignores off-node nginx and singleton role flags**

   - **Bug**
     - `start_services.sh` supports nodes with `MANAGE_NGINX=false`, `ENABLE_ARI_MANAGER=false`, and `ENABLE_CAMPAIGN_ORCHESTRATOR=false`, but `rolling_update.sh` aborts when local nginx is absent and, when nginx exists, reloads it and starts both singleton services anyway. This makes the advertised API/worker-only role incompatible with rolling updates and can create duplicate singleton processes.
   - **Cause**
     - `rolling_update.sh` loads the environment but never reads or branches on the three role flags. It unconditionally checks nginx at lines 226-231, renders/tests/reloads it at lines 371-411, and hard-codes both singleton services in restart arrays at lines 519-526.
   - **Fix**
     - Define the flags after environment loading, matching `start_services.sh`. Gate nginx preflight and Phase 4 on `MANAGE_NGINX == true`; for off-node nginx, require or invoke the external load-balancer/upstream switch instead of pretending local nginx switches traffic. Add ARI manager and campaign orchestrator to `RESTART_NAMES`/`RESTART_COMMANDS` only when their respective enable flag is `true`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(logging): apply the configured forma..."](https://github.com/dograh-hq/dograh/commit/90d2409a88045c336b60d90a5d0a863fdd983057) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51848299)</sub>

<!-- /greptile_comment -->