### PR TITLE
Update README with badges for Product Hunt and Trendshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 - **Maintained by YC alumni and exit founders**, committed to keeping voice AI open
 
 <p align="center">
+  <a href="https://www.producthunt.com/products/dograh?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-dograh-3" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1217382&theme=light&period=daily&t=1786607298379" alt="Dograh - The open source VAPI alternative | Product Hunt" width="250" height="54"></a>
+  &nbsp;
   <a href="https://trendshift.io/repositories/31007" target="_blank"><img src="https://trendshift.io/api/badge/repositories/31007" alt="dograh-hq%2Fdograh | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
 


### PR DESCRIPTION
Added Product Hunt badge to README. In the same line as of Trend Shift, Badge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Product Hunt badge to the README, displayed inline with the existing Trendshift badge, to highlight our launch and social proof.

- Places the Product Hunt badge before Trendshift within the centered badges row, adds a non-breaking space for spacing, and sets explicit width/height.
- Uses external embed image URLs and `target="_blank"` links; verify rendering on light/dark themes and that links open correctly.

<sup>Written for commit 70141f473096fe772666b8ddb350800478f76be6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Product Hunt badge beside the existing Trendshift badge in the centered README badge row. The updated badge block was checked against the previous version: the Product Hunt image is correctly nested in its HTTPS link, the separator is present, the existing Trendshift badge remains intact, and the Product Hunt SVG endpoint responds successfully.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the documentation badge renders as a correctly linked image and preserves the surrounding badge layout.

The only changed file was checked with an HTML parser against both revisions and with live requests for the Product Hunt image endpoint. The checked badge structure and image response behaved as intended, and no defects were found.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before capture, I verified the base README badge state had only the Trendshift badge.
- After the PR, I verified the README now includes exactly one Product Hunt badge and retains the Trendshift badge.
- I also validated that the Product Hunt image source is live (200, image/svg+xml) and that the destination endpoint returned 403 to automated clients.
- I collected and reviewed the validation artifacts, including the focused validation script and the before/after badge validation logs.

<a href="https://app.greptile.com/trex/runs/18833879/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Update README with badges for Product Hu..."](https://github.com/dograh-hq/dograh/commit/70141f473096fe772666b8ddb350800478f76be6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53226942)</sub>

<!-- /greptile_comment -->