### PR TITLE
feat(deepgram): allow a custom base_url for Deepgram STT and TTS

### DIFF
--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -946,6 +946,15 @@ class DeepgramTTSConfiguration(BaseServiceConfiguration):
         default="aura-2-helena-en",
         description="Deepgram voice ID (model is inferred from the 'aura-N' prefix).",
     )
+    base_url: str = Field(
+        default="",
+        description=(
+            "Deepgram API base URL. Override to reach a Deepgram self-hosted / "
+            "on-prem deployment, a regional endpoint, or an API-compatible "
+            "gateway. Leave empty to use Deepgram's default "
+            "(wss://api.deepgram.com)."
+        ),
+    )
 
     @computed_field
     @property
@@ -1509,6 +1518,15 @@ class DeepgramSTTConfiguration(BaseSTTConfiguration):
                 "flux-general-multi": DEEPGRAM_FLUX_MULTILINGUAL_LANGUAGE_OPTIONS,
             },
         },
+    )
+    base_url: str = Field(
+        default="",
+        description=(
+            "Deepgram API base URL. Override to reach a Deepgram self-hosted / "
+            "on-prem deployment, a regional endpoint, or an API-compatible "
+            "gateway. Leave empty to use Deepgram's default. Not applied to "
+            "the Flux models, whose service does not accept a custom URL."
+        ),
     )
 
 

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -288,6 +288,11 @@ def create_stt_service(
         # Other models than flux
         # Use language from user config, defaulting to "multi" for multilingual support
         language = getattr(user_config.stt, "language", None) or "multi"
+        kwargs = {}
+        base_url = getattr(user_config.stt, "base_url", None)
+        if base_url:
+            _validate_runtime_service_url(base_url, "base_url")
+            kwargs["base_url"] = base_url
         return DeepgramSTTService(
             api_key=user_config.stt.api_key,
             settings=DeepgramSTTSettings(
@@ -299,6 +304,7 @@ def create_stt_service(
             ),
             should_interrupt=False,  # Let UserAggregator take care of sending InterruptionFrame
             sample_rate=audio_config.transport_in_sample_rate,
+            **kwargs,
         )
     elif user_config.stt.provider == ServiceProviders.OPENAI.value:
         kwargs = {}
@@ -566,12 +572,18 @@ def create_tts_service(
     # Create function call filter to prevent TTS from speaking function call tags
     xml_function_tag_filter = XMLFunctionTagFilter()
     if user_config.tts.provider == ServiceProviders.DEEPGRAM.value:
+        kwargs = {}
+        base_url = getattr(user_config.tts, "base_url", None)
+        if base_url:
+            _validate_runtime_service_url(base_url, "base_url")
+            kwargs["base_url"] = base_url
         return DeepgramTTSService(
             api_key=user_config.tts.api_key,
             settings=DeepgramTTSSettings(voice=user_config.tts.voice),
             text_filters=[xml_function_tag_filter],
             skip_aggregator_types=["recording_router", "recording"],
             silence_time_s=1.0,
+            **kwargs,
         )
     elif user_config.tts.provider == ServiceProviders.OPENAI.value:
         kwargs = {}

--- a/api/tests/test_deepgram_base_url_service_factory.py
+++ b/api/tests/test_deepgram_base_url_service_factory.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from api.services.configuration.registry import (
+    DeepgramSTTConfiguration,
+    DeepgramTTSConfiguration,
+    ServiceProviders,
+)
+from api.services.pipecat.audio_config import AudioConfig
+from api.services.pipecat.service_factory import create_stt_service, create_tts_service
+
+ON_PREM_URL = "wss://deepgram.internal.example.com"
+
+
+def _audio_config() -> AudioConfig:
+    return AudioConfig(
+        transport_in_sample_rate=16000,
+        transport_out_sample_rate=16000,
+    )
+
+
+def _stt_config(base_url: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        stt=SimpleNamespace(
+            provider=ServiceProviders.DEEPGRAM.value,
+            api_key="test-key",
+            model="nova-3-general",
+            language="multi",
+            base_url=base_url,
+        )
+    )
+
+
+def _tts_config(base_url: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        tts=SimpleNamespace(
+            provider=ServiceProviders.DEEPGRAM.value,
+            api_key="test-key",
+            model="aura-2",
+            voice="aura-2-helena-en",
+            base_url=base_url,
+        )
+    )
+
+
+def test_deepgram_configurations_default_to_empty_base_url():
+    assert DeepgramSTTConfiguration(api_key="test-key").base_url == ""
+    assert DeepgramTTSConfiguration(api_key="test-key").base_url == ""
+
+
+def test_deepgram_stt_passes_custom_base_url():
+    with patch("api.services.pipecat.service_factory.DeepgramSTTService") as stt_service:
+        create_stt_service(_stt_config(ON_PREM_URL), _audio_config())
+
+    kwargs = stt_service.call_args.kwargs
+    assert kwargs["base_url"] == ON_PREM_URL
+    assert kwargs["api_key"] == "test-key"
+
+
+def test_deepgram_stt_omits_base_url_when_unset():
+    with patch("api.services.pipecat.service_factory.DeepgramSTTService") as stt_service:
+        create_stt_service(_stt_config(), _audio_config())
+
+    assert "base_url" not in stt_service.call_args.kwargs
+
+
+def test_deepgram_tts_passes_custom_base_url():
+    with patch("api.services.pipecat.service_factory.DeepgramTTSService") as tts_service:
+        create_tts_service(_tts_config(ON_PREM_URL), _audio_config())
+
+    kwargs = tts_service.call_args.kwargs
+    assert kwargs["base_url"] == ON_PREM_URL
+    assert kwargs["settings"].voice == "aura-2-helena-en"
+
+
+def test_deepgram_tts_omits_base_url_when_unset():
+    with patch("api.services.pipecat.service_factory.DeepgramTTSService") as tts_service:
+        create_tts_service(_tts_config(), _audio_config())
+
+    assert "base_url" not in tts_service.call_args.kwargs


### PR DESCRIPTION
## What

Adds an optional `base_url` to the Deepgram STT and TTS configurations and passes it through to the pipecat services.

## Why

`ElevenlabsTTSConfiguration` already carries a `base_url` — its description says it exists so users can reach a Data Residency endpoint "for GDPR / HIPAA / regional compliance." Deepgram has exactly the same needs but is hard-wired to `api.deepgram.com`, so a self-hoster currently cannot point at:

- a **Deepgram self-hosted / on-prem deployment** (what regulated and healthcare customers buy),
- a **regional endpoint** for data residency,
- an **API-compatible gateway or corporate egress proxy**,
- a **local mock in CI**, to run tests without burning credits.

So this is mostly a consistency fix: one provider in that schema can be redirected, the other can't.

## How

`pipecat` already supports it — `DeepgramSTTService` and `DeepgramTTSService` both take a `base_url` argument (STT even derives the ws/http pair from it and falls back to the default if it can't). Nothing new is needed downstream; this only exposes what is already there.

- `api/services/configuration/registry.py` — an optional `base_url` field on `DeepgramSTTConfiguration` and `DeepgramTTSConfiguration`. It **defaults to empty, meaning "use Deepgram's default"**, so existing stored configurations behave exactly as before.
- `api/services/pipecat/service_factory.py` — passes it through only when set, using the same `_validate_runtime_service_url` guard the OpenAI STT/TTS branches already use. That keeps SaaS-mode SSRF protection intact (`validate_user_configured_service_url` already allows `ws`/`wss` and blocks private IPs), while OSS deployments can still point at a LAN host.

**Flux STT is deliberately excluded**: `DeepgramFluxSTTService` does not accept a `base_url`, so the field's description notes it doesn't apply there. Happy to extend it if that changes upstream.

## Tests

New `api/tests/test_deepgram_base_url_service_factory.py`, following the shape of the existing ElevenLabs factory tests: defaults stay empty, a custom URL reaches both services, and the kwarg is omitted entirely when unset.

```
tests/test_deepgram_base_url_service_factory.py .....            [100%]
5 passed
```

I also ran the wider related selection (`-k "deepgram or config or service_factory or url"`): **473 passed**. The only failures are in `test_from_number_pool_isolation.py`, which fail identically on a clean checkout in my environment (they need a live Redis) — unrelated to this change.

## Notes

I'm running Dograh self-hosted (Fly.io) for a small side project and hit this while wiring up the model layer. Related: #656, which asks whether a managed-voice + BYO-LLM hybrid could be supported — happy to take a crack at that too if you think it's a direction you'd want.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows a custom `base_url` for Deepgram STT and TTS configs and passes it to `pipecat` services. Previously we always used `api.deepgram.com`; now you can override per config without changing defaults, and SaaS SSRF protections still apply.

**Review / rollout**
- Adds `base_url` to `DeepgramSTTConfiguration` and `DeepgramTTSConfiguration` (default empty = Deepgram’s default). Not applied to Flux STT (`DeepgramFluxSTTService` does not accept a `base_url`).
- Passes `base_url` through in `api/services/pipecat/service_factory.py` only when set, guarded by `_validate_runtime_service_url` (same check used for OpenAI).
- Migration: No action required. To use a custom endpoint, set `base_url` in Deepgram STT/TTS configs. In SaaS, only `ws`/`wss` and public IPs are allowed; OSS deployments can point to LAN hosts.
- Tests cover default empty value, override propagation, and omission when unset for both services.

<sup>Written for commit 22db6b790227478cfdcceb6159eb042f392fa27f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional custom Deepgram endpoints to STT and TTS configuration and forwards configured values through the Pipecat service factory, while leaving the default provider endpoint in use when the setting is empty.

Disproved drop: the documented TTS WebSocket endpoint is compatible with the selected Deepgram TTS implementation. Direct execution accepted `wss://api.deepgram.com` in configuration and captured the configured `wss://.../v1/speak` WebSocket handshake from the exact service used by the factory; it did not issue an HTTP POST.

## T-Rex validation blocked

The focused repository test module could not collect because the active environment is missing the `python-dotenv` package. The direct configuration and service-protocol checks completed successfully despite that missing package.

<h3>Confidence Score: 5/5</h3>

The reviewed endpoint configuration behavior is safe to merge.

Direct execution covered the documented WebSocket configuration value and the outbound request construction of the exact Deepgram TTS service selected by the factory, contradicting the reported protocol-mismatch consequence.

**Files Needing Attention:** No files require follow-up from this review.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Configuration acceptance reproduction ran and completed with exit code 0, printing accepted\_base\_url=wss://api.deepgram.com.
- Before/HTTP contrast reproduction ran and captured the HTTP TTS endpoint https://api.deepgram.com/v1/speak via the DeepgramHttpTTSService.
- After/exact selected service reproduction ran and captured the WebSocket endpoint wss://configured.deepgram.example/v1/speak?model=aura-2-helena-en&encoding=linear16&sample\_rate=0, and it did not invoke an HTTP POST.
- Focused PR test run attempted with pytest and exited with code 4 due to ModuleNotFoundError: No module named 'dotenv'.
- A focused factory test collection blocker was observed in the logs.

<a href="https://app.greptile.com/trex/runs/18880914/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(deepgram): allow a custom base\_url ..."](https://github.com/dograh-hq/dograh/commit/22db6b790227478cfdcceb6159eb042f392fa27f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53318277)</sub>

<!-- /greptile_comment -->