### PR TITLE
feat(tts): add Speechify as a Voice (TTS) provider (Simba 3.2)

### DIFF
--- a/api/services/configuration/check_validity.py
+++ b/api/services/configuration/check_validity.py
@@ -69,6 +69,7 @@ class UserConfigurationValidator:
             ServiceProviders.SMALLEST.value: self._check_smallest_api_key,
             ServiceProviders.XAI.value: self._check_xai_api_key,
             ServiceProviders.LMNT.value: self._check_lmnt_api_key,
+            ServiceProviders.SPEECHIFY.value: self._check_speechify_api_key,
         }
 
     async def validate(
@@ -444,6 +445,29 @@ class UserConfigurationValidator:
                 "Invalid LMNT API key. The key was rejected by the LMNT API. "
                 "Please check that your API key is correct and active. "
                 "You can find your key at https://app.lmnt.com."
+            )
+        return True
+
+    def _check_speechify_api_key(self, model: str, api_key: str) -> bool:
+        # Best-effort smoke test against Speechify's voice-list endpoint. Only a
+        # clear auth failure rejects the save; other statuses are treated as
+        # inconclusive so transient errors or API changes don't block valid keys.
+        try:
+            response = httpx.get(
+                "https://api.speechify.ai/v1/voices?limit=1",
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=10.0,
+            )
+        except httpx.RequestError:
+            raise ValueError(
+                "Could not connect to the Speechify API. Please check your network "
+                "connection and try again."
+            )
+        if response.status_code == 401:
+            raise ValueError(
+                "Invalid Speechify API key. The key was rejected by the Speechify API. "
+                "Please check that your API key is correct and active. "
+                "You can find your key at https://platform.speechify.ai."
             )
         return True
 

--- a/api/services/configuration/check_validity.py
+++ b/api/services/configuration/check_validity.py
@@ -450,8 +450,9 @@ class UserConfigurationValidator:
 
     def _check_speechify_api_key(self, model: str, api_key: str) -> bool:
         # Best-effort smoke test against Speechify's voice-list endpoint. Only a
-        # clear auth failure rejects the save; other statuses are treated as
-        # inconclusive so transient errors or API changes don't block valid keys.
+        # clear auth failure rejects the save; connection failures and other
+        # statuses are treated as inconclusive so transient errors or API
+        # changes don't block valid keys.
         try:
             response = httpx.get(
                 "https://api.speechify.ai/v1/voices?limit=1",
@@ -459,10 +460,7 @@ class UserConfigurationValidator:
                 timeout=10.0,
             )
         except httpx.RequestError:
-            raise ValueError(
-                "Could not connect to the Speechify API. Please check your network "
-                "connection and try again."
-            )
+            return True
         if response.status_code == 401:
             raise ValueError(
                 "Invalid Speechify API key. The key was rejected by the Speechify API. "

--- a/api/services/configuration/check_validity.py
+++ b/api/services/configuration/check_validity.py
@@ -467,6 +467,13 @@ class UserConfigurationValidator:
                 "Please check that your API key is correct and active. "
                 "You can find your key at https://platform.speechify.ai."
             )
+        if response.status_code == 403:
+            raise ValueError(
+                "Speechify API authorization failed: the key was recognized but is "
+                "not allowed to access the TTS API (expired plan, revoked key, or "
+                "missing scope). Check your key and plan at "
+                "https://platform.speechify.ai."
+            )
         return True
 
     def _check_ultravox_realtime_api_key(self, model: str, api_key: str) -> bool:

--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -1598,6 +1598,15 @@ SPEECHIFY_TTS_MODELS = [
     "simba-multilingual",
 ]
 SPEECHIFY_TTS_VOICES = ["beatrice_32", "geffen_32", "alicia", "alton"]
+# The API rejects voices outside a model's allow-list (HTTP 400): simba-3.2
+# only accepts voices that list it in GET /v1/voices, currently its dedicated
+# "_32" voices. The other models accept the general shared catalog.
+SPEECHIFY_TTS_VOICES_BY_MODEL = {
+    "simba-3.2": ["beatrice_32", "geffen_32"],
+    "simba-3.0": SPEECHIFY_TTS_VOICES,
+    "simba-english": SPEECHIFY_TTS_VOICES,
+    "simba-multilingual": SPEECHIFY_TTS_VOICES,
+}
 # Documented languages per model, used to filter the language dropdown. The
 # API accepts other codes (synthesis succeeds), so this steers rather than
 # hard-blocks: allow_custom_input still permits manual entry.
@@ -1650,12 +1659,14 @@ class SpeechifyTTSConfiguration(BaseTTSConfiguration):
     voice: str = Field(
         default="beatrice_32",
         description=(
-            "Speechify voice ID. Use a shared voice from the Speechify catalog "
-            "or a cloned voice ID from your account."
+            "Speechify voice ID. Options are filtered to voices available for "
+            "the selected model; a custom or cloned voice ID must support the "
+            "selected model (see GET /v1/voices), or synthesis fails."
         ),
         json_schema_extra={
             "examples": SPEECHIFY_TTS_VOICES,
             "allow_custom_input": True,
+            "model_options": SPEECHIFY_TTS_VOICES_BY_MODEL,
         },
     )
     language: str = Field(

--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -1598,6 +1598,40 @@ SPEECHIFY_TTS_MODELS = [
     "simba-multilingual",
 ]
 SPEECHIFY_TTS_VOICES = ["beatrice_32", "geffen_32", "alicia", "alton"]
+# Documented languages per model, used to filter the language dropdown. The
+# API accepts other codes (synthesis succeeds), so this steers rather than
+# hard-blocks: allow_custom_input still permits manual entry.
+SPEECHIFY_TTS_LANGUAGES_BY_MODEL = {
+    "simba-3.2": ["en"],
+    "simba-3.0": ["en", "de", "es", "fr", "it", "pt-BR"],
+    "simba-english": ["en"],
+    "simba-multilingual": [
+        "en",
+        "ar",
+        "bn",
+        "da",
+        "de",
+        "es",
+        "fr",
+        "gu",
+        "hi",
+        "it",
+        "ja",
+        "ko",
+        "mr",
+        "nb",
+        "nl",
+        "pt-BR",
+        "pt-PT",
+        "ru",
+        "sv",
+        "ta",
+        "te",
+        "tr",
+        "ur",
+        "yue",
+    ],
+}
 
 
 @register_tts
@@ -1628,9 +1662,14 @@ class SpeechifyTTSConfiguration(BaseTTSConfiguration):
         default="en",
         description=(
             "Language code for synthesis (e.g. 'en', 'de', 'es', 'fr', 'it', "
-            "'pt-BR'). simba-3.2 is English-only."
+            "'pt-BR'). Options are filtered to the selected model's documented "
+            "languages; simba-3.2 is documented as English-only."
         ),
-        json_schema_extra={"allow_custom_input": True},
+        json_schema_extra={
+            "examples": SPEECHIFY_TTS_LANGUAGES_BY_MODEL["simba-3.0"],
+            "allow_custom_input": True,
+            "model_options": SPEECHIFY_TTS_LANGUAGES_BY_MODEL,
+        },
     )
 
 

--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -1591,21 +1591,20 @@ class LmntTTSConfiguration(BaseTTSConfiguration):
     )
 
 
+# Only the streaming-native Simba models: pipecat's SpeechifyHttpTTSService
+# uses the /v1/audio/stream/with-timestamps endpoint, which rejects the legacy
+# simba-english/simba-multilingual models.
 SPEECHIFY_TTS_MODELS = [
     "simba-3.2",
     "simba-3.0",
-    "simba-english",
-    "simba-multilingual",
 ]
 SPEECHIFY_TTS_VOICES = ["beatrice_32", "geffen_32", "alicia", "alton"]
 # The API rejects voices outside a model's allow-list (HTTP 400): simba-3.2
 # only accepts voices that list it in GET /v1/voices, currently its dedicated
-# "_32" voices. The other models accept the general shared catalog.
+# "_32" voices. simba-3.0 accepts the general shared catalog.
 SPEECHIFY_TTS_VOICES_BY_MODEL = {
     "simba-3.2": ["beatrice_32", "geffen_32"],
     "simba-3.0": SPEECHIFY_TTS_VOICES,
-    "simba-english": SPEECHIFY_TTS_VOICES,
-    "simba-multilingual": SPEECHIFY_TTS_VOICES,
 }
 # Documented languages per model, used to filter the language dropdown. The
 # API accepts other codes (synthesis succeeds), so this steers rather than
@@ -1613,33 +1612,6 @@ SPEECHIFY_TTS_VOICES_BY_MODEL = {
 SPEECHIFY_TTS_LANGUAGES_BY_MODEL = {
     "simba-3.2": ["en"],
     "simba-3.0": ["en", "de", "es", "fr", "it", "pt-BR"],
-    "simba-english": ["en"],
-    "simba-multilingual": [
-        "en",
-        "ar",
-        "bn",
-        "da",
-        "de",
-        "es",
-        "fr",
-        "gu",
-        "hi",
-        "it",
-        "ja",
-        "ko",
-        "mr",
-        "nb",
-        "nl",
-        "pt-BR",
-        "pt-PT",
-        "ru",
-        "sv",
-        "ta",
-        "te",
-        "tr",
-        "ur",
-        "yue",
-    ],
 }
 
 

--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -99,6 +99,7 @@ class ServiceProviders(str, Enum):
     SMALLEST = "smallest"
     XAI = "xai"
     LMNT = "lmnt"
+    SPEECHIFY = "speechify"
 
 
 class BaseServiceConfiguration(BaseModel):
@@ -133,6 +134,7 @@ class BaseServiceConfiguration(BaseModel):
         ServiceProviders.SMALLEST,
         ServiceProviders.XAI,
         ServiceProviders.LMNT,
+        ServiceProviders.SPEECHIFY,
     ]
     api_key: str | list[str]
 
@@ -317,6 +319,10 @@ ELEVENLABS_PROVIDER_MODEL_CONFIG = provider_model_config("ElevenLabs")
 CARTESIA_PROVIDER_MODEL_CONFIG = provider_model_config("Cartesia")
 XAI_PROVIDER_MODEL_CONFIG = provider_model_config("xAI")
 LMNT_PROVIDER_MODEL_CONFIG = provider_model_config("LMNT")
+SPEECHIFY_PROVIDER_MODEL_CONFIG = provider_model_config(
+    "Speechify",
+    provider_docs_url="https://docs.speechify.ai",
+)
 INWORLD_PROVIDER_MODEL_CONFIG = provider_model_config(
     "Inworld",
     description=(
@@ -1585,6 +1591,49 @@ class LmntTTSConfiguration(BaseTTSConfiguration):
     )
 
 
+SPEECHIFY_TTS_MODELS = [
+    "simba-3.2",
+    "simba-3.0",
+    "simba-english",
+    "simba-multilingual",
+]
+SPEECHIFY_TTS_VOICES = ["beatrice_32", "geffen_32", "alicia", "alton"]
+
+
+@register_tts
+class SpeechifyTTSConfiguration(BaseTTSConfiguration):
+    model_config = SPEECHIFY_PROVIDER_MODEL_CONFIG
+    provider: Literal[ServiceProviders.SPEECHIFY] = ServiceProviders.SPEECHIFY
+    model: str = Field(
+        default="simba-3.2",
+        description=(
+            "Speechify TTS model. 'simba-3.2' is the streaming-native English "
+            "model with the lowest latency; 'simba-3.0' adds German, Spanish, "
+            "French, Italian, and Portuguese."
+        ),
+        json_schema_extra={"examples": SPEECHIFY_TTS_MODELS},
+    )
+    voice: str = Field(
+        default="beatrice_32",
+        description=(
+            "Speechify voice ID. Use a shared voice from the Speechify catalog "
+            "or a cloned voice ID from your account."
+        ),
+        json_schema_extra={
+            "examples": SPEECHIFY_TTS_VOICES,
+            "allow_custom_input": True,
+        },
+    )
+    language: str = Field(
+        default="en",
+        description=(
+            "Language code for synthesis (e.g. 'en', 'de', 'es', 'fr', 'it', "
+            "'pt-BR'). simba-3.2 is English-only."
+        ),
+        json_schema_extra={"allow_custom_input": True},
+    )
+
+
 TTSConfig = Annotated[
     Union[
         DeepgramTTSConfiguration,
@@ -1603,6 +1652,7 @@ TTSConfig = Annotated[
         SmallestAITTSConfiguration,
         XAITTSConfiguration,
         LmntTTSConfiguration,
+        SpeechifyTTSConfiguration,
     ],
     Field(discriminator="provider"),
 ]

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -922,17 +922,21 @@ def create_tts_service(
         voice = getattr(user_config.tts, "voice", None) or "beatrice_32"
         model = getattr(user_config.tts, "model", None) or "simba-3.2"
         language_code = getattr(user_config.tts, "language", None) or "en"
+        language: Language | str
         try:
-            pipecat_language = Language(language_code)
+            language = Language(language_code)
         except ValueError:
-            pipecat_language = Language.EN
+            # The config allows custom language codes; codes the pipecat enum
+            # doesn't model (e.g. "en-ZA") are sent to Speechify verbatim
+            # rather than silently replaced with English.
+            language = language_code
         return SpeechifyTTSService(
             api_key=user_config.tts.api_key,
             sample_rate=audio_config.transport_out_sample_rate,
             settings=SpeechifyTTSSettings(
                 voice=voice,
                 model=model,
-                language=pipecat_language,
+                language=language,
             ),
             text_filters=[xml_function_tag_filter],
             skip_aggregator_types=["recording_router", "recording"],

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -87,6 +87,7 @@ from pipecat.services.smallest.tts import SmallestTTSService, SmallestTTSSetting
 from pipecat.services.speaches.llm import SpeachesLLMService, SpeachesLLMSettings
 from pipecat.services.speaches.stt import SpeachesSTTService, SpeachesSTTSettings
 from pipecat.services.speaches.tts import SpeachesTTSService, SpeachesTTSSettings
+from pipecat.services.speechify.tts import SpeechifyTTSService, SpeechifyTTSSettings
 from pipecat.services.speechmatics.stt import (
     SpeechmaticsSTTService,
     SpeechmaticsSTTSettings,
@@ -912,6 +913,26 @@ def create_tts_service(
                 voice=voice,
                 language=pipecat_language,
                 model=model,
+            ),
+            text_filters=[xml_function_tag_filter],
+            skip_aggregator_types=["recording_router", "recording"],
+            silence_time_s=1.0,
+        )
+    elif user_config.tts.provider == ServiceProviders.SPEECHIFY.value:
+        voice = getattr(user_config.tts, "voice", None) or "beatrice_32"
+        model = getattr(user_config.tts, "model", None) or "simba-3.2"
+        language_code = getattr(user_config.tts, "language", None) or "en"
+        try:
+            pipecat_language = Language(language_code)
+        except ValueError:
+            pipecat_language = Language.EN
+        return SpeechifyTTSService(
+            api_key=user_config.tts.api_key,
+            sample_rate=audio_config.transport_out_sample_rate,
+            settings=SpeechifyTTSSettings(
+                voice=voice,
+                model=model,
+                language=pipecat_language,
             ),
             text_filters=[xml_function_tag_filter],
             skip_aggregator_types=["recording_router", "recording"],

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -87,7 +87,6 @@ from pipecat.services.smallest.tts import SmallestTTSService, SmallestTTSSetting
 from pipecat.services.speaches.llm import SpeachesLLMService, SpeachesLLMSettings
 from pipecat.services.speaches.stt import SpeachesSTTService, SpeachesSTTSettings
 from pipecat.services.speaches.tts import SpeachesTTSService, SpeachesTTSSettings
-from pipecat.services.speechify.tts import SpeechifyTTSService, SpeechifyTTSSettings
 from pipecat.services.speechmatics.stt import (
     SpeechmaticsSTTService,
     SpeechmaticsSTTSettings,
@@ -919,6 +918,11 @@ def create_tts_service(
             silence_time_s=1.0,
         )
     elif user_config.tts.provider == ServiceProviders.SPEECHIFY.value:
+        # SpeechifyHttpTTSService ships in upstream pipecat; imported lazily so
+        # this module keeps loading on pipecat checkouts that predate it.
+        from api.services.pipecat.speechify_tts import SpeechifyOwnedSessionTTSService
+        from pipecat.services.speechify.tts import SpeechifyTTSSettings
+
         voice = getattr(user_config.tts, "voice", None) or "beatrice_32"
         model = getattr(user_config.tts, "model", None) or "simba-3.2"
         language_code = getattr(user_config.tts, "language", None) or "en"
@@ -930,8 +934,10 @@ def create_tts_service(
             # doesn't model (e.g. "en-ZA") are sent to Speechify verbatim
             # rather than silently replaced with English.
             language = language_code
-        return SpeechifyTTSService(
+        session = aiohttp.ClientSession()
+        return SpeechifyOwnedSessionTTSService(
             api_key=user_config.tts.api_key,
+            aiohttp_session=session,
             sample_rate=audio_config.transport_out_sample_rate,
             settings=SpeechifyTTSSettings(
                 voice=voice,

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -926,6 +926,11 @@ def create_tts_service(
             )
             from pipecat.services.speechify.tts import SpeechifyTTSSettings
         except ModuleNotFoundError as e:
+            missing = e.name or ""
+            if missing != "pipecat.services.speechify" and not missing.startswith(
+                "pipecat.services.speechify."
+            ):
+                raise
             raise HTTPException(
                 status_code=400,
                 detail=(

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -920,8 +920,19 @@ def create_tts_service(
     elif user_config.tts.provider == ServiceProviders.SPEECHIFY.value:
         # SpeechifyHttpTTSService ships in upstream pipecat; imported lazily so
         # this module keeps loading on pipecat checkouts that predate it.
-        from api.services.pipecat.speechify_tts import SpeechifyOwnedSessionTTSService
-        from pipecat.services.speechify.tts import SpeechifyTTSSettings
+        try:
+            from api.services.pipecat.speechify_tts import (
+                SpeechifyOwnedSessionTTSService,
+            )
+            from pipecat.services.speechify.tts import SpeechifyTTSSettings
+        except ModuleNotFoundError as e:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Speechify TTS requires a pipecat build that includes "
+                    "pipecat.services.speechify; the installed pipecat does not."
+                ),
+            ) from e
 
         voice = getattr(user_config.tts, "voice", None) or "beatrice_32"
         model = getattr(user_config.tts, "model", None) or "simba-3.2"

--- a/api/services/pipecat/speechify_tts.py
+++ b/api/services/pipecat/speechify_tts.py
@@ -18,6 +18,8 @@ class SpeechifyOwnedSessionTTSService(SpeechifyHttpTTSService):
         self._owned_session = aiohttp_session
 
     async def cleanup(self):
-        await super().cleanup()
-        if not self._owned_session.closed:
-            await self._owned_session.close()
+        try:
+            await super().cleanup()
+        finally:
+            if not self._owned_session.closed:
+                await self._owned_session.close()

--- a/api/services/pipecat/speechify_tts.py
+++ b/api/services/pipecat/speechify_tts.py
@@ -1,0 +1,23 @@
+"""Speechify TTS wrapper that closes its aiohttp session in cleanup().
+
+Pipecat's SpeechifyHttpTTSService leaves session disposal to the caller. Our
+factory creates a fresh session per service instance, so we own its close
+here to avoid leaking sockets/FDs on shutdown.
+"""
+
+import aiohttp
+
+from pipecat.services.speechify.tts import SpeechifyHttpTTSService
+
+
+class SpeechifyOwnedSessionTTSService(SpeechifyHttpTTSService):
+    """SpeechifyHttpTTSService variant that owns its aiohttp session lifecycle."""
+
+    def __init__(self, *args, aiohttp_session: aiohttp.ClientSession, **kwargs):
+        super().__init__(*args, aiohttp_session=aiohttp_session, **kwargs)
+        self._owned_session = aiohttp_session
+
+    async def cleanup(self):
+        await super().cleanup()
+        if not self._owned_session.closed:
+            await self._owned_session.close()

--- a/api/tests/test_speechify_tts_service_factory.py
+++ b/api/tests/test_speechify_tts_service_factory.py
@@ -10,6 +10,7 @@ from api.services.configuration.registry import (
     SPEECHIFY_TTS_LANGUAGES_BY_MODEL,
     SPEECHIFY_TTS_MODELS,
     SPEECHIFY_TTS_VOICES,
+    SPEECHIFY_TTS_VOICES_BY_MODEL,
     ServiceProviders,
     SpeechifyTTSConfiguration,
 )
@@ -154,3 +155,23 @@ def test_speechify_key_validation_rejects_bad_key():
         mock_get.return_value.status_code = 401
         with pytest.raises(ValueError):
             validator._check_speechify_api_key("simba-3.2", "bad-key")
+
+
+def test_speechify_key_validation_rejects_unauthorized_key():
+    validator = UserConfigurationValidator()
+    with patch("api.services.configuration.check_validity.httpx.get") as mock_get:
+        mock_get.return_value.status_code = 403
+        with pytest.raises(ValueError, match="authorization failed"):
+            validator._check_speechify_api_key("simba-3.2", "unauthorized-key")
+
+
+def test_speechify_voice_options_cover_every_model():
+    # The voice dropdown is filtered per model via model_options; the API
+    # rejects voices outside a model's allow-list with HTTP 400.
+    assert set(SPEECHIFY_TTS_VOICES_BY_MODEL) == set(SPEECHIFY_TTS_MODELS)
+    assert SPEECHIFY_TTS_VOICES_BY_MODEL["simba-3.2"] == ["beatrice_32", "geffen_32"]
+    voice_extra = SpeechifyTTSConfiguration.model_fields["voice"].json_schema_extra
+    assert voice_extra["model_options"] is SPEECHIFY_TTS_VOICES_BY_MODEL
+    # The default voice must be valid for the default model.
+    default_config = SpeechifyTTSConfiguration(api_key="test-key")
+    assert default_config.voice in SPEECHIFY_TTS_VOICES_BY_MODEL[default_config.model]

--- a/api/tests/test_speechify_tts_service_factory.py
+++ b/api/tests/test_speechify_tts_service_factory.py
@@ -1,11 +1,13 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import httpx
 import pytest
 from pipecat.transcriptions.language import Language
 
 from api.services.configuration.check_validity import UserConfigurationValidator
 from api.services.configuration.registry import (
+    SPEECHIFY_TTS_LANGUAGES_BY_MODEL,
     SPEECHIFY_TTS_MODELS,
     SPEECHIFY_TTS_VOICES,
     ServiceProviders,
@@ -23,6 +25,17 @@ def test_speechify_tts_configuration_defaults():
     assert config.language == "en"
     assert SPEECHIFY_TTS_MODELS[0] == "simba-3.2"
     assert "beatrice_32" in SPEECHIFY_TTS_VOICES
+
+
+def test_speechify_language_options_cover_every_model():
+    # The language dropdown is filtered per model via model_options; every
+    # selectable model needs an entry, and simba-3.2 is documented English-only.
+    assert set(SPEECHIFY_TTS_LANGUAGES_BY_MODEL) == set(SPEECHIFY_TTS_MODELS)
+    assert SPEECHIFY_TTS_LANGUAGES_BY_MODEL["simba-3.2"] == ["en"]
+    language_extra = SpeechifyTTSConfiguration.model_fields[
+        "language"
+    ].json_schema_extra
+    assert language_extra["model_options"] is SPEECHIFY_TTS_LANGUAGES_BY_MODEL
 
 
 @pytest.mark.parametrize("transport_out_sample_rate", [8000, 16000, 24000])
@@ -125,6 +138,13 @@ def test_speechify_key_validation_treats_non_auth_errors_as_inconclusive():
     validator = UserConfigurationValidator()
     with patch("api.services.configuration.check_validity.httpx.get") as mock_get:
         mock_get.return_value.status_code = 500
+        assert validator._check_speechify_api_key("simba-3.2", "sk-valid-key") is True
+
+
+def test_speechify_key_validation_treats_connection_errors_as_inconclusive():
+    validator = UserConfigurationValidator()
+    with patch("api.services.configuration.check_validity.httpx.get") as mock_get:
+        mock_get.side_effect = httpx.ConnectError("connection failed")
         assert validator._check_speechify_api_key("simba-3.2", "sk-valid-key") is True
 
 

--- a/api/tests/test_speechify_tts_service_factory.py
+++ b/api/tests/test_speechify_tts_service_factory.py
@@ -20,6 +20,13 @@ from api.services.configuration.registry import (
 from api.services.pipecat.service_factory import create_tts_service
 
 
+def _speechify_pipecat_module_present() -> bool:
+    try:
+        return importlib.util.find_spec("pipecat.services.speechify.tts") is not None
+    except ModuleNotFoundError:
+        return False
+
+
 @pytest.fixture
 def speechify_pipecat_stub(monkeypatch):
     """Provide pipecat.services.speechify.tts for the factory's lazy import.
@@ -28,13 +35,7 @@ def speechify_pipecat_stub(monkeypatch):
     SpeechifyHttpTTSService. Once the submodule includes the real module, the
     tests run against the real classes so signature drift fails loudly.
     """
-    try:
-        real_module_present = (
-            importlib.util.find_spec("pipecat.services.speechify.tts") is not None
-        )
-    except ModuleNotFoundError:
-        real_module_present = False
-    if real_module_present:
+    if _speechify_pipecat_module_present():
         sys.modules.pop("api.services.pipecat.speechify_tts", None)
         yield
         sys.modules.pop("api.services.pipecat.speechify_tts", None)
@@ -182,6 +183,34 @@ def test_create_speechify_tts_service_passes_custom_language_through(
 
     kwargs = mock_service.call_args.kwargs
     assert kwargs["settings"].language == "en-ZA"
+
+
+@pytest.mark.skipif(
+    _speechify_pipecat_module_present(),
+    reason="pinned pipecat ships the Speechify module",
+)
+def test_create_speechify_tts_service_reports_missing_pipecat_module():
+    # Selecting Speechify on a pipecat checkout without the service must fail
+    # with an explicit configuration error, not a bare ModuleNotFoundError.
+    from fastapi import HTTPException
+
+    user_config = SimpleNamespace(
+        tts=SimpleNamespace(
+            provider=ServiceProviders.SPEECHIFY.value,
+            api_key="test-key",
+            model="simba-3.2",
+            voice="beatrice_32",
+            language="en",
+        )
+    )
+    audio_config = SimpleNamespace(
+        transport_out_sample_rate=16000,
+        transport_in_sample_rate=16000,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        create_tts_service(user_config, audio_config)
+    assert "pipecat build" in exc_info.value.detail
 
 
 def test_speechify_is_registered_for_key_validation():

--- a/api/tests/test_speechify_tts_service_factory.py
+++ b/api/tests/test_speechify_tts_service_factory.py
@@ -1,3 +1,4 @@
+import importlib.util
 import sys
 import types
 from types import SimpleNamespace
@@ -23,9 +24,21 @@ from api.services.pipecat.service_factory import create_tts_service
 def speechify_pipecat_stub(monkeypatch):
     """Provide pipecat.services.speechify.tts for the factory's lazy import.
 
-    The pinned pipecat checkout predates upstream's SpeechifyHttpTTSService, so
-    the module the factory imports at call time is stubbed here.
+    Stubs the module only when the pinned pipecat checkout predates upstream's
+    SpeechifyHttpTTSService. Once the submodule includes the real module, the
+    tests run against the real classes so signature drift fails loudly.
     """
+    try:
+        real_module_present = (
+            importlib.util.find_spec("pipecat.services.speechify.tts") is not None
+        )
+    except ModuleNotFoundError:
+        real_module_present = False
+    if real_module_present:
+        sys.modules.pop("api.services.pipecat.speechify_tts", None)
+        yield
+        sys.modules.pop("api.services.pipecat.speechify_tts", None)
+        return
 
     class StubSpeechifyHttpTTSService:
         def __init__(self, *args, **kwargs):

--- a/api/tests/test_speechify_tts_service_factory.py
+++ b/api/tests/test_speechify_tts_service_factory.py
@@ -1,0 +1,136 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from pipecat.transcriptions.language import Language
+
+from api.services.configuration.check_validity import UserConfigurationValidator
+from api.services.configuration.registry import (
+    SPEECHIFY_TTS_MODELS,
+    SPEECHIFY_TTS_VOICES,
+    ServiceProviders,
+    SpeechifyTTSConfiguration,
+)
+from api.services.pipecat.service_factory import create_tts_service
+
+
+def test_speechify_tts_configuration_defaults():
+    config = SpeechifyTTSConfiguration(api_key="test-key")
+
+    assert config.provider == ServiceProviders.SPEECHIFY
+    assert config.model == "simba-3.2"
+    assert config.voice == "beatrice_32"
+    assert config.language == "en"
+    assert SPEECHIFY_TTS_MODELS[0] == "simba-3.2"
+    assert "beatrice_32" in SPEECHIFY_TTS_VOICES
+
+
+@pytest.mark.parametrize("transport_out_sample_rate", [8000, 16000, 24000])
+def test_create_speechify_tts_service_uses_transport_sample_rate(
+    transport_out_sample_rate,
+):
+    user_config = SimpleNamespace(
+        tts=SimpleNamespace(
+            provider=ServiceProviders.SPEECHIFY.value,
+            api_key="test-key",
+            model="simba-3.2",
+            voice="geffen_32",
+            language="en",
+        )
+    )
+    audio_config = SimpleNamespace(
+        transport_out_sample_rate=transport_out_sample_rate,
+        transport_in_sample_rate=16000,
+    )
+
+    with patch(
+        "api.services.pipecat.service_factory.SpeechifyTTSService"
+    ) as mock_service:
+        create_tts_service(user_config, audio_config)
+
+    assert mock_service.call_count == 1
+    kwargs = mock_service.call_args.kwargs
+    assert kwargs["api_key"] == "test-key"
+    assert kwargs["sample_rate"] == transport_out_sample_rate
+    assert kwargs["settings"].voice == "geffen_32"
+    assert kwargs["settings"].model == "simba-3.2"
+    assert kwargs["settings"].language == Language.EN
+
+
+def test_create_speechify_tts_service_converts_language():
+    user_config = SimpleNamespace(
+        tts=SimpleNamespace(
+            provider=ServiceProviders.SPEECHIFY.value,
+            api_key="test-key",
+            model="simba-3.0",
+            voice="adriana",
+            language="pt-BR",
+        )
+    )
+    audio_config = SimpleNamespace(
+        transport_out_sample_rate=24000,
+        transport_in_sample_rate=16000,
+    )
+
+    with patch(
+        "api.services.pipecat.service_factory.SpeechifyTTSService"
+    ) as mock_service:
+        create_tts_service(user_config, audio_config)
+
+    kwargs = mock_service.call_args.kwargs
+    assert kwargs["settings"].language == Language.PT_BR
+
+
+def test_create_speechify_tts_service_falls_back_to_english_for_unknown_language():
+    user_config = SimpleNamespace(
+        tts=SimpleNamespace(
+            provider=ServiceProviders.SPEECHIFY.value,
+            api_key="test-key",
+            model="simba-3.2",
+            voice="beatrice_32",
+            language="not-a-language",
+        )
+    )
+    audio_config = SimpleNamespace(
+        transport_out_sample_rate=24000,
+        transport_in_sample_rate=16000,
+    )
+
+    with patch(
+        "api.services.pipecat.service_factory.SpeechifyTTSService"
+    ) as mock_service:
+        create_tts_service(user_config, audio_config)
+
+    kwargs = mock_service.call_args.kwargs
+    assert kwargs["settings"].language == Language.EN
+
+
+def test_speechify_is_registered_for_key_validation():
+    validator = UserConfigurationValidator()
+    assert ServiceProviders.SPEECHIFY.value in validator._validator_map
+
+
+def test_speechify_key_validation_accepts_valid_key():
+    validator = UserConfigurationValidator()
+    with patch("api.services.configuration.check_validity.httpx.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        assert validator._check_speechify_api_key("simba-3.2", "sk-valid-key") is True
+    called_url = mock_get.call_args.args[0]
+    assert called_url == "https://api.speechify.ai/v1/voices?limit=1"
+    headers = mock_get.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer sk-valid-key"
+
+
+def test_speechify_key_validation_treats_non_auth_errors_as_inconclusive():
+    validator = UserConfigurationValidator()
+    with patch("api.services.configuration.check_validity.httpx.get") as mock_get:
+        mock_get.return_value.status_code = 500
+        assert validator._check_speechify_api_key("simba-3.2", "sk-valid-key") is True
+
+
+def test_speechify_key_validation_rejects_bad_key():
+    validator = UserConfigurationValidator()
+    with patch("api.services.configuration.check_validity.httpx.get") as mock_get:
+        mock_get.return_value.status_code = 401
+        with pytest.raises(ValueError):
+            validator._check_speechify_api_key("simba-3.2", "bad-key")

--- a/api/tests/test_speechify_tts_service_factory.py
+++ b/api/tests/test_speechify_tts_service_factory.py
@@ -1,3 +1,5 @@
+import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -15,6 +17,40 @@ from api.services.configuration.registry import (
     SpeechifyTTSConfiguration,
 )
 from api.services.pipecat.service_factory import create_tts_service
+
+
+@pytest.fixture
+def speechify_pipecat_stub(monkeypatch):
+    """Provide pipecat.services.speechify.tts for the factory's lazy import.
+
+    The pinned pipecat checkout predates upstream's SpeechifyHttpTTSService, so
+    the module the factory imports at call time is stubbed here.
+    """
+
+    class StubSpeechifyHttpTTSService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def cleanup(self):
+            pass
+
+    class StubSpeechifyTTSSettings:
+        def __init__(self, voice=None, model=None, language=None):
+            self.voice = voice
+            self.model = model
+            self.language = language
+
+    tts_mod = types.ModuleType("pipecat.services.speechify.tts")
+    tts_mod.SpeechifyHttpTTSService = StubSpeechifyHttpTTSService
+    tts_mod.SpeechifyTTSSettings = StubSpeechifyTTSSettings
+    pkg = types.ModuleType("pipecat.services.speechify")
+    pkg.tts = tts_mod
+    monkeypatch.setitem(sys.modules, "pipecat.services.speechify", pkg)
+    monkeypatch.setitem(sys.modules, "pipecat.services.speechify.tts", tts_mod)
+    # Force the wrapper module to rebind against this stub.
+    sys.modules.pop("api.services.pipecat.speechify_tts", None)
+    yield
+    sys.modules.pop("api.services.pipecat.speechify_tts", None)
 
 
 def test_speechify_tts_configuration_defaults():
@@ -41,6 +77,7 @@ def test_speechify_language_options_cover_every_model():
 
 @pytest.mark.parametrize("transport_out_sample_rate", [8000, 16000, 24000])
 def test_create_speechify_tts_service_uses_transport_sample_rate(
+    speechify_pipecat_stub,
     transport_out_sample_rate,
 ):
     user_config = SimpleNamespace(
@@ -57,21 +94,25 @@ def test_create_speechify_tts_service_uses_transport_sample_rate(
         transport_in_sample_rate=16000,
     )
 
-    with patch(
-        "api.services.pipecat.service_factory.SpeechifyTTSService"
-    ) as mock_service:
+    with (
+        patch(
+            "api.services.pipecat.speechify_tts.SpeechifyOwnedSessionTTSService"
+        ) as mock_service,
+        patch("api.services.pipecat.service_factory.aiohttp.ClientSession"),
+    ):
         create_tts_service(user_config, audio_config)
 
     assert mock_service.call_count == 1
     kwargs = mock_service.call_args.kwargs
     assert kwargs["api_key"] == "test-key"
+    assert kwargs["aiohttp_session"] is not None
     assert kwargs["sample_rate"] == transport_out_sample_rate
     assert kwargs["settings"].voice == "geffen_32"
     assert kwargs["settings"].model == "simba-3.2"
     assert kwargs["settings"].language == Language.EN
 
 
-def test_create_speechify_tts_service_converts_language():
+def test_create_speechify_tts_service_converts_language(speechify_pipecat_stub):
     user_config = SimpleNamespace(
         tts=SimpleNamespace(
             provider=ServiceProviders.SPEECHIFY.value,
@@ -86,16 +127,21 @@ def test_create_speechify_tts_service_converts_language():
         transport_in_sample_rate=16000,
     )
 
-    with patch(
-        "api.services.pipecat.service_factory.SpeechifyTTSService"
-    ) as mock_service:
+    with (
+        patch(
+            "api.services.pipecat.speechify_tts.SpeechifyOwnedSessionTTSService"
+        ) as mock_service,
+        patch("api.services.pipecat.service_factory.aiohttp.ClientSession"),
+    ):
         create_tts_service(user_config, audio_config)
 
     kwargs = mock_service.call_args.kwargs
     assert kwargs["settings"].language == Language.PT_BR
 
 
-def test_create_speechify_tts_service_passes_custom_language_through():
+def test_create_speechify_tts_service_passes_custom_language_through(
+    speechify_pipecat_stub,
+):
     # The config allows custom language codes; ones the pipecat Language enum
     # doesn't model must reach the provider verbatim, not be replaced with
     # English.
@@ -113,9 +159,12 @@ def test_create_speechify_tts_service_passes_custom_language_through():
         transport_in_sample_rate=16000,
     )
 
-    with patch(
-        "api.services.pipecat.service_factory.SpeechifyTTSService"
-    ) as mock_service:
+    with (
+        patch(
+            "api.services.pipecat.speechify_tts.SpeechifyOwnedSessionTTSService"
+        ) as mock_service,
+        patch("api.services.pipecat.service_factory.aiohttp.ClientSession"),
+    ):
         create_tts_service(user_config, audio_config)
 
     kwargs = mock_service.call_args.kwargs

--- a/api/tests/test_speechify_tts_service_factory.py
+++ b/api/tests/test_speechify_tts_service_factory.py
@@ -95,14 +95,17 @@ def test_create_speechify_tts_service_converts_language():
     assert kwargs["settings"].language == Language.PT_BR
 
 
-def test_create_speechify_tts_service_falls_back_to_english_for_unknown_language():
+def test_create_speechify_tts_service_passes_custom_language_through():
+    # The config allows custom language codes; ones the pipecat Language enum
+    # doesn't model must reach the provider verbatim, not be replaced with
+    # English.
     user_config = SimpleNamespace(
         tts=SimpleNamespace(
             provider=ServiceProviders.SPEECHIFY.value,
             api_key="test-key",
             model="simba-3.2",
             voice="beatrice_32",
-            language="not-a-language",
+            language="en-ZA",
         )
     )
     audio_config = SimpleNamespace(
@@ -116,7 +119,7 @@ def test_create_speechify_tts_service_falls_back_to_english_for_unknown_language
         create_tts_service(user_config, audio_config)
 
     kwargs = mock_service.call_args.kwargs
-    assert kwargs["settings"].language == Language.EN
+    assert kwargs["settings"].language == "en-ZA"
 
 
 def test_speechify_is_registered_for_key_validation():

--- a/docs/configurations/voice.mdx
+++ b/docs/configurations/voice.mdx
@@ -3,7 +3,7 @@ title: "Voice"
 description: "Voice Agents use TTS (Text to Speech), which generates audio that LLMs generate during the course of a conversation. This is the audio that the end user having the conversation listens to."
 ---
 
-Dograh platform supports ElevenLabs, OpenAI, Google, Azure Speech, Deepgram, Cartesia, Smallest AI, MiniMax, Sarvam, Rime, Inworld, Camb.ai, xAI, LMNT, and Dograh TTS engines. There are some voices from the providers that we ship by default. You can refer to the providers API documentation to select a voice ID that's most relevant for your language requirement.
+Dograh platform supports ElevenLabs, OpenAI, Google, Azure Speech, Deepgram, Cartesia, Smallest AI, MiniMax, Sarvam, Rime, Inworld, Camb.ai, xAI, LMNT, Speechify, and Dograh TTS engines. There are some voices from the providers that we ship by default. You can refer to the providers API documentation to select a voice ID that's most relevant for your language requirement.
 
 <Warning>
 Voice providers receive the data needed to synthesize speech, such as generated text, selected voice, model settings, and request metadata. Review the provider's data processing, retention, model training, and regional hosting policies before using sensitive data.

--- a/ui/src/client/types.gen.ts
+++ b/ui/src/client/types.gen.ts
@@ -5923,7 +5923,7 @@ export type SpeechifyTtsConfiguration = {
     /**
      * Language
      *
-     * Language code for synthesis (e.g. 'en', 'de', 'es', 'fr', 'it', 'pt-BR'). simba-3.2 is English-only.
+     * Language code for synthesis (e.g. 'en', 'de', 'es', 'fr', 'it', 'pt-BR'). Options are filtered to the selected model's documented languages; simba-3.2 is documented as English-only.
      */
     language?: string;
 };

--- a/ui/src/client/types.gen.ts
+++ b/ui/src/client/types.gen.ts
@@ -657,7 +657,9 @@ export type ByokPipelineAiModelConfiguration = {
         provider: 'xai';
     } & XaittsConfiguration) | ({
         provider: 'lmnt';
-    } & LmntTtsConfiguration);
+    } & LmntTtsConfiguration) | ({
+        provider: 'speechify';
+    } & SpeechifyTtsConfiguration);
     /**
      * Stt
      */
@@ -5892,6 +5894,38 @@ export type SpeachesTtsConfiguration = {
      * Speech speed (0.25 to 4.0).
      */
     speed?: number;
+};
+
+/**
+ * Speechify
+ */
+export type SpeechifyTtsConfiguration = {
+    /**
+     * Provider
+     */
+    provider?: 'speechify';
+    /**
+     * Api Key
+     */
+    api_key: string | Array<string>;
+    /**
+     * Model
+     *
+     * Speechify TTS model. 'simba-3.2' is the streaming-native English model with the lowest latency; 'simba-3.0' adds German, Spanish, French, Italian, and Portuguese.
+     */
+    model?: string;
+    /**
+     * Voice
+     *
+     * Speechify voice ID. Use a shared voice from the Speechify catalog or a cloned voice ID from your account.
+     */
+    voice?: string;
+    /**
+     * Language
+     *
+     * Language code for synthesis (e.g. 'en', 'de', 'es', 'fr', 'it', 'pt-BR'). simba-3.2 is English-only.
+     */
+    language?: string;
 };
 
 /**

--- a/ui/src/client/types.gen.ts
+++ b/ui/src/client/types.gen.ts
@@ -5917,7 +5917,7 @@ export type SpeechifyTtsConfiguration = {
     /**
      * Voice
      *
-     * Speechify voice ID. Use a shared voice from the Speechify catalog or a cloned voice ID from your account.
+     * Speechify voice ID. Options are filtered to voices available for the selected model; a custom or cloned voice ID must support the selected model (see GET /v1/voices), or synthesis fails.
      */
     voice?: string;
     /**

--- a/ui/src/components/ServiceConfigurationForm.tsx
+++ b/ui/src/components/ServiceConfigurationForm.tsx
@@ -410,6 +410,20 @@ export function ServiceConfigurationForm({
         }
     }, [ttsModel, serviceProviders.tts, setValue, getValues, schemas, isCustomInput.tts_voice]);
 
+    // Reset language when TTS model changes if the provider has model-dependent language options
+    useEffect(() => {
+        const languageSchema = schemas?.tts?.[serviceProviders.tts]?.properties?.language;
+        const modelOptions = languageSchema?.model_options;
+        if (!modelOptions || !ttsModel) return;
+
+        const validLanguages = modelOptions[ttsModel as string];
+        const currentLanguage = getValues("tts_language") as string;
+        const isCustomLanguage = !!isCustomInput.tts_language;
+        if (validLanguages && currentLanguage && !validLanguages.includes(currentLanguage) && !isCustomLanguage) {
+            setValue("tts_language", validLanguages[0], { shouldDirty: true });
+        }
+    }, [ttsModel, serviceProviders.tts, setValue, getValues, schemas, isCustomInput.tts_language]);
+
     // Reset language when STT model changes if the provider has model-dependent language options
     const sttModel = watch("stt_model");
     useEffect(() => {


### PR DESCRIPTION
## Summary

Adds Speechify as a selectable BYOK Voice/TTS provider using the streaming-native Simba models.

- registers Speechify configuration with model-aware voice and language options
- creates the upstream `SpeechifyHttpTTSService` through an owned-session wrapper
- validates API keys against `GET /v1/voices`, rejecting clear 401/403 authorization failures
- exposes the provider through the generated OpenAPI/UI client and voice documentation
- bumps the Pipecat submodule to `6cd1758e7` from dograh-hq/pipecat#59

## Audio-rate handling

Speechify timestamped streaming was observed returning 24 kHz signed 16-bit mono PCM when `pcm_16000` was requested while reporting a 16 kHz response rate. That mismatch made playback 1.5x slower and lower-pitched.

The Pipecat fix requests reliable `pcm_24000`, labels frames as 24 kHz, and lets the existing output transport resample to the configured WebRTC or telephony rate.

## Validation

- live local Dograh WebRTC call with Speechify Simba 3.2; voices play at the expected speed and pitch
- Dograh Speechify factory/configuration tests: 14 passed, 1 skipped
- Pipecat Speechify tests: 36 passed
- UI tests: 119 passed
- TypeScript, Ruff, formatting, and whitespace checks passed

## Dependency

Pipecat PR dograh-hq/pipecat#59 is merged and included by the submodule pointer in this PR.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=52904921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

No blocking failure remains.

What we checked:
- Executed controlled runtime checks using review-authored Speechify factory and cleanup harnesses, including constructing Speechify with en-ZA retained Language.EN_ZA, simulating a missing tts configuration error, re-raising an unrelated import failure, and a cleanup exception that still closed the owned session. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Ran the focused API Speechify factory suite and Pipecat's Speechify suite, which reported 14 passed, 1 skipped and 36 passed respectively, confirming the integration paths behaved as intended. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Blocked the upload action due to the missing Greptile artifact upload mechanism in this runtime, not due to missing files, and noted that the listed local artifact references are captured evidence not uploaded in this response. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- ## Summary Adds Speechify as a bring-your-own-key text-to-speech provider, with model-aware voice and language choices, credential validation, provider construction, configuration-form support, and documentation.
- Focused runtime checks disproved the previously reported blocking concerns: custom language codes are preserved through `api/services/pipecat/service_factory.py`; a missing Speechify Pipecat module produces a clear configuration error without masking unrelated import failures; and `api/services/pipecat/speechify_tts.py` closes its owned HTTP session even when upstream cleanup raises. The targeted API factory tests passed (14 passed, 1 skipped), and the upstream Pipecat Speechify tests passed (36 passed).

<sub>Reviews (11) · Last reviewed commit: ["fix(tts): close the owned Speechify sess..."](https://github.com/dograh-hq/dograh/commit/15c9051c49bbe174fa8e12346bd3167bd75d62b1)</sub>

<!-- /greptile_comment -->