### PR TITLE
fix(telephony): don't double-prefix numbers using the 00 international access prefix

### DIFF
--- a/api/tests/utils/test_telephony_address.py
+++ b/api/tests/utils/test_telephony_address.py
@@ -1,0 +1,108 @@
+import pytest
+
+from api.utils.telephony_address import normalize_telephony_address
+
+
+class TestPstnNormalization:
+    """PSTN inputs, with and without an India country hint."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # Already E.164 — the hint must be a no-op.
+            ("+919262175513", "+919262175513"),
+            ("919262175513", "+919262175513"),
+            # National format with the trunk-prefix zero.
+            ("09262175513", "+919262175513"),
+            ("02271264296", "+912271264296"),
+            ("08071582014", "+918071582014"),
+            # Bare national significant number.
+            ("9262175513", "+919262175513"),
+        ],
+    )
+    def test_india_hint(self, raw, expected):
+        assert normalize_telephony_address(raw, country_hint="IN").canonical == expected
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # "00" is the ITU international access prefix — the country code
+            # already follows, so the hint must not be applied on top.
+            ("00919262175513", "+919262175513"),
+            ("00918071582014", "+918071582014"),
+            # A non-Indian number reached through the same access prefix.
+            ("00442079460958", "+442079460958"),
+        ],
+    )
+    def test_international_access_prefix_is_not_double_prefixed(self, raw, expected):
+        """Regression: "0091..." used to normalize to "+9191...".
+
+        `_normalize_pstn` tested `digits.startswith(dial)` before stripping the
+        leading zeros, so the access prefix hid the country code and the dial
+        code was prepended a second time. The resulting address matched no
+        configured phone number and inbound calls were rejected with
+        PHONE_NUMBER_NOT_CONFIGURED.
+        """
+        assert normalize_telephony_address(raw, country_hint="IN").canonical == expected
+
+    def test_country_code_claimed_only_when_dial_code_matches(self):
+        """An explicitly international number need not be in the hinted country."""
+        indian = normalize_telephony_address("00919262175513", country_hint="IN")
+        assert indian.country_code == "IN"
+
+        british = normalize_telephony_address("00442079460958", country_hint="IN")
+        assert british.country_code is None
+
+    def test_no_hint_leaves_digits_untouched(self):
+        result = normalize_telephony_address("919262175513")
+        assert result.canonical == "+919262175513"
+        assert result.country_code is None
+
+    def test_separators_are_stripped(self):
+        assert (
+            normalize_telephony_address("+91 92621-75513").canonical
+            == "+919262175513"
+        )
+
+    def test_address_type_is_pstn(self):
+        assert normalize_telephony_address("919262175513").address_type == "pstn"
+
+
+class TestSipUriNormalization:
+    def test_default_port_dropped_and_host_lowercased(self):
+        result = normalize_telephony_address("sip:Alice@Example.COM:5060")
+        assert result.canonical == "sip:Alice@example.com"
+        assert result.address_type == "sip_uri"
+
+    def test_non_default_port_preserved(self):
+        assert (
+            normalize_telephony_address("sip:alice@example.com:5080").canonical
+            == "sip:alice@example.com:5080"
+        )
+
+    def test_sips_default_port_dropped(self):
+        assert (
+            normalize_telephony_address("sips:alice@example.com:5061").canonical
+            == "sips:alice@example.com"
+        )
+
+
+class TestExtensionsAndInvalidInput:
+    def test_short_extension_is_not_pstn(self):
+        result = normalize_telephony_address("1001")
+        assert result.canonical == "1001"
+        assert result.address_type == "sip_extension"
+
+    def test_alphanumeric_username(self):
+        result = normalize_telephony_address("Support-Queue")
+        assert result.canonical == "support-queue"
+        assert result.address_type == "sip_extension"
+
+    @pytest.mark.parametrize("raw", ["", "   "])
+    def test_empty_rejected(self, raw):
+        with pytest.raises(ValueError):
+            normalize_telephony_address(raw)
+
+    def test_none_rejected(self):
+        with pytest.raises(ValueError):
+            normalize_telephony_address(None)

--- a/api/utils/telephony_address.py
+++ b/api/utils/telephony_address.py
@@ -73,10 +73,25 @@ def normalize_telephony_address(
 def _normalize_pstn(digits: str, country_hint: Optional[str]) -> NormalizedAddress:
     country_code: Optional[str] = None
 
+    # A leading "00" is the ITU international access prefix (ITU-T E.164 §3.3):
+    # the country code already follows it, so the hint must not be applied on
+    # top. Carriers that hand us "0091..." would otherwise get the dial code
+    # prepended twice ("00919262175513" → "+91919262175513").
+    #
+    # This is checked before the country hint because the hint's own
+    # `startswith(dial)` test cannot see past the access prefix.
+    if digits.startswith("00"):
+        digits = digits[2:]
+        # The number is explicitly international, so it need not belong to the
+        # hinted country — only claim the ISO code when the dial code matches.
+        if country_hint:
+            dial = get_country_code(country_hint)
+            if dial and digits.startswith(dial):
+                country_code = country_hint.upper()
     # If a country hint is given and the digits don't already start with that
     # country's dial code, try to apply it. Local numbers may include a leading
     # zero that needs stripping (e.g. India "0xxxx" → "+91xxxx").
-    if country_hint:
+    elif country_hint:
         dial = get_country_code(country_hint)
         if dial:
             country_code = country_hint.upper()


### PR DESCRIPTION
## Problem

Inbound calls to one of our Vobiz numbers were answered with *"Phone number not configured"* and immediately hung up, even though the number was configured and active. Other numbers on the same account worked.

The cause is in `normalize_telephony_address`. `_normalize_pstn` applies the country hint by testing `digits.startswith(dial)` **before** stripping leading zeros:

```python
if not digits.startswith(dial):        # "00919262175513" does not start with "91"
    stripped = digits.lstrip("0")      # -> "919262175513"  (already has the CC)
    candidate = f"{dial}{stripped}"    # -> "91" + "919262175513"
    if 8 <= len(candidate) <= 15:      # 14, so the length guard doesn't catch it
        digits = candidate
```

A number carrying the ITU international access prefix (`00` + country code, ITU-T E.164 3.3) looks like it has no country code, so the dial code is prepended a second time:

```
00919262175513  ->  +91919262175513     # doubled "91"
```

`find_inbound_route_by_account` then matches no row and `/inbound/run` returns `PHONE_NUMBER_NOT_CONFIGURED`, so the call is rejected.

Only numbers delivered with the `00` prefix are affected, which is why this looked number-specific. Every other format the carrier sends normalizes correctly:

| Input | Before | After |
|---|---|---|
| `00919262175513` | `+91919262175513` (wrong) | `+919262175513` |
| `08071582014` | `+918071582014` | `+918071582014` |
| `918065382456` | `+918065382456` | `+918065382456` |
| `02271264296` | `+912271264296` | `+912271264296` |

## Fix

Handle `00` before the country hint: strip it and treat what follows as already-qualified E.164. The hint branch is untouched, so national trunk-prefix numbers still resolve as before.

An explicitly international number need not belong to the hinted country, so the ISO code is now only claimed when the dial code actually matches - `normalize_telephony_address("00442079460958", country_hint="IN")` returns `+442079460958` with `country_code=None` rather than mislabelling it `IN`.

The tempting shorter fix - re-checking `stripped.startswith(dial)` after `lstrip("0")` - is **not** correct: legitimate 10-digit Indian mobile numbers begin with `91` (the `91xxxxxxxx` series), so `09188123456` would be misread as already carrying a country code.

## Tests

`api/utils/telephony_address.py` had no direct test coverage. This adds `api/tests/utils/test_telephony_address.py` with 21 tests covering PSTN normalization, the `00` regression, SIP URI canonicalization, extensions, and invalid input.

Verified against the fix: the 4 new regression assertions fail on `main` and pass with this change; the other 17 pass both ways, so existing behaviour is unchanged.

```
21 passed
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PSTN normalization to avoid double-prefixing numbers that use the 00 international access prefix. Before: a number like 0091… with a country hint normalized to +9191…, causing no inbound route and PHONE_NUMBER_NOT_CONFIGURED. Now: we strip 00 first, treat the rest as E.164, and only set the ISO country_code when the dial code matches; national trunk-prefix logic is unchanged.

- Handles the 00 access prefix before applying the country hint; prevents adding the dial code twice and mislabeling the country.
- Keeps existing behavior for national formats (e.g., 0xxxxxxxxx → +91xxxxxxxxx for IN).
- Adds api/tests/utils/test_telephony_address.py with 21 tests covering PSTN normalization, the 00 regression, SIP URI canonicalization, extensions, and invalid input.

<sup>Written for commit 3d4a5316472b0e4f3a49a5a9d9aae84fc2c7c898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change corrects PSTN normalization for addresses using the `00` international access prefix and adds focused normalization coverage. It also changes the canonical key produced for values that may already have been stored by the phone-number backfill: legacy rows can contain `+00...`, while inbound calls now normalize to `+...`. Because the routing lookup and fallback comparison do not reconcile those forms, affected configured numbers reject inbound calls until persisted canonical values are migrated or compatibility matching is added.

## T-Rex validation blocked

The focused reproduction could not complete because required Python packages were missing: `loguru`, `python-dotenv`, and `alembic`. The attempted imports also require configured `DATABASE_URL` and `REDIS_URL`. Focused pytest collection stopped on the missing `python-dotenv` package.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until legacy persisted phone-number canonical values are reconciled or inbound matching supports both canonical forms.

There is one independent non-security P1 finding, which maps to a score of 4. The code path shows the legacy migration, corrected normalizer, exact lookup, and fallback matcher use incompatible representations for the same number.

**Files Needing Attention:** api/utils/telephony_address.py needs a compatibility strategy coordinated with the legacy backfill in api/alembic/versions/a2355fc6bdc1_add_multi_telephony_config_tables.py and inbound lookup behavior in api/db/telephony_phone_number_client.py and api/routes/telephony.py.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Authored a legacy inbound-route reproduction script to exercise the inbound path for the 0091... value.
- Tried to reproduce using the migration snapshot normalizer, current normalizer, and route fallback matcher for 0091..., but the run could not complete because loguru, python-dotenv, and alembic were unavailable; the focused command pytest -q api/tests/utils/test\_telephony\_address.py started but halted during collection due to missing python-dotenv.
- Inspected the legacy persisted-value reproduction attempt log to assess the blocker and what it revealed.
- Inspected the repaired stored-value comparison attempt log to verify the progress after the initial blocker.
- Inspected the normalizer test-suite attempt log to capture the remaining validation steps and outcomes.

<a href="https://app.greptile.com/trex/runs/18708721/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(telephony): don&#39;t double-prefix numb..."](https://github.com/dograh-hq/dograh/commit/3d4a5316472b0e4f3a49a5a9d9aae84fc2c7c898) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52981114)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->