### PR TITLE
fix(ui): don't label a secret-only integration node "Not configured"

### DIFF
--- a/ui/src/components/flow/nodes/GenericNode.tsx
+++ b/ui/src/components/flow/nodes/GenericNode.tsx
@@ -131,12 +131,20 @@ function resolveIntegrationSummary(
     spec: NodeSpec,
     data: FlowNodeData,
 ): string {
+    let hasSecret = false;
     for (const prop of spec.properties) {
-        if (
-            prop.name === "name" ||
-            prop.name.endsWith("enabled") ||
-            /api[_-]?key|token|secret/i.test(prop.name)
-        ) {
+        if (prop.name === "name" || prop.name.endsWith("enabled")) {
+            continue;
+        }
+        // A configured API key/token/secret is never displayed, but it does
+        // prove the node is set up. Remember that so a node whose only real
+        // config is a secret (e.g. an integration identified solely by its key)
+        // isn't mislabelled "Not configured".
+        if (/api[_-]?key|token|secret/i.test(prop.name)) {
+            const secret = data[prop.name];
+            if (typeof secret === "string" && secret.trim().length > 0) {
+                hasSecret = true;
+            }
             continue;
         }
 
@@ -148,7 +156,7 @@ function resolveIntegrationSummary(
             return String(value);
         }
     }
-    return "Not configured";
+    return hasSecret ? "Configured" : "Not configured";
 }
 
 function getBadgeForSpec(


### PR DESCRIPTION
Problem
An integration node whose only real configuration is a secret (API key/token) renders as "Not configured" on its workflow card even when enabled and fully set up — it reads like an error.

Root cause
`resolveIntegrationSummary` (GenericNode.tsx) skips `name`, `*enabled`, and `api_key`/`token`/`secret` fields, shows the first remaining string/number field, and falls back to "Not configured". Every shipped integration happens to carry a guaranteed-populated non-secret field — tuner's required `agent_id`, noveum's `environment` default, paygent's `indicator` default — so that fallback was never reached. An integration identified solely by its key has no such field and hits it.

Fix
Track whether a secret field is actually populated; fall back to "Configured" in that case, keeping "Not configured" only when nothing is set. Peer nodes are unaffected — they still resolve to their existing display field first.

Verification
- `tsc --noEmit`: passes
- `eslint` on the changed file: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the workflow card label for secret-only integrations. When an API key/token/secret is set, the card now shows "Configured" instead of "Not configured".

- **Bug Fixes**
  - Updated `resolveIntegrationSummary` in `ui/src/components/flow/nodes/GenericNode.tsx` to detect populated secret fields and use "Configured" as the fallback.
  - Keeps existing priority: show the first non-secret string/number field; only show "Not configured" when nothing is set.

<sup>Written for commit 46c1e7da8a2a9802dfe4ae7024c01907e3a41c7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates workflow integration cards so integrations configured only with a populated API key, token, or secret display “Configured” without revealing the credential. Rendered checks confirmed that populated secret-only integrations now show the intended status, whitespace-only secrets and empty settings remain “Not configured,” and ordinary string and numeric summaries continue to render normally.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised integration-card summary behavior.

The rendered UI was checked before and after the change across secret-only, whitespace-only, empty, string, and numeric configuration states. The intended status changed only for populated secret-only integrations, and no credential disclosure was observed.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Rendered a focused React/JSDOM integration-card harness against both the parent and current implementations.
- Observed that the parent rendering produced a populated secret-only integration as Not configured, while the current implementation rendered five assertions for populated secret-only, whitespace-only secret, empty configuration, ordinary string, and numeric configurations.
- Confirmed the rendered output did not include the populated secret value, ensuring the status updates occur without disclosing credentials.
- Before running, the parent rendered the secret-only case as Not configured; after running, all five current assertions passed, including secret non-disclosure, and no product source was modified, with the narrow test source and command outputs saved as evidence.

<a href="https://app.greptile.com/trex/runs/18181365/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): don&#39;t label a secret-only integ..."](https://github.com/dograh-hq/dograh/commit/46c1e7da8a2a9802dfe4ae7024c01907e3a41c7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51953177)</sub>

<!-- /greptile_comment -->