### PR TITLE
feat(stt): add Soniox real-time transcriber provider

### DIFF
--- a/api/services/configuration/options/__init__.py
+++ b/api/services/configuration/options/__init__.py
@@ -54,6 +54,10 @@ from .smallest import (
     SMALLEST_TTS_PRO_VOICES,
     SMALLEST_TTS_VOICES,
 )
+from .soniox import (
+    SONIOX_STT_LANGUAGES,
+    SONIOX_STT_MODELS,
+)
 from .speechmatics import SPEECHMATICS_STT_LANGUAGES
 
 __all__ = [
@@ -103,5 +107,7 @@ __all__ = [
     "SMALLEST_TTS_MODELS",
     "SMALLEST_TTS_PRO_VOICES",
     "SMALLEST_TTS_VOICES",
+    "SONIOX_STT_LANGUAGES",
+    "SONIOX_STT_MODELS",
     "SPEECHMATICS_STT_LANGUAGES",
 ]

--- a/api/services/configuration/options/soniox.py
+++ b/api/services/configuration/options/soniox.py
@@ -1,0 +1,44 @@
+"""Soniox real-time STT options (models and language hints).
+
+Soniox exposes a single real-time transcription API over WebSocket that supports
+60+ languages with automatic language identification. See
+https://soniox.com/docs/stt/rt/real-time-transcription for the model list and
+language coverage.
+"""
+
+# Real-time (rt) models only — Dograh transcribes live call audio, so the async
+# models are intentionally excluded. stt-rt-v5 is the recommended current model.
+SONIOX_STT_MODELS = (
+    "stt-rt-v5",
+    "stt-rt-preview",
+    "stt-rt-v4",
+    "stt-rt-v3",
+)
+
+# "auto" enables Soniox's automatic language identification (no language hint).
+# The remaining entries are language *hints* (ISO 639-1). Soniox supports many
+# more codes than listed here; this is a curated set covering Dograh's common
+# languages plus South Asian languages. Any code Soniox accepts can be used.
+SONIOX_STT_LANGUAGES = (
+    "auto",
+    "bn",  # Bengali / Bangla
+    "en",
+    "hi",
+    "ur",
+    "ta",
+    "te",
+    "ar",
+    "es",
+    "fr",
+    "de",
+    "pt",
+    "it",
+    "nl",
+    "ru",
+    "tr",
+    "zh",
+    "ja",
+    "ko",
+    "id",
+    "vi",
+)

--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -51,6 +51,8 @@ from api.services.configuration.options import (
     SMALLEST_TTS_MODELS,
     SMALLEST_TTS_PRO_VOICES,
     SMALLEST_TTS_VOICES,
+    SONIOX_STT_LANGUAGES,
+    SONIOX_STT_MODELS,
     SPEECHMATICS_STT_LANGUAGES,
 )
 from api.services.configuration.options.google import GOOGLE_VERTEX_MODELS
@@ -98,6 +100,7 @@ class ServiceProviders(str, Enum):
     SMALLEST = "smallest"
     XAI = "xai"
     LMNT = "lmnt"
+    SONIOX = "soniox"
 
 
 class BaseServiceConfiguration(BaseModel):
@@ -328,6 +331,7 @@ CAMB_PROVIDER_MODEL_CONFIG = provider_model_config("Camb.ai")
 RIME_PROVIDER_MODEL_CONFIG = provider_model_config("Rime")
 GOOGLE_CLOUD_PROVIDER_MODEL_CONFIG = provider_model_config("Google Cloud")
 SPEECHMATICS_PROVIDER_MODEL_CONFIG = provider_model_config("Speechmatics")
+SONIOX_PROVIDER_MODEL_CONFIG = provider_model_config("Soniox")
 ASSEMBLYAI_PROVIDER_MODEL_CONFIG = provider_model_config("AssemblyAI")
 GLADIA_PROVIDER_MODEL_CONFIG = provider_model_config("Gladia")
 SPEACHES_PROVIDER_MODEL_CONFIG = provider_model_config(
@@ -1640,6 +1644,27 @@ class SarvamSTTConfiguration(BaseSTTConfiguration):
                 "saaras:v3": SARVAM_STT_LANGUAGES_V3,
             },
         },
+    )
+
+
+@register_stt
+class SonioxSTTConfiguration(BaseSTTConfiguration):
+    model_config = SONIOX_PROVIDER_MODEL_CONFIG
+    provider: Literal[ServiceProviders.SONIOX] = ServiceProviders.SONIOX
+    model: str = Field(
+        default="stt-rt-v5",
+        description=(
+            "Soniox real-time STT model. stt-rt-v5 is the recommended current model."
+        ),
+        json_schema_extra={"examples": SONIOX_STT_MODELS},
+    )
+    language: str = Field(
+        default="auto",
+        description=(
+            "Language hint (ISO 639-1). Use 'auto' for Soniox automatic language "
+            "identification."
+        ),
+        json_schema_extra={"examples": SONIOX_STT_LANGUAGES},
     )
 
 

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -227,6 +227,8 @@ def stt_uses_external_turns(user_config) -> bool:
         return dograh_stt_uses_flux_language(getattr(user_config.stt, "language", None))
     if user_config.stt.provider == ServiceProviders.CARTESIA.value:
         return user_config.stt.model == "ink-2"
+    if user_config.stt.provider == ServiceProviders.SONIOX.value:
+        return True
     return False
 
 
@@ -437,6 +439,12 @@ def create_stt_service(
                 language_hints=language_hints,
                 enable_language_identification=language_hints is None,
             ),
+            # Let Soniox's own endpoint detection decide end-of-turn (it is
+            # classified as an external-turn provider in stt_uses_external_turns);
+            # otherwise local VAD would force finalization and Soniox's low-latency
+            # turn detection would be unused.
+            vad_force_turn_endpoint=False,
+            should_interrupt=False,  # external turn strategies own interruption
             sample_rate=audio_config.transport_in_sample_rate,
         )
     elif user_config.stt.provider == ServiceProviders.SPEACHES.value:

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -87,6 +87,7 @@ from pipecat.services.sarvam.stt import SarvamSTTService, SarvamSTTSettings
 from pipecat.services.sarvam.tts import SarvamTTSService, SarvamTTSSettings
 from pipecat.services.smallest.stt import SmallestSTTService, SmallestSTTSettings
 from pipecat.services.smallest.tts import SmallestTTSService, SmallestTTSSettings
+from pipecat.services.soniox.stt import SonioxSTTService, SonioxSTTSettings
 from pipecat.services.speaches.llm import SpeachesLLMService, SpeachesLLMSettings
 from pipecat.services.speaches.stt import SpeachesSTTService, SpeachesSTTSettings
 from pipecat.services.speaches.tts import SpeachesTTSService, SpeachesTTSSettings
@@ -415,6 +416,26 @@ def create_stt_service(
             settings=SarvamSTTSettings(
                 model=user_config.stt.model,
                 language=pipecat_language,
+            ),
+            sample_rate=audio_config.transport_in_sample_rate,
+        )
+    elif user_config.stt.provider == ServiceProviders.SONIOX.value:
+        # Soniox real-time STT. Pass a language hint when configured; "auto"
+        # (or an unmapped code) falls back to Soniox automatic language
+        # identification. Soniox drives its own end-of-turn detection.
+        language = getattr(user_config.stt, "language", None)
+        language_hints = None
+        if language and language not in ("auto", "unknown"):
+            try:
+                language_hints = [Language(language)]
+            except ValueError:
+                language_hints = None
+        return SonioxSTTService(
+            api_key=user_config.stt.api_key,
+            settings=SonioxSTTSettings(
+                model=user_config.stt.model,
+                language_hints=language_hints,
+                enable_language_identification=language_hints is None,
             ),
             sample_rate=audio_config.transport_in_sample_rate,
         )

--- a/api/tests/test_soniox_stt_service_factory.py
+++ b/api/tests/test_soniox_stt_service_factory.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from api.services.configuration.options import (
+    SONIOX_STT_LANGUAGES,
+    SONIOX_STT_MODELS,
+)
+from api.services.configuration.registry import (
+    ServiceProviders,
+    SonioxSTTConfiguration,
+)
+from api.services.pipecat.audio_config import AudioConfig
+from api.services.pipecat.service_factory import (
+    create_stt_service,
+    stt_uses_external_turns,
+)
+
+
+def _audio_config() -> AudioConfig:
+    return AudioConfig(
+        transport_in_sample_rate=16000,
+        transport_out_sample_rate=16000,
+    )
+
+
+def _soniox_config(language: str = "auto", model: str = "stt-rt-v5") -> SimpleNamespace:
+    return SimpleNamespace(
+        stt=SimpleNamespace(
+            provider=ServiceProviders.SONIOX.value,
+            api_key="test-key",
+            model=model,
+            language=language,
+        )
+    )
+
+
+def test_soniox_stt_configuration_defaults_and_options():
+    config = SonioxSTTConfiguration(api_key="test-key")
+
+    assert config.provider == ServiceProviders.SONIOX
+    assert config.model == "stt-rt-v5"
+    assert config.language == "auto"
+    assert SONIOX_STT_MODELS[0] == "stt-rt-v5"
+    assert "auto" in SONIOX_STT_LANGUAGES
+    assert "bn" in SONIOX_STT_LANGUAGES
+
+
+def test_soniox_uses_external_turns():
+    assert stt_uses_external_turns(_soniox_config())
+
+
+def test_soniox_auto_language_enables_language_identification():
+    user_config = _soniox_config(language="auto")
+
+    with patch(
+        "api.services.pipecat.service_factory.SonioxSTTService"
+    ) as soniox_service:
+        create_stt_service(user_config, _audio_config())
+
+    soniox_service.assert_called_once()
+    kwargs = soniox_service.call_args.kwargs
+    assert kwargs["api_key"] == "test-key"
+    assert kwargs["sample_rate"] == 16000
+    # Soniox drives its own end-of-turn detection.
+    assert kwargs["vad_force_turn_endpoint"] is False
+    assert kwargs["should_interrupt"] is False
+    settings = kwargs["settings"]
+    assert settings.model == "stt-rt-v5"
+    assert settings.language_hints is None
+    assert settings.enable_language_identification is True
+
+
+def test_soniox_language_hint_disables_auto_identification():
+    user_config = _soniox_config(language="bn")
+
+    with patch(
+        "api.services.pipecat.service_factory.SonioxSTTService"
+    ) as soniox_service:
+        create_stt_service(user_config, _audio_config())
+
+    kwargs = soniox_service.call_args.kwargs
+    settings = kwargs["settings"]
+    assert settings.language_hints is not None
+    assert len(settings.language_hints) == 1
+    assert settings.enable_language_identification is False


### PR DESCRIPTION
## What

Adds **Soniox** as a first-class BYOK speech-to-text (transcriber) provider.

The streaming WebSocket client (`SonioxSTTService`) already ships in the pinned
`tuner-pipecat-sdk==0.2.4`, so this PR only registers it on the Dograh side — no
dependency bump.

## Why

Soniox provides real-time streaming transcription (~sub-200ms) across 60+
languages **including Bengali**, with automatic language identification and its
own end-of-turn detection. It's a strong fit for low-latency, multilingual voice
agents, and it's the one major streaming STT not yet selectable in Dograh.

## Changes

- `ServiceProviders.SONIOX` enum value.
- `api/services/configuration/options/soniox.py`: real-time model list
  (`stt-rt-v5` default) and curated language hints, with `auto` for Soniox's
  automatic language identification.
- `SonioxSTTConfiguration` (`@register_stt`) exposing `model` + `language` so the
  provider appears in the BYOK Transcriber UI (schema-driven).
- `create_stt_service()` branch that builds `SonioxSTTService`; a configured
  language maps to a Soniox language hint, otherwise auto language ID is enabled.

Net: **+96 lines across 4 files**, mirroring the existing Sarvam/Speechmatics
providers.

## Testing

- `SonioxSTTConfiguration()` validates with expected defaults
  (`provider=soniox, model=stt-rt-v5, language=auto`).
- `api.services.pipecat.service_factory` imports cleanly against the pinned
  pipecat inside the official `dograhai/dograh-api` image (the Soniox symbols and
  factory branch resolve).
- Verified the pinned `tuner-pipecat-sdk==0.2.4` ships
  `pipecat.services.soniox.stt` with the referenced settings fields
  (`model`, `language_hints`, `enable_language_identification`).

Happy to add a unit test alongside the other STT provider config tests if
preferred, and to extend the docs (`configurations/transcriber`) to list Soniox.

## Notes

- No secrets included; the API key is user-provided at runtime via BYOK config.
- UI is backend-schema-driven, so the provider dropdown/options populate from the
  registered `SonioxSTTConfiguration` — no separate UI change required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Soniox as a BYOK real-time STT provider with automatic language identification and Soniox-managed end-of-turn detection. Previously Soniox was not selectable; the Transcriber UI now exposes `provider=soniox` with default `model=stt-rt-v5` and `language=auto`.

- Registers `ServiceProviders.SONIOX` and `SonioxSTTConfiguration` (model, language) and adds `options/soniox.py` with real-time models and curated language hints.
- Service factory builds `SonioxSTTService` from `tuner-pipecat-sdk==0.2.4`, maps non-`auto` language to a Soniox hint, enables auto language ID otherwise, sets `vad_force_turn_endpoint=False`, and classifies Soniox as an external-turn provider.
- No dependency changes; adds `api/tests/test_soniox_stt_service_factory.py` covering defaults, external-turn classification, and auto vs hinted language.
- UI picks up the provider via the backend schema; users must supply a Soniox API key in BYOK config.
- Note: the typed STT configuration union still excludes Soniox; registry-generated Soniox configs will not round-trip through `STTConfig` until the union is updated.

<sup>Written for commit 021fbe61ab807585a67bf8b94e3b99745b76f60e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Soniox as a real-time speech-to-text option and configures it to manage turn detection. Saved Soniox selections cannot be restored because the persisted speech-to-text configuration schema does not recognize the Soniox provider.

<h3>Confidence Score: 4/5</h3>

The change is not ready to merge until persisted Soniox configurations can be loaded without being replaced by defaults.

One verified non-security failure remains: loading a saved Soniox speech-to-text configuration fails validation and returns the default configuration.

**Files Needing Attention:** api/services/configuration/registry.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the review comment.
- Validated the persistence workflow by inspecting the schema and persistence handling, confirming Soniox payloads are treated as unsupported and replaced with defaults.
- Verified the persistence parsing probe exercises the runtime model construction for a persisted payload, demonstrating the relevant runtime check.
- Observed the provider parsing behavior: provider=deepgram yields a DeepgramSTTConfiguration, while Soniox parsing fails with union\_tag\_invalid.

<a href="https://app.greptile.com/trex/runs/18648254/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (5)</h3></summary>

1. `api/services/configuration/registry.py`, line 1906-1924 ([link](https://github.com/dograh-hq/dograh/blob/e7a435725c209a273e9964031d7bec9ee7f74c6d/api/services/configuration/registry.py#L1906-L1924)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Soniox is absent from the persisted STT configuration union**

   The registry advertises `provider="soniox"` and produces a `SonioxSTTConfiguration`, but `STTConfig` does not include that type in its discriminated union. Loading the registry-generated payload through `STTConfig` therefore raises Pydantic `union_tag_invalid`, so Soniox BYOK configurations cannot be saved or loaded through the typed configuration path. Add `SonioxSTTConfiguration` to `STTConfig` and cover the registry-to-union round trip with a regression test.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Focused Soniox STT configuration reproduction script](https://app.greptile.com/trex/artifacts/2e5fd237-f2a0-4ae9-9438-1b30cd9122d0)**

   - The uploaded script constructs the live registry configuration and validates its serialized payload through STTConfig, showing the exact failing path.

   **[Registry-advertised Soniox STT payload](https://app.greptile.com/trex/artifacts/9ccf29ef-e5e5-4203-82be-c41ed31a7683)**

   - The captured registry run exits successfully and shows Soniox is advertised with its serialized STT configuration payload.

   **[STTConfig rejects the registry-advertised Soniox payload](https://app.greptile.com/trex/artifacts/99be2b3d-9996-4781-b681-74edab52f793)**

   - The captured parsing run exits 1 with Pydantic union\_tag\_invalid for provider soniox, confirming the configuration cannot load.

   <a href="https://app.greptile.com/trex/runs/18647030/artifacts?artifact=2e5fd237-f2a0-4ae9-9438-1b30cd9122d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Soniox is registered for STT but omitted from STTConfig**

   - **Bug**
     - The live STT registry exposes Soniox and produces a valid Soniox payload, but Pydantic rejects that same payload when it is loaded through `STTConfig`. Consequently, workflows/configurations using the registry-advertised Soniox STT provider cannot be saved or loaded through the static typed configuration path.
   - **Cause**
     - `SonioxSTTConfiguration` is decorated with `@register_stt` at lines 1650-1668, while the discriminated `STTConfig` union at lines 1906-1924 does not include that class.
   - **Fix**
     - Add `SonioxSTTConfiguration` to the `STTConfig` `Union` and retain a focused regression test that validates a registry-generated Soniox payload through `TypeAdapter(STTConfig)`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Soniox provider is configured for local VAD instead of its advertised endpoint detection**

   - **Bug**
     - The new Soniox branch at `api/services/pipecat/service_factory.py:433-441` does not pass `vad_force_turn_endpoint=False`. The pinned SDK declares the omitted argument's default as `True` at `pipecat/src/pipecat/services/soniox/stt.py:287`; in that mode the SDK disables Soniox endpoint detection and sends `finalize` when it receives a local `VADUserStoppedSpeakingFrame` (`:314-321`, `:542-546`). Separately, `stt_uses_external_turns()` at factory lines `223-230` returns `False` for Soniox. Thus non-realtime pipeline setup selects local VAD and `SpeechTimeoutUserTurnStopStrategy` (`run_pipeline.py:173-203`) rather than external Soniox turn frames, contrary to the factory comment that Soniox drives end-of-turn detection.
   - **Cause**
     - The provider wiring omitted both the SDK mode override (`vad_force_turn_endpoint=False`) and the Soniox case in `stt_uses_external_turns()`.
   - **Fix**
     - Pass `vad_force_turn_endpoint=False` when constructing `SonioxSTTService`, add `ServiceProviders.SONIOX.value` to `stt_uses_external_turns()`, and add a regression test asserting the resulting service uses `ExternalUserTurnStrategies` / Soniox endpoint detection rather than local speech-timeout finalization.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

4. `api/services/configuration/registry.py`, line 1906-1922 ([link](https://github.com/dograh-hq/dograh/blob/021fbe61ab807585a67bf8b94e3b99745b76f60e/api/services/configuration/registry.py#L1906-L1922)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Soniox persisted configurations cannot be parsed**

   `SonioxSTTConfiguration` is registered but missing from the `STTConfig` discriminated union. A saved configuration with `stt.provider="soniox"` therefore fails validation when it is loaded, and the configuration loader returns the default model configuration instead. Add `SonioxSTTConfiguration` to `STTConfig` and cover loading a persisted Soniox payload with a regression test.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Schema and persistence inspection](https://app.greptile.com/trex/artifacts/026856e1-a83b-4c25-beee-716eef35db1d)**

   - Inspected the registry and stored-configuration read path, showing Soniox is registered while absent from the STT union and parse failures fall back to defaults; the claim's static cause is present.

   **[Soniox persistence parsing probe source](https://app.greptile.com/trex/artifacts/91fe2155-a660-414f-b793-d03602946651)**

   - Captured the script that constructs the effective persistence model from an STT payload with a selected provider; it directly targets persisted parsing.

   **[Supported-provider control parse](https://app.greptile.com/trex/artifacts/53ae39ca-bda9-44ce-b1d5-c3fe5d24bd04)**

   - Ran the same parsing probe with Deepgram and it succeeded as DeepgramSTTConfiguration; the persistence-model construction path works for union members.

   **[Soniox persisted payload parse](https://app.greptile.com/trex/artifacts/1e668d53-0ff6-4a05-99b8-18d8f4fba1bb)**

   - Ran the parsing probe with Soniox and observed Pydantic union\_tag\_invalid because soniox is not an expected discriminator tag; persisted Soniox parsing fails.

   <a href="https://app.greptile.com/trex/runs/18648254/artifacts?artifact=026856e1-a83b-4c25-beee-716eef35db1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


5. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Soniox persisted STT configurations cannot be parsed**

   - **Bug**
     - `SonioxSTTConfiguration` is decorated with `@register_stt`, yet it is absent from the `STTConfig` discriminated union. A persisted-style payload containing `stt.provider='soniox'` fails construction of `EffectiveAIModelConfiguration` with Pydantic `union_tag_invalid`. The user configuration persistence read path catches this validation error and returns an empty default configuration, so saved Soniox configuration is discarded from the effective model.
   - **Cause**
     - The manually maintained `STTConfig` union in `api/services/configuration/registry.py:1906-1924` does not include `SonioxSTTConfiguration`, despite registration at `api/services/configuration/registry.py:1650-1668`.
   - **Fix**
     - Add `SonioxSTTConfiguration` to the `STTConfig` union and add a regression test that validates a persisted-style `EffectiveAIModelConfiguration` payload with `stt.provider='soniox'`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(stt): use Soniox-managed turn endpoi..."](https://github.com/dograh-hq/dograh/commit/021fbe61ab807585a67bf8b94e3b99745b76f60e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52860314)</sub>

<!-- /greptile_comment -->