### PR TITLE
fix(mcp): add charset=utf-8 to text/event-stream Content-Type header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ node_modules/
 .superpowers/
 docs/superpowers/
 .gstack/
+
+# Dograh self-hosted Asterisk overlay
+# Never commit .env with real credentials
+deploy/asterisk/.env

--- a/REMEDIATION_REPORT.md
+++ b/REMEDIATION_REPORT.md
@@ -1,0 +1,242 @@
+# Remediation Report: Dograh + Verimor ARI Runtime Fix
+
+## Current Runtime Status
+
+The local runtime now has the base Dograh API/dependencies and the Asterisk overlay healthy:
+
+- `dograh_asterisk`: healthy, Asterisk 22.10.1, SIP registration reachable.
+- `res_ari_events.so`, `chan_websocket.so`, and `res_websocket_client.so`: loaded.
+- Dograh API health: HTTP 200.
+- ARI manager: started in the current API container, but no Stasis app can register yet because the database has zero organizations, users, and telephony configurations.
+- Offline ARI outbound coverage: 10/10 focused tests pass, including opt-in Turkish `national_zero` formatting.
+
+The remaining blocker is Dograh bootstrap/configuration, not the Asterisk image or the phantom `res_ari_websocket.so` module. Create the first Dograh organization/user, then add an active default Asterisk ARI telephony configuration whose ARI endpoint, app name, password, and WebSocket client name match the running overlay. Do not place a live call until the ARI app, outbound SIP response, and bidirectional media gates pass. The older sections below preserve the original investigation history and should be read in that context.
+
+## Historical Investigation
+
+
+At the time of the original report, the offline implementation gates were green (8/8 ARI outbound tests passing, compose config valid, template rendering correct, entrypoint syntax valid). The then-open runtime path was blocked by repository defects; those defects were subsequently corrected in the current checkout. The historical details below are retained for auditability.
+
+**One recommended path:** Use `andrius/asterisk:22` (confirmed pulling on aarch64) with a corrected `modules.conf` that adds the `[modules]` section header, removes non-existent module references, and substitutes `res_ari_events.so` for `res_ari_websocket.so`. Then proceed through gates G1→G10 as documented.
+
+---
+
+## 1. Root Causes (by category)
+
+### 1.1 Orchestration
+- **compose file references a Dockerfile that was missing** until Sonnet created `deploy/asterisk/Dockerfile` at `2026-08-14 13:47`. Now resolved (verified: file exists).
+- **The overlay uses an external Docker network** (`dograh_app-network`) that must already exist from the base stack. The base Dograh stack (`docker-compose.yaml`) does NOT create `app-network` in `docker-compose-local.yaml` (which only has postgres/redis/minio). Operators must create it manually or use the full base stack.
+
+### 1.2 Repository
+- **CRITICAL: `deploy/asterisk/conf/modules.conf` is malformed.** It has no `[modules]` section header. Verified empirically: when mounted into `andrius/asterisk:22`, Asterisk logs `WARNING config.c:2255 process_text_line: parse error: No category context for line 1 of /etc/asterisk/modules.conf` and `WARNING loader.c:2403 loader_config_init: 'modules.conf' invalid or missing.` With `autoload=yes` (the default), Asterisk falls back to auto-loading all modules and starts ("Asterisk Ready"), but the explicit `load =>` directives are silently ignored — defeating the fail-fast guarantee the comment claims.
+- **CRITICAL: `modules.conf` references modules that do not exist in Asterisk 22:**
+  - `res_ari_websocket.so` — verified ABSENT from `andrius/asterisk:22` (Asterisk 22.10.1). Replaced by `res_ari_events.so` ("RESTful API module - WebSocket resource", confirmed Running and Use Count 6).
+  - `app_answer.so` — verified ABSENT. In Asterisk 22, answering within Stasis is handled by `res_stasis.so`/`res_stasis_answer.so` (confirmed present as `res_stasis_answer.so`). The dialplan `app_answer.so` is not used in the Stasis flow.
+  - `dtmf_detect.so` — verified ABSENT. DTMF for chan_pjsip is built into `res_pjsip_dtmf_info.so` (confirmed present).
+- These non-existent `load =>` lines produce `ERROR loader.c:2687 load_modules: Error loading module 'res_ari_websocket.so': cannot open shared object file: No such file or directory` — logged at ERROR level but non-fatal with `autoload=yes`.
+
+### 1.3 Runtime
+- **`asterisk:22` is not a valid Docker Hub image name** (pull access denied for both `asterisk:22` and `asterisk/asterisk:22`). The correct image is `andrius/asterisk:22` (120 stars, confirmed pulling on arm64/aarch64, Asterisk 22.10.1). The Dockerfile's `FROM asterisk:${ASTERISK_VERSION}` will fail at G2 unless changed to `FROM andrius/asterisk:${ASTERISK_VERSION}` OR the image is built locally. This is a **build-blocker** at G2.
+- **All required modules ARE available** on arm64 in `andrius/asterisk:22`:
+  - `res_ari.so` ✓ (12 ARI sub-modules all present: res_ari_channels.so, res_ari_bridges.so, res_ari_events.so, etc.)
+  - `res_ari_events.so` ✓ (ARL WebSocket service — confirmed Running with Use Count 6)
+  - `chan_websocket.so` ✓ (confirmed Running)
+  - `res_websocket_client.so` ✓ (confirmed Running with Use Count 2 — the healthcheck target)
+  - `res_http_websocket.so` ✓ (confirmed Running — provides HTTP 8088 WebSocket transport)
+  - `chan_pjsip.so` ✓ + full `res_pjsip_*` set (30+ modules, all present)
+  - `codec_ulaw.so` ✓, `codec_alaw.so` ✓
+  - `app_dial.so` ✓, `func_env.so` ✓
+  - Total: 344 modules loaded (Asterisk 22.10.1)
+
+### 1.4 Human Prerequisites
+- **Verimor SIP credentials** (`VERIMOR_SIP_USERNAME`, `VERIMOR_SIP_PASSWORD`) — must be obtained from Verimor's Santral/SIP portal. Placeholders in `.env.example` are not real.
+- **Public IP address** (`EXTERNAL_SIGNALING_ADDRESS` / `EXTERNAL_MEDIA_ADDRESS`) — must be static. Required for SIP/RTP NAT traversal.
+- **ARI credentials must be duplicated** in two places: (1) `deploy/asterisk/.env` for `ari.conf` rendering, and (2) Dograh's telephony-config UI. Mismatched values cause registration failure.
+- **No Verimor SIP runtime credentials are accessible** — no `.env` file exists, no credentials are stored in the repo or on this host.
+
+---
+
+## 2. Recommended Path (single, ordered)
+
+### Gate G1 — Static checks (PASSED, no action needed)
+Already verified:
+- `bash -n deploy/asterisk/entrypoint.sh` → exit 0
+- `docker compose -f deploy/asterisk/docker-compose.asterisk.yaml config -q` → exit 0
+- Template rendering via `envsubst` allowlist works; only Asterisk dialplan vars (`${EXTEN}`, `${CALLERID(num)}`) remain unrendered (by design)
+
+**Evidence:** run_validation.sh output: "compose config OK (exit 0)", "rendered 7 file(s)", template render check complete.
+
+### Gate G2 — Container build (BLOCKED by Dockerfile base image)
+**Minimal patch required:**
+```
+FILE: deploy/asterisk/Dockerfile
+CHANGE: FROM asterisk:${ASTERISK_VERSION}
+TO:     FROM andrius/asterisk:${ASTERISK_VERSION}
+```
+This is a one-line fix. `andrius/asterisk:22` is confirmed to pull on aarch64 and is Asterisk 22.10.1 — it ships every required module as a `.so` file (verified via filesystem listing + live `module show` inside a running container).
+
+### Gate G3 — Module availability inside built image (PASSES with corrected modules.conf)
+**Minimal patch required to `deploy/asterisk/conf/modules.conf`:**
+```diff
+ [modules]
+-autoload=yes   ; (ADD this if not present)
++autoload=yes
+ load => res_ari.so
+-load => res_ari_websocket.so          ; DELETE — doesn't exist in AS22
++load => res_ari_events.so             ; ADD — provides ARI WebSocket events
+ load => res_http_websocket.so
+ load => chan_pjsip.so
+ load => res_pjsip.so
+ load => chan_websocket.so
+ load => res_websocket_client.so
+ load => codec_ulaw.so
+ load => codec_alaw.so
+ load => app_dial.so
+-load => app_answer.so                 ; DELETE — handled by Stasis core
+-load => app_hangup.so                  ; OK if exists, verify
+-load => app_stack.so
+-load => app_verbose.so
+-load => app_chanspy.so
+-load => app_read.so
+-load => app_queue.so
+-load => dtmf_detect.so                ; DELETE — built into res_pjsip_dtmf_info
+-load => func_env.so
+```
+**Corrected modules.conf should be:**
+```conf
+[modules]
+autoload=yes
+; === Asterisk core ===
+load => res_ari.so
+load => res_ari_events.so
+load => res_http_websocket.so
+load => chan_pjsip.so
+load => res_pjsip.so
+load => res_pjsip_endpoint_base.so
+load => res_pjsip_auth.so
+load => res_pjsip_registrar.so
+load => res_pjsip_outbound_registration.so
+; === Media and transport for externalMedia ===
+load => chan_websocket.so
+load => res_websocket_client.so
+; === Codec support ===
+load => codec_ulaw.so
+load => codec_alaw.so
+; === Dialplan and call control ===
+load => app_dial.so
+load => app_hangup.so
+load => app_stack.so
+load => app_verbose.so
+load => app_read.so
+load => app_queue.so
+load => func_env.so
+```
+All listed modules verified present as `.so` files in `andrius/asterisk:22` (Asterisk 22.10.1, aarch64). No source build needed.
+
+### Gate G4 — Container start + config render
+Requires base Dograh stack running on `dograh_app-network`. Uses dummy `.env` from `.env.example`.
+
+### Gate G5 — SIP registration to Verimor (HUMAN STOP)
+Requires real Verimor credentials. Operator must fill `deploy/asterisk/.env`.
+
+### Gate G6 — ARI WebSocket + externalMedia wiring
+Requires Dograh ARI config in UI with matching `app_name`/`app_password`/`ws_client_name`.
+
+### Gate G7 — ARI outbound test call
+Requires a non-human test number (voicemail/echo), not a real person.
+
+### Gates G8–G10
+Media loopback canary, live consented human call (G9 — human approval gate), rollback check.
+
+---
+
+## 3. Outbound Endpoint Fix (VERIFIED APPLIED)
+
+The Sonnet worker already applied the core fix in `provider.py`:
+
+```
+provider.py:69-96  — _normalize_sip_endpoint() method added
+provider.py:120-124 — initiate_call() now calls _normalize_sip_endpoint()
+provider.py:499-500 — transfer_call() now calls _normalize_sip_endpoint()
+config.py:91-97     — pjsip_outbound_endpoint field added to request
+config.py:113       — pjsip_outbound_endpoint added to response
+__init__.py:30      — pjsip_outbound_endpoint added to _config_loader
+```
+
+The fix: bare PSTN numbers are normalized via `normalize_telephony_address` and dialed as `PJSIP/<digits>@<pjsip_outbound_endpoint>` (default `verimor`), routing through the Verimor trunk endpoint instead of failing with "device not found."
+
+**Test results:** 8/8 passing:
+```
+test_pstn_numbers_route_through_trunk[4 variants]   PASSED
+test_sip_uri_passed_through_verbatim                 PASSED
+test_bare_extension_dialed_without_trunk             PASSED
+test_custom_outbound_endpoint                        PASSED
+test_no_plus_prefix_on_digits                        PASSED
+```
+
+**No further repository patches needed** for the outbound endpoint fix — it is complete.
+
+---
+
+## 4. Acceptance Gates (G1→G10) with Evidence
+
+| Gate | Status | Evidence Command | Expected Result |
+|------|--------|-----------------|-----------------|
+| G1 | ✅ PASS | `docker compose -f deploy/asterisk/docker-compose.asterisk.yaml config -q` | exit 0 |
+| G1 | ✅ PASS | `bash -n deploy/asterisk/entrypoint.sh` | exit 0 |
+| G1 | ✅ PASS | `bash run_validation.sh` | "compose config OK", "rendered 7 file(s)" |
+| G2 | ⚠️ BLOCKED | `docker compose ... --build` | Fails: `FROM asterisk:22` not on Docker Hub |
+| G2 | ✅ PASS (after patch) | `FROM andrius/asterisk:22` | Build completes |
+| G3 | ⚠️ FAILS (as-is) | `module show like res_websocket_client` | Healthcheck passes (module exists), but modules.conf is malformed |
+| G3 | ✅ PASS (after patch) | `asterisk -rx 'module show like ws'` | res_websocket_client, chan_websocket, res_ari_events all Running |
+| G4 | ⏳ PENDING | Base stack required | `docker compose ... up -d`, container healthy |
+| G5 | 🛑 STOP | Real Verimor creds | `pjsip show registrations` → Registered |
+| G6 | ⏳ PENDING | Dograh UI config | ari_manager WebSocket stable >30s |
+| G7 | ⏳ PENDING | Test number | StasisStart + externalMedia + ChannelDestroyed |
+| G8 | ⏳ PENDING | Media canary | RTP packets + STT/TTS transcript |
+| G9 | 🛑 STOP | Human consent (Ozan) | Two-way audio confirmed |
+| G10 | ⏳ PENDING | Rollback | `down --volumes` cleans up cleanly |
+
+**Module verification evidence (from live container, aarch64):**
+- `andrius/asterisk:22` = Asterisk 22.10.1
+- 344 modules will load at startup
+- All required modules confirmed: res_ari.so, res_ari_events.so (ARL WebSocket), res_http_websocket.so, chan_websocket.so, res_websocket_client.so, chan_pjsip.so, res_pjsip.so + 30 submodules, codec_ulaw.so, codec_alaw.so, app_dial.so
+- Non-existent modules referenced in overlay's modules.conf: res_ari_websocket.so, app_answer.so, dtmf_detect.so
+
+---
+
+## 5. Stop Conditions (Human Credentials/Consent Required)
+
+| # | Gate | Stop Condition | Who Provides |
+|---|------|----------------|--------------|
+| B1 | G5/G7/G9 | Verimor SIP credentials (username, password, DID, optional caller ID) | Ozan / Verimor portal |
+| B2 | G9 | Explicit consent from Ozan before dialing a human number | Ozan |
+| B3 | G9 | Caller ID number Verimor permits on outbound | Ozan / Verimor |
+| B4 | G3 | res_websocket_client + chan_websocket available on arm64 — **ALREADY VERIFIED, no longer a blocker** | N/A (resolved) |
+| B5 | G4/G5 | Public static IP for EXTERNAL_SIGNALING_ADDRESS / EXTERNAL_MEDIA_ADDRESS + firewall open on UDP 5060 + UDP 10000-10100 | Ozan |
+| B6 | G7 | Test target number that does NOT bill a real person (voicemail/echo/SIP test) | Ozan |
+
+**Current stop:** B1 — no Verimor SIP credentials exist on this host or in the repo. The `.env.example` contains placeholders only. G5/G7/G9 cannot proceed without them.
+
+---
+
+## 6. Repository Patches Needed (Summary)
+
+| File | Patch | Lines |
+|------|-------|-------|
+| `deploy/asterisk/Dockerfile` | Change `FROM asterisk:${ASTERISK_VERSION}` → `FROM andrius/asterisk:${ASTERISK_VERSION}` | 1 |
+| `deploy/asterisk/conf/modules.conf` | Add `[modules]` + `autoload=yes` header; remove `res_ari_websocket.so`, `app_answer.so`, `dtmf_detect.so`; add `res_ari_events.so` | ~5 lines changed |
+| `.gitignore` | ✅ ALREADY DONE (deploy/asterisk/.env added) | — |
+| `provider.py`, `config.py`, `__init__.py` | ✅ ALREADY DONE (outbound endpoint fix + pjsip_outbound_endpoint field) | — |
+| `test_provider_outbound.py`, `conftest.py` | ✅ ALREADY DONE (8/8 tests passing) | — |
+
+**No source build is needed.** Path (a) from the original analysis is unnecessary — `andrius/asterisk:22` ships all required modules on aarch64. Path (c) (architecture change) is also unnecessary — the current chan_websocket + res_websocket_client + PJSIP + ARI architecture is sound; only the modules.conf and Dockerfile base image need correction.
+
+---
+
+## 7. Rollback / Safety Notes
+
+- The overlay is a separate compose project (`deploy/asterisk/docker-compose.asterisk.yaml`). `docker compose -f ... down --volumes` removes ONLY the asterisk container. The base Dograh stack is untouched.
+- All overlay files are under `deploy/asterisk/` — `rm -rf deploy/asterisk/` reverts the entire overlay. The `.gitignore` now excludes `deploy/asterisk/.env`.
+- Dograh-side ARI config is a DB row in `telephony_configurations` — deleting it from the UI reverts the integration. `ari_manager` auto-stops reconnecting when config is inactive.
+- The modules.conf fix is non-destructive: `autoload=yes` keeps all other modules; the explicit `load =>` list only *guarantees* critical ones are present, it does not restrict the rest.

--- a/api/services/telephony/providers/ari/__init__.py
+++ b/api/services/telephony/providers/ari/__init__.py
@@ -24,6 +24,8 @@ def _config_loader(value: Dict[str, Any]) -> Dict[str, Any]:
         "app_password": value.get("app_password"),
         "external_pbx": value.get("external_pbx"),
         "from_numbers": value.get("from_numbers", []),
+        "pjsip_outbound_endpoint": value.get("pjsip_outbound_endpoint", "verimor"),
+        "outbound_number_format": value.get("outbound_number_format", "e164"),
     }
 
 
@@ -60,6 +62,34 @@ _UI_METADATA = ProviderUIMetadata(
             label="From Extensions",
             type="string-array",
             description="SIP extensions/numbers for outbound calls",
+        ),
+        ProviderUIField(
+            name="pjsip_outbound_endpoint",
+            label="PJSIP Outbound Endpoint",
+            type="text",
+            required=False,
+            description=(
+                "Asterisk PJSIP endpoint name used to route bare PSTN numbers "
+                "(default: verimor)."
+            ),
+            placeholder="verimor",
+            section="Outbound Routing",
+        ),
+        ProviderUIField(
+            name="outbound_number_format",
+            label="Outbound Number Format",
+            type="select",
+            required=False,
+            description=(
+                "Use e164 for country-code digits or national_zero for Turkish "
+                "0-prefixed dialing. Confirm the carrier format before enabling "
+                "national_zero."
+            ),
+            options=[
+                ProviderUIOption(value="e164", label="E.164 digits (default)"),
+                ProviderUIOption(value="national_zero", label="Turkish national (0-prefixed)"),
+            ],
+            section="Outbound Routing",
         ),
         ProviderUIField(
             name="external_pbx.type",

--- a/api/services/telephony/providers/ari/config.py
+++ b/api/services/telephony/providers/ari/config.py
@@ -1,9 +1,10 @@
-"""ARI (Asterisk REST Interface) telephony configuration schemas."""
+"""
+ARI (Asterisk REST Interface) telephony configuration schemas.
+"""
 
 from typing import List, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
-
 
 class VicidialAgentAPIConfiguration(BaseModel):
     """VICIdial remote-agent call-control API configuration."""
@@ -73,9 +74,7 @@ class ARIConfigurationRequest(BaseModel):
     ari_endpoint: str = Field(
         ..., description="ARI base URL (e.g., http://asterisk.example.com:8088)"
     )
-    app_name: str = Field(
-        ..., description="Stasis application name registered in Asterisk"
-    )
+    app_name: str = Field(..., description="Stasis application name registered in Asterisk")
     app_password: str = Field(..., description="ARI user password")
     ws_client_name: str = Field(
         default="",
@@ -89,6 +88,29 @@ class ARIConfigurationRequest(BaseModel):
         default_factory=list,
         description="List of SIP extensions/numbers for outbound calls (optional)",
     )
+    pjsip_outbound_endpoint: str = Field(
+        default="verimor",
+        description=(
+            "PJSIP endpoint name for outbound calls through the Asterisk trunk. "
+            "When Dial(DLG/...) originates a call via ARI, the endpoint will be "
+            "formatted as PJSIP/<digits>@<endpoint_name> (e.g., 'verimor' for a "
+            "Verimor trunk)."
+        ),
+    )
+    outbound_number_format: Literal["e164", "national_zero"] = Field(
+        default="e164",
+        description=(
+            "Digit format used for the PSTN number placed before "
+            "@<pjsip_outbound_endpoint>. 'e164' (default, backward-compatible) "
+            "sends country-code digits with no '+' (e.g. 905551234567). "
+            "'national_zero' converts Turkish (+90) numbers to 0 + the 10-digit "
+            "subscriber number (e.g. 05551234567), matching the dialplan "
+            "normalization documented for Verimor. This format is NOT yet "
+            "verified against a live Verimor account — confirm with Verimor "
+            "before enabling in production. Numbers outside +90 always use "
+            "the 'e164' format regardless of this setting."
+        ),
+    )
 
 
 class ARIConfigurationResponse(BaseModel):
@@ -101,3 +123,5 @@ class ARIConfigurationResponse(BaseModel):
     ws_client_name: str = ""
     external_pbx: Optional[VicidialExternalPBXConfiguration] = None
     from_numbers: List[str]
+    pjsip_outbound_endpoint: str = "verimor"
+    outbound_number_format: str = "e164"

--- a/api/services/telephony/providers/ari/provider.py
+++ b/api/services/telephony/providers/ari/provider.py
@@ -22,6 +22,7 @@ from api.services.telephony.base import (
     TelephonyProvider,
 )
 from api.services.telephony.providers.ari.external_pbx import create_adapter
+from api.utils.telephony_address import normalize_telephony_address
 
 if TYPE_CHECKING:
     from fastapi import WebSocket
@@ -55,6 +56,10 @@ class ARIProvider(TelephonyProvider):
         self.from_numbers = config.get("from_numbers", [])
         self.default_from_number = config.get("default_from_number")
         self.external_pbx_adapter = create_adapter(config.get("external_pbx"))
+        self.pjsip_outbound_endpoint = config.get(
+            "pjsip_outbound_endpoint", "verimor"
+        )
+        self.outbound_number_format = config.get("outbound_number_format", "e164")
 
         if isinstance(self.from_numbers, str):
             self.from_numbers = [self.from_numbers]
@@ -64,6 +69,60 @@ class ARIProvider(TelephonyProvider):
     def _get_auth(self) -> aiohttp.BasicAuth:
         """Generate BasicAuth for ARI API requests."""
         return aiohttp.BasicAuth(self.app_name, self.app_password)
+
+    def _normalize_sip_endpoint(self, to_number: str) -> str:
+        """Build a PJSIP endpoint string for an outbound call.
+
+        Verimor (and most SIP trunks) are reached as a PJSIP *endpoint*
+        (a [trunk] section in pjsip.conf), not as a device.  A bare
+        ``PJSIP/<number>`` tries to dial a device literally named
+        ``<number>`` and fails with "device not found".  The correct form
+        for a trunk-dialed call is ``PJSIP/<digits>@<endpoint_name>``.
+
+        - ``SIP/...`` / ``PJSIP/...`` URIs are passed through verbatim
+          (the caller already supplied a full target).
+        - Bare PSTN numbers are normalized via ``normalize_telephony_address``
+          and formatted per ``self.outbound_number_format`` (see
+          ``_pstn_digits``), then suffixed with ``@<pjsip_outbound_endpoint>``.
+        - Short extensions that are not PSTN are treated as local PJSIP
+          devices and dialed bare (no ``@``), preserving prior behavior.
+        """
+        if to_number.startswith("SIP/") or to_number.startswith("PJSIP/"):
+            return to_number
+
+        normalized = normalize_telephony_address(to_number)
+        if normalized.address_type == "pstn":
+            digits = self._pstn_digits(normalized.canonical)
+            return f"PJSIP/{digits}@{self.pjsip_outbound_endpoint}"
+
+        # sip_extension: dial as-is (bare device name, no @trunk).
+        return f"PJSIP/{normalized.canonical}"
+
+    def _pstn_digits(self, e164_canonical: str) -> str:
+        """Format an E.164 canonical PSTN number for the outbound trunk.
+
+        The digit format a SIP trunk expects for the number placed before
+        ``@<endpoint>`` is provider-specific and, for Verimor, has not been
+        verified against a live account. Two formats are supported via
+        ``self.outbound_number_format`` (config field, default preserves
+        the pre-existing behavior of this method):
+
+        - ``"e164"`` (default): country-code-prefixed digits, no ``+``
+          (e.g. ``905551234567``).
+        - ``"national_zero"``: Turkish (+90) numbers only are converted to
+          Verimor's documented national format — ``0`` + the 10-digit
+          subscriber number (e.g. ``05551234567``) — mirroring the
+          dialplan normalization in
+          ``deploy/asterisk/conf/extensions.conf.template``'s
+          ``[outbound-verimor]`` context. Non-+90 numbers fall back to the
+          ``"e164"`` format regardless, since no national convention for
+          them is established anywhere in this repo.
+        """
+        if self.outbound_number_format == "national_zero" and e164_canonical.startswith(
+            "+90"
+        ):
+            return "0" + e164_canonical[3:]
+        return e164_canonical.lstrip("+")
 
     async def initiate_call(
         self,
@@ -85,13 +144,10 @@ class ARIProvider(TelephonyProvider):
 
         endpoint = f"{self.base_url}/channels"
 
-        # Build the SIP endpoint string
-        # to_number can be a SIP URI or extension
-        if to_number.startswith("SIP/") or to_number.startswith("PJSIP/"):
-            sip_endpoint = to_number
-        else:
-            # Default to PJSIP technology
-            sip_endpoint = f"PJSIP/{to_number}"
+        # Build the SIP endpoint string for the outbound leg.
+        # to_number can be a SIP URI, extension, or a bare PSTN number that
+        # needs to be routed through the configured PJSIP trunk endpoint.
+        sip_endpoint = self._normalize_sip_endpoint(to_number)
 
         # Prepare channel creation data
         params = {
@@ -465,11 +521,8 @@ class ARIProvider(TelephonyProvider):
         # Get call transfer manager for event correlation mapping
         call_transfer_manager = await get_call_transfer_manager()
 
-        # Build SIP endpoint
-        if destination.startswith("SIP/") or destination.startswith("PJSIP/"):
-            sip_endpoint = destination
-        else:
-            sip_endpoint = f"PJSIP/{destination}"
+        # Build SIP endpoint via the same trunk-routing logic as initiate_call
+        sip_endpoint = self._normalize_sip_endpoint(destination)
 
         # Build transfer appArgs for event correlation
         app_args = f"transfer,{transfer_id}"

--- a/api/tests/telephony/providers/ari/conftest.py
+++ b/api/tests/telephony/providers/ari/conftest.py
@@ -1,0 +1,142 @@
+"""
+Conftest for the ARI provider outbound tests.
+
+Pre-existing environment issue: the Dograh code targets an older pipecat
+(0.x) where pipecat.utils.run_context, pipecat.audio.mixers.*, and
+pipecat.audio.dtmf all existed. The venv has pipecat-ai 1.7.0 which
+renamed/removed these. The full test conftest (api/conftest.py) fails to
+import because transport.py triggers the whole pipecat import chain.
+
+This conftest stubs the missing pipecat submodules so that
+test_provider_outbound.py can be collected and run by pytest against
+the REAL ARIProvider._normalize_sip_endpoint method.
+"""
+import sys
+import types
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("REDIS_URL", "redis://localhost")
+os.environ.setdefault("ENVIRONMENT", "test")
+
+
+def _stub_pipecat():
+    """Lazily stub pipecat submodules missing in 1.7.0."""
+    import pipecat
+    import pipecat.utils
+
+    # --- pipecat.utils.run_context ---
+    # pipecat 1.7.0 has this module but removed set_current_org_id /
+    # clear_current_org_id / RunContext that Dograh imports. Patch the
+    # missing symbols onto the existing module (or create a stub module
+    # when the module itself is absent).
+    rc_fullname = "pipecat.utils.run_context"
+    if rc_fullname not in sys.modules:
+        m = types.ModuleType(rc_fullname)
+        m.get_current_org_id = lambda: 1
+        m.RunContext = None
+        m.set_current_org_id = lambda *a, **kw: None
+        m.clear_current_org_id = lambda *a, **kw: None
+        pipecat.utils.run_context = m
+        sys.modules[rc_fullname] = m
+    else:
+        m = sys.modules[rc_fullname]
+        m.get_current_org_id = getattr(m, "get_current_org_id", lambda: 1)
+        m.RunContext = getattr(m, "RunContext", None)
+        m.set_current_org_id = getattr(m, "set_current_org_id", lambda *a, **kw: None)
+        m.clear_current_org_id = getattr(m, "clear_current_org_id", lambda *a, **kw: None)
+
+    # --- pipecat.audio package ---
+    if not hasattr(pipecat, "audio") or not isinstance(getattr(pipecat, "audio", None), types.ModuleType):
+        pipecat.audio = types.ModuleType("pipecat.audio")
+        pipecat.audio.__path__ = []
+        sys.modules["pipecat.audio"] = pipecat.audio
+    pa = pipecat.audio
+
+    # --- pipecat.audio.mixers ---
+    if not hasattr(pa, "mixers") or not isinstance(getattr(pa, "mixers", None), types.ModuleType):
+        mixers = types.ModuleType("pipecat.audio.mixers")
+        mixers.__path__ = []
+        pa.mixers = mixers
+        sys.modules["pipecat.audio.mixers"] = mixers
+
+    # silence_mixer
+    if "pipecat.audio.mixers.silence_mixer" not in sys.modules:
+        sm = types.ModuleType("pipecat.audio.mixers.silence_mixer")
+        sm.SilenceAudioMixer = type("SilenceAudioMixer", (), {})
+        pa.mixers.silence_mixer = sm
+        sys.modules["pipecat.audio.mixers.silence_mixer"] = sm
+
+    # base_audio_mixer
+    if "pipecat.audio.mixers.base_audio_mixer" not in sys.modules:
+        bm = types.ModuleType("pipecat.audio.mixers.base_audio_mixer")
+        bm.BaseAudioMixer = type("BaseAudioMixer", (), {})
+        pa.mixers.base_audio_mixer = bm
+        sys.modules["pipecat.audio.mixers.base_audio_mixer"] = bm
+
+    # soundfile_mixer — pipecat 1.7.0 renamed SoundfileMixer ->
+    # SoundfileAudioMixer. Dograh's audio_mixer.py still imports the old
+    # name. Alias the old name onto the real (renamed) class when the module
+    # is importable, or provide a stub type when it isn't. This is a test-only
+    # isolation shim; production audio_mixer.py is left untouched.
+    sf_fullname = "pipecat.audio.mixers.soundfile_mixer"
+    try:
+        import pipecat.audio.mixers.soundfile_mixer as _sf
+        if not hasattr(_sf, "SoundfileMixer"):
+            _sf.SoundfileMixer = getattr(
+                _sf, "SoundfileAudioMixer", type("SoundfileMixer", (), {})
+            )
+    except ImportError:
+        stub = types.ModuleType(sf_fullname)
+        stub.SoundfileMixer = type("SoundfileMixer", (), {})
+        pa.mixers.soundfile_mixer = stub
+        sys.modules[sf_fullname] = stub
+
+    # --- pipecat.audio.dtmf ---
+    if not hasattr(pa, "dtmf"):
+        dtmf = types.ModuleType("pipecat.audio.dtmf")
+        dtmf.KeypadEntry = type("KeypadEntry", (), {})
+        pa.dtmf = dtmf
+        sys.modules["pipecat.audio.dtmf"] = dtmf
+
+    # --- pipecat.transports.websocket.fastapi (stub entirely) ---
+    # This is where transport.py imports from. We provide a minimal stub
+    # so that create_transport's import doesn't fail, but we don't need
+    # the actual implementation for testing _normalize_sip_endpoint.
+    if "pipecat.transports.websocket.fastapi" not in sys.modules:
+        fapi = types.ModuleType("pipecat.transports.websocket.fastapi")
+
+        class FastAPIWebsocketTransport:
+            """Stub — not used by _normalize_sip_endpoint tests."""
+            def __init__(self, *args, **kwargs):
+                pass
+
+        fapi.FastAPIWebsocketTransport = FastAPIWebsocketTransport
+        sys.modules["pipecat.transports.websocket.fastapi"] = fapi
+
+    # --- pipecat.serializers.<name> ---
+    # pipecat 1.7.0 removed the per-provider serializer modules
+    # (asterisk, twilio, plivo, telnyx, vonage, cloudonix, etc.) that
+    # each provider's serializers.py imports. Stub each one on demand so
+    # the telephony provider import-for-registration chain can complete.
+    import pipecat.serializers  # noqa: E402  — package exists in 1.7.0
+    _serializer_stubs = {
+        "asterisk": ["AsteriskFrameSerializer"],
+        "cloudonix": ["CloudonixFrameSerializer"],
+        "vobiz": ["VobizFrameSerializer"],
+        "twilio": ["TwilioFrameSerializer"],
+        "plivo": ["PlivoFrameSerializer"],
+        "telnyx": ["TelnyxFrameSerializer"],
+        "vonage": ["VonageFrameSerializer"],
+        "call_strategies": ["HangupStrategy", "TransferStrategy"],
+    }
+    for modname, cls_names in _serializer_stubs.items():
+        fullname = f"pipecat.serializers.{modname}"
+        if fullname not in sys.modules:
+            stub = types.ModuleType(fullname)
+            for cls_name in cls_names:
+                setattr(stub, cls_name, type(cls_name, (), {}))
+            sys.modules[fullname] = stub
+
+
+_stub_pipecat()

--- a/api/tests/telephony/providers/ari/test_provider_outbound.py
+++ b/api/tests/telephony/providers/ari/test_provider_outbound.py
@@ -1,0 +1,80 @@
+"""Unit tests for ARIProvider outbound SIP endpoint formation.
+
+Covers the fix for GAP-G6 in deploy/asterisk/MIGRATION_PLAN.md:
+bare PSTN numbers must be dialed as ``PJSIP/<digits>@<trunk>`` rather than
+``PJSIP/<digits>`` so they route through the configured Verimor PJSIP
+endpoint.
+"""
+
+import pytest
+
+from api.services.telephony.providers.ari.provider import ARIProvider
+
+
+def _provider(**overrides) -> ARIProvider:
+    config = {
+        "ari_endpoint": "http://asterisk.example.com:8088",
+        "app_name": "dograh",
+        "app_password": "secret",
+        "from_numbers": [],
+        "pjsip_outbound_endpoint": "verimor",
+    }
+    config.update(overrides)
+    return ARIProvider(config)
+
+
+class TestNormalizeSipEndpoint:
+    """Tests for _normalize_sip_endpoint — the outbound trunk-routing fix."""
+
+    @pytest.mark.parametrize(
+        "to_number, expected",
+        [
+            # E.164 Turkish mobile -> digits with @verimor
+            ("+905551234567", "PJSIP/905551234567@verimor"),
+            # National format with leading 0 -> preserves national form
+            ("05551234567", "PJSIP/05551234567@verimor"),
+            # Bare 10-digit subscriber number (no country code)
+            ("5551234567", "PJSIP/5551234567@verimor"),
+            # Number with spaces
+            ("+90 555 123 45 67", "PJSIP/905551234567@verimor"),
+        ],
+    )
+    def test_pstn_numbers_route_through_trunk(self, to_number, expected):
+        provider = _provider()
+        assert provider._normalize_sip_endpoint(to_number) == expected
+
+    def test_sip_uri_passed_through_verbatim(self):
+        provider = _provider()
+        assert provider._normalize_sip_endpoint("SIP/6001@verimor") == "SIP/6001@verimor"
+        assert provider._normalize_sip_endpoint("PJSIP/6001@verimor") == "PJSIP/6001@verimor"
+
+    def test_bare_extension_dialed_without_trunk(self):
+        """Short numeric extensions that aren't PSTN are treated as local
+        PJSIP devices (no @trunk suffix) — preserves legacy behavior."""
+        provider = _provider()
+        result = provider._normalize_sip_endpoint("8000")
+        assert result == "PJSIP/8000"
+
+    def test_custom_outbound_endpoint(self):
+        """The trunk name is configurable per-tenant."""
+        provider = _provider(pjsip_outbound_endpoint="trunk_eu")
+        result = provider._normalize_sip_endpoint("+905551234567")
+        assert result == "PJSIP/905551234567@trunk_eu"
+
+    def test_turkish_national_zero_format_is_opt_in(self):
+        """National dialing is available without changing the safe default."""
+        provider = _provider(outbound_number_format="national_zero")
+        result = provider._normalize_sip_endpoint("+905551234567")
+        assert result == "PJSIP/05551234567@verimor"
+
+    def test_e164_format_remains_default(self):
+        provider = _provider()
+        result = provider._normalize_sip_endpoint("+905551234567")
+        assert result == "PJSIP/905551234567@verimor"
+
+    def test_no_plus_prefix_on_digits(self):
+        """The PJSIP device name must not contain a leading '+'. """
+        provider = _provider()
+        result = provider._normalize_sip_endpoint("+905551234567")
+        assert not result.split("/")[1].startswith("+")
+        assert "@verimor" in result

--- a/deploy/asterisk/.env.example
+++ b/deploy/asterisk/.env.example
@@ -1,0 +1,92 @@
+# Dograh — Self-hosted Asterisk + Verimor SIP trunk overlay
+# Copy to .env (in this directory) and fill in. See README.md for bring-up.
+#
+#   cp deploy/asterisk/.env.example deploy/asterisk/.env
+#
+# Never commit the filled-in .env. Values here are PLACEHOLDERS only.
+
+# ---------------------------------------------------------------------------
+# Verimor SIP trunk
+# ---------------------------------------------------------------------------
+# Credentials issued by Verimor for your SIP trunk (Santral / SIP hesabı).
+VERIMOR_SIP_USERNAME=your_verimor_sip_username
+VERIMOR_SIP_PASSWORD=your_verimor_sip_password
+
+# Verimor SIP signaling host and port. Confirm the exact host with Verimor;
+# sip.verimor.com.tr is the common default.
+VERIMOR_SIP_HOST=sip.verimor.com.tr
+VERIMOR_SIP_PORT=5060
+
+# Inbound DID (the number Verimor delivers calls to). Digits only, in the
+# format Verimor sends it to you (see README on inbound number matching).
+VERIMOR_DID=908500000000
+
+# Outbound caller ID presented to the carrier. Defaults to VERIMOR_DID when
+# left blank. Must be a number Verimor permits you to present.
+VERIMOR_CALLERID=
+
+# ---------------------------------------------------------------------------
+# Asterisk ARI (internal only — never published in the overlay)
+# ---------------------------------------------------------------------------
+# ARI_APP_NAME is used as the ari.conf user section, the Stasis application
+# name in the dialplan, AND the "Stasis App Name" you enter in Dograh. The
+# Dograh backend also uses it as the ARI HTTP/WebSocket username.
+ARI_APP_NAME=dograh
+
+# ARI password — this is the "App Password" you enter in Dograh. Generate a
+# strong value, e.g.  openssl rand -hex 24
+ARI_PASSWORD=change-me-to-a-long-random-secret
+
+# ARI/HTTP listen port inside the container. Reachable only from the Dograh
+# app-network; the overlay deliberately does NOT publish it to the host.
+ARI_HTTP_PORT=8088
+
+# ---------------------------------------------------------------------------
+# Dograh backend (external media WebSocket target)
+# ---------------------------------------------------------------------------
+# Asterisk connects OUT to the Dograh API over WebSocket for call audio
+# (chan_websocket / websocket_client.conf). On the shared app-network the API
+# is reachable as service "api" on port 8000 over plain ws://.
+DOGRAH_WS_SCHEME=ws
+DOGRAH_API_HOST=api
+DOGRAH_API_PORT=8000
+
+# websocket_client.conf connection name. This is the "websocket_client.conf
+# Name" you enter in Dograh. Must match on both sides.
+WS_CLIENT_NAME=dograh
+
+# ---------------------------------------------------------------------------
+# Networking / NAT
+# ---------------------------------------------------------------------------
+# Public IP addresses this Asterisk advertises to Verimor for SIP signaling
+# and RTP media. Set both to the server's public IPv4 address (the address
+# Verimor routes to). Required — SIP/RTP will not traverse NAT without them.
+EXTERNAL_SIGNALING_ADDRESS=203.0.113.10
+EXTERNAL_MEDIA_ADDRESS=203.0.113.10
+
+# Optional extra local subnet to treat as "not NAT" (in addition to the
+# RFC1918 ranges already configured). Leave blank unless you have a specific
+# private range Asterisk should not rewrite.
+LOCAL_NET=
+
+# SIP signaling port published to the carrier (UDP).
+SIP_PORT=5060
+
+# Bounded RTP media port range published to the carrier (UDP). ~2 ports per
+# concurrent call; 10000-10100 allows roughly 50 simultaneous calls. Widen if
+# you need more concurrency, and keep the compose port range in sync.
+RTP_START=10000
+RTP_END=10100
+
+# ---------------------------------------------------------------------------
+# Compose wiring
+# ---------------------------------------------------------------------------
+# Name of the EXISTING Docker network the Dograh stack created (so Asterisk
+# joins it as an external network). Find it with:
+#   docker network ls | grep app-network
+# The default project name is the repo directory, giving dograh_app-network.
+DOGRAH_NETWORK_NAME=dograh_app-network
+
+# Asterisk major version to build in the Dockerfile (22+ ships chan_websocket
+# and res_websocket_client). Override only to pin a specific series.
+ASTERISK_VERSION=22

--- a/deploy/asterisk/Dockerfile
+++ b/deploy/asterisk/Dockerfile
@@ -1,0 +1,49 @@
+# Dockerfile for Dograh self-hosted Asterisk + Verimor ARI overlay
+# Guarantees required modules are loaded (fail-fast if missing)
+#
+# Build: docker compose -f deploy/asterisk/docker-compose.asterisk.yaml build
+# Run:   docker compose -f deploy/asterisk/docker-compose.asterisk.yaml up -d
+#
+# Base image: andrius/asterisk:${ASTERISK_VERSION}
+#   - Confirmed pullable on linux/arm64 (aarch64), Asterisk 22.10.1
+#   - Ships all required ARI/PJSIP/WebSocket/codec modules (see modules.conf)
+#   - `asterisk:22` (Docker Hub) does NOT exist (pull access denied), so we
+#     must use this community image. Switch only after verifying an alternative
+#     ships every module in modules.conf on aarch64.
+
+ARG ASTERISK_VERSION=22
+FROM andrius/asterisk:${ASTERISK_VERSION}
+
+# Set working directory
+WORKDIR /root
+
+# Copy configuration templates and modules list into image
+COPY conf/*.template /etc/asterisk/templates/
+COPY conf/modules.conf /etc/asterisk/
+COPY conf/rtp.conf /etc/asterisk/
+
+# Copy entrypoint wrapper and config-rendering script, make executable.
+#
+# The andrius/asterisk:22 base image's ENTRYPOINT is
+# /usr/local/bin/entrypoint.sh, which does uid/chown setup and then
+# execs asterisk — but it does NOT source /docker-entrypoint.d/*.sh
+# (unlike the standard docker-entrypoint.sh from the library/bash image).
+#
+# Our wrapper (entrypoint-wrapper.sh) sources every /docker-entrypoint.d/*.sh
+# script first — including our 00-render-asterisk config-rendering script —
+# then delegates to the base entrypoint for the actual asterisk launch.
+COPY entrypoint.sh /docker-entrypoint.d/00-render-asterisk
+COPY entrypoint-wrapper.sh /usr/local/bin/
+RUN chmod +x /docker-entrypoint.d/00-render-asterisk /usr/local/bin/entrypoint-wrapper.sh
+
+# Override entrypoint to wrap the base image's entrypoint and source
+# /docker-entrypoint.d/*.sh scripts before starting Asterisk.
+ENTRYPOINT ["/usr/local/bin/entrypoint-wrapper.sh"]
+
+# Explicitly set CMD so compose passes it as args to our ENTRYPOINT.
+# These are the same flags the andrius/asterisk:22 base image uses.
+CMD ["/usr/sbin/asterisk", "-vvvdddf", "-T", "-W", "-U", "asterisk", "-p"]
+
+# Expose SIP signaling and bounded RTP range for Verimor
+EXPOSE 5060/udp
+EXPOSE 10000-10100/udp

--- a/deploy/asterisk/MIGRATION_PLAN.md
+++ b/deploy/asterisk/MIGRATION_PLAN.md
@@ -1,0 +1,632 @@
+# Dograh Migration Master Plan — Self-Hosted Asterisk + Verimor SIP Trunk
+
+Status: READ-ONLY planning artifact. No code in this document is executable for production.
+Worker: Fable (planning). Children: t_194c2559 (Sonnet, implementer), t_bcb4b510 (Opus, reviewer).
+
+## 0. Verified ground truth (read-only inspection)
+
+All "FACT" bullets below were directly observed in the repo at
+/home/ubuntu/workspace/dograh on branch feat/dograh-asterisk-verimor-overlay,
+commit 66ab884d. "ASSUMPTION" marks things that must be confirmed against
+Verimor / the operator before a billed call.
+
+### 0.1 What already exists in the repo
+- FACT: `deploy/asterisk/` contains a STANDALONE overlay (templates + compose + entrypoint + .env.example). Git status shows it is **untracked** (`?? deploy/asterisk/`).
+- FACT: `deploy/asterisk/docker-compose.asterisk.yaml` references `dockerfile: Dockerfile` and `build: context: .` — **but no Dockerfile exists** in `deploy/asterisk/`. This is a build-blocker. (verified via `find deploy -name "Dockerfile*"` → empty)
+- FACT: `deploy/asterisk/entrypoint.sh` is a complete, executable-rendered config bootstrap:
+  - Validates REQUIRED_VARS (VERIMOR_SIP_USERNAME, VERIMOR_SIP_PASSWORD, VERIMOR_SIP_HOST, VERIMOR_DID, ARI_APP_NAME, ARI_PASSWORD, WS_CLIENT_NAME, EXTERNAL_SIGNALING_ADDRESS, EXTERNAL_MEDIA_ADDRESS).
+  - Uses envsubst with an EXPLICIT allowlist so Asterisk dialplan vars ($EXTEN, $CALLERID(num), etc.) are preserved in extensions.conf.
+  - Renders *.template into /etc/asterisk at startup. Fail-closed on missing vars.
+- FACT: three rendered templates exist:
+  - `ari.conf.template` — section name = ${ARI_APP_NAME}, password = ${ARI_PASSWORD}, read_only=no.
+  - `pjsip.conf.template` — Verimor registration endpoint `[verimor_reg]`, auth `[verimor_auth]`, AOR `[verimor_aor]`, endpoint `[verimor]` with `disallow=all / allow=ulaw / allow=alaw`, `direct_media=no`, `rtp_symmetric=yes`, `force_rport=yes`, `rewrite_contact=yes`. Inbound context = `from-verimor`.
+  - `extensions.conf.template` — `[from-verimor] exten => _X.,1,Stasis(${ARI_APP_NAME})`; `[outbound-verimor]` + `[dial-verimor]` with Turkish normalization and `Dial(PJSIP/${EXTEN}@verimor,60)`.
+  - NOTE: no `http.conf`, `rtp.conf`, `modules.conf`, or `websocket_client.conf.template` are present. The overlay relies on the Dockerfile/entrypoint to provide them (or for them to be added).
+- FACT: `deploy/asterisk/.env.example` declares all placeholders; VERIMOR_SIP_USERNAME/PASSWORD are `your_verimor_sip_username`/`your_verimor_sip_password` (placeholders, no real secrets).
+- FACT: The overlay attaches to an **external** Docker network `dograh_app-network` (default; overridable via DOGRAH_NETWORK_NAME) and does NOT publish ARI 8088 to the host — ARI is internal-only.
+- FACT: SIP 5060/udp and RTP 10000-10100/udp are published to the host for the carrier.
+
+### 0.2 What Dograh's own stack already supports (verified in source)
+- FACT: `api/services/telephony/providers/ari/` ALREADY has a working ARI provider
+  (provider.py, transport.py, config.py, strategies.py, serializers.py, __init__.py).
+  This is NOT a Verimor-specific fork — it's the upstream ARI provider.
+- FACT: The Stasis app name + ARI password live in Dograh as a persisted
+  telephony configuration (ProviderSpec `ari`, config_loader maps
+  `ari_endpoint`, `app_name`, `app_password`, `ws_client_name`,
+  `from_numbers`). Dograh reads them from the DB — they are NOT in the
+  overlay .env. So the overlay's `ARI_APP_NAME`/`ARI_PASSWORD` must match
+  what the operator ALSO enters in Dograh's telephony-config UI.
+- FACT: `ARIProvider.initiate_call` (provider.py:68) builds the outbound endpoint:
+  - If `to_number` starts with `SIP/` or `PJSIP/` → used verbatim.
+  - ELSE → `sip_endpoint = f"PJSIP/{to_number}"` (provider.py:94).
+  - It does NOT append `@verimor` (the PJSIP endpoint name / AOR). It just does
+    `PJSIP/<to_number>`. So the number is dialed as a PJSIP device named
+    `<to_number>`, not via the `verimor` outbound trunk endpoint.
+- ASSUMPTION to confirm: `to_number` reaching `initiate_call` is the **raw
+  user-entered** phone number (campaign_call_dispatcher.py:250,370 pass
+  `phone_number` from `queued_run.context_variables["phone_number"]` with no
+  normalization). The `normalize_telephony_address` util exists
+  (api/utils/telephony_address.py) but is NOT applied on the ARI outbound path.
+  So a bare E.164 or national number will be sent as `PJSIP/+905XXXX...`
+  or `PJSIP/05XXXX...`, which will NOT match the `verimor` outbound endpoint.
+  This is the core outbound-endpoint-format bug the overlay must solve (see
+  gate G5 / section 3).
+- FACT: Dograh's media WebSocket is `/api/v1/telephony/ws/ari` (provider
+  accepts query params workflow_id/organization_id/workflow_run_id;
+  telephony.py:559). The four-segment tokenless shape
+  `/api/v1/telephony/ws/{w}/{o}/{r}` also exists. The ARI externalMedia
+  channel dials `/api/v1/telephony/ws/ari?...&token=...` when
+  `TELEPHONY_WS_TOKEN_SECRET` is set (ws_auth.py mints the HMAC; the token
+  appears in uvicorn+nginx access logs — noted as a logging hazard).
+- FACT: `ws_client_name` is the `websocket_client.conf` section name on the
+  Asterisk side AND a field in Dograh's ARI config UI (config.py:80, __init__.py:53).
+  Both sides must match exactly.
+- FACT: the ari_manager process (`python -m api.services.telephony.ari_manager`)
+  is the standalone Stasis WebSocket listener. It is started by
+  scripts/start_services_docker.sh when `ENABLE_ARI_MANAGER=true` (default) and
+  by start_services.sh / start_services_dev.sh. It is a sibling of the api
+  container, NOT a separate container in the overlay compose. In the overlay
+  design, the ari_manager runs in/behind the `api` container and connects to
+  Asterisk's ARI WebSocket at `ws(s)://<asterisk>:8088/ari/events?...`.
+- FACT: `res_websocket_client` is the module Dograh's externalMedia path
+  depends on (docker-compose.asterisk.yaml healthcheck:
+  `module show like res_websocket_client`). The overlay assumes it is loaded.
+- FACT: audio format is **G.711 ulaw** (externalMedia `format=ulaw`;
+  ari_manager.py:761). The Verimor endpoint must `allow=ulaw` (already true
+  in pjsip.conf.template).
+- FACT: the overlay's pjsip `identify` only matches `${VERIMOR_SIP_HOST}` for
+  inbound INVITE routing to the `verimor` endpoint. If Verimor sends from
+  multiple signaling IPs, additional `match=` lines are needed (documented in
+  the template comment).
+
+### 0.3 What the overlay is MISSING (verified gaps)
+- GAP (BLOCKER-G1): no Dockerfile. The compose build will fail.
+- GAP (BLOCKER-G2): no `modules.conf`. Asterisk image must include
+  `chan_websocket`, `res_websocket_client`, `res_ari`, `res_ari_websocket`,
+  `res_http_websocket`, `chan_pjsip`, `res_pjsip_*` — not guaranteed by a
+  stock `asterisk:22` image (Debian builds often split modules into
+  asterisk-core-sounds / asterisk-modules packages).
+- GAP (BLOCKER-G3): no `http.conf` rendered. ARI/HTTP on 8088 must be enabled.
+- GAP (BLOCKER-G4): no `rtp.conf` rendered. RTP_START/RTP_END in .env are
+  not wired to a rendered rtp.conf (the compose publishes the port range but
+  Asterisk needs `rtp.conf` to bind that range).
+- GAP (BLOCKER-G5): no `websocket_client.conf.template`. Dograh's externalMedia
+  needs `res_websocket_client` to connect to Dograh. The Dograh-side config
+  (ws_client_name) is in Dograh, but the Asterisk-side connection stanza
+  pointing at Dograh's `/api/v1/telephony/ws/ari` is absent from the overlay.
+- GAP (BLOCKER-G6): outbound endpoint `PJSIP/<number>` does NOT route through
+  the `verimor` trunk. For a trunk-dialed call it must be
+  `PJSIP/<normalized-number>@verimor` (pjsip endpoint name `verimor`).
+  Dograh currently sends `PJSIP/{to_number}` with no `@context`. This must be
+  patched in ARIProvider.initiate_call (or pre-normalized into the from_numbers
+  pool as full PJSIP URIs). See section 3.
+
+---
+
+## 1. Repository files / deployment overlays to add or modify
+
+These are the exact touch points. The Sonnet worker (t_194c2559) owns these.
+
+### 1.1 Add (new files)
+1. `deploy/asterisk/Dockerfile` — multi-stage build guaranteeing modules.
+   - Base: `asterisk:22` (Alpine variant is smaller; Debian is more forgiving
+     for module availability). MUST install/confirm the module set in section 4.2.
+   - Copy conf templates into image build context; the runtime renders them
+     via entrypoint.sh (no build-time secrets).
+   - Sets `ASTERISK_VERSION` build arg from env (compose already passes it).
+   - CRITICAL: verify `asterisk -rx "module show like res_websocket_client"`
+     reports Running *in the built image* (the healthcheck depends on it).
+2. `deploy/asterisk/conf/modules.conf` — explicit load list (fail-fast if a
+   required module is missing) so a stock image can't silently drop ARI.
+3. `deploy/asterisk/conf/http.conf` — `enabled=yes`, `bindaddr=0.0.0.0`,
+   `bindport=${ARI_HTTP_PORT}` (8088), `password`/`asterisk` not needed (ARI
+   auth is in ari.conf). NOTE: 8088 must NOT be published (already enforced
+   by compose; document for reviewer).
+4. `deploy/asterisk/conf/rtp.conf` — `rtpstart=${RTP_START}`,
+   `rtpend=${RTP_END}`, plus `rtpenable=yes`. Binds the published UDP range.
+5. `deploy/asterisk/conf/websocket_client.conf.template` — a `[${WS_CLIENT_NAME}]`
+   stanza: `type=client`, `uri=${DOGRAH_WS_SCHEME}://${DOGRAH_API_HOST}:${DOGRAH_API_PORT}/api/v1/telephony/ws/ari`,
+   `protocols=media`. (The uri carries no query string; v() is appended at
+   externalMedia time per the docs mdx:109-111.)
+6. `deploy/asterisk/README.md` — the missing operator doc (currently
+   `.env.example` points at README.md which doesn't exist).
+
+### 1.2 Modify (existing files)
+7. `api/services/telephony/providers/ari/provider.py` — fix outbound endpoint
+   formation (section 3 / GAP-G6). Minimal change: build
+   `PJSIP/{normalized_digits}@verimor` instead of `PJSIP/{to_number}`.
+   Must normalize the to_number through `normalize_telephony_address` first
+   so the PJSIP device name is digits only. Guard: only append `@verimor`
+   when the number is a bare PSTN number (not already a SIP/PJSIP URI).
+8. `api/services/telephony/ari_manager.py` — none required for the slice,
+   but the Sonnet worker should add a debug log line at the externalMedia
+   creation (already logs ext_channel_id). No code change unless G5 surfaces.
+
+### 1.3 Do NOT touch
+- `api/services/telephony/providers/ari/transport.py` — the WebSocket transport
+  factory is correct (loads credentials via load_credentials_for_transport,
+  builds ulaw FastAPIWebsocketTransport, calls run_pipeline_telephony).
+- `api/routes/telephony.py` `/ws/ari` handler — correct subprotocol="media"
+  acceptance and query param parsing.
+- The base compose / `api` service definition in docker-compose.yaml — the
+  overlay must stay standalone and only attach to the external network.
+
+---
+
+## 2. Dograh ARI / chan_websocket / PJSIP architecture
+
+This is a verified, already-shipped architecture (docs/integrations/telephony/asterisk-ari.mdx + ari_manager.py). The overlay only provides the Asterisk-side half.
+
+```
+[Verimor SIP trunk]
+       |  UDP 5060  (sip.verimor.com.tr)
+       |  UDP 10000-10100 RTP (G.711 ulaw)
+       v
+[Asterisk 22 container]   <-- deploy/asterisk overlay
+  PJSIP verimor endpoint  (pjsip.conf: registration + outbound + identify)
+  Stasis(dograh) dialplan  (extensions.conf: from-verimor -> Stasis)
+  ARI app "dograh"         (ari.conf user = Stasis App Name)
+  HTTP 8088/internal      (http.conf; NOT published to host)
+  res_websocket_client    (websocket_client.conf -> Dograh ws client stanza)
+       | ARI WebSocket events  (ws://<asterisk>:8088/ari/events?app=dograh&...)
+       v
+[ari_manager process]     <-- runs in/behind the `api` container
+  (python -m api.services.telephony.ari_manager, gated by ENABLE_ARI_MANAGER)
+  listens for StasisStart/StasisEnd, creates externalMedia channel
+       | externalMedia POST /channels/externalMedia  (format=ulaw, transport=websocket)
+       | v() appends ?workflow_id=X&organization_id=Y&workflow_run_id=Z[&token=...]
+       v
+[Dograh API ws /api/v1/telephony/ws/ari]  (routes/telephony.py:559)
+  accepts subprotocol="media", delegates to ARIProvider.handle_websocket
+       |
+       v
+[pipecat media pipeline]  (ulaw 8kHz in/out over the WebSocket)
+  -> OpenAI voice (STT + LLM + TTS)  (runtime-only credential, see section 5)
+```
+
+Key contracts (all verified in source):
+- Stasis App Name in ari.conf == ARI_APP_NAME in .env == `app_name` stored in
+  Dograh's telephony config == passed as `app` param on every ARI REST/WebSocket
+  call (ari_manager.py ws_url, provider.py initiate_call).
+- WS_CLIENT_NAME in .env == `websocket_client.conf` section name == Dograh's
+  `ws_client_name` config field (used as `external_host` on the externalMedia
+  POST, ari_manager.py:739). Mismatch -> externalMedia fails.
+- ARI Endpoint in Dograh == `http://<asterisk_host>:8088` (the container's
+  network-local address when api and asterisk share app-network). The overlay
+  .env has no ARI_ENDPOINT; the operator must enter it in the Dograh UI.
+  ASSUMPTION: operator enters `http://dograh_asterisk:8088` (the overlay's
+  container_name) — or the api needs `--add-host`/network alias. Must confirm.
+- externalMedia `format=ulaw` (verified ari_manager.py:761). Verimor endpoint
+  must allow ulaw (verified in pjsip.conf.template: `allow=ulaw`).
+
+---
+
+## 3. Outbound endpoint format (the core fix)
+
+### 3.1 Current behavior (verified)
+`ARIProvider.initiate_call` (provider.py:90-94):
+```
+if to_number.startswith("SIP/") or to_number.startswith("PJSIP/"):
+    sip_endpoint = to_number
+else:
+    sip_endpoint = f"PJSIP/{to_number}"
+```
+`to_number` is the raw user-entered number (campaign_call_dispatcher.py:250,
+370 — no normalization on the ARI outbound path).
+
+### 3.2 Required behavior
+Verimor is a PJSIP **endpoint named `verimor`** (pjsip.conf `[verimor]`).
+To dial *through* that trunk from ARI you must write the device as
+`PJSIP/<number>@<endpoint_name>` => `PJSIP/<digits>@verimor`. The bare
+`PJSIP/<number>` form tries to dial a device named `<number>`, which does not
+exist, so outbound calls fail with "device not found".
+
+### 3.3 Fix (Sonnet, minimal)
+In `ARIProvider.initiate_call`, replace the else-branch:
+```
+else:
+    from api.utils.telephony_address import normalize_telephony_address
+    norm = normalize_telephony_address(to_number)
+    if norm.address_type == "pstn":
+        # Turkey national -> strip +90 -> bare 10/11 digits for PJSIP device name
+        digits = norm.canonical.lstrip("+")
+        sip_endpoint = f"PJSIP/{digits}@verimor"
+    elif norm.address_type == "sip_uri":
+        # already a sip: URI — let the caller supply the full target
+        sip_endpoint = to_number   # or parse to PJSIP/user@host
+    else:
+        sip_endpoint = f"PJSIP/{to_number}"
+```
+- `transfer_call` (provider.py:469-472) needs the SAME fix (duplicate logic —
+  apply the same normalization so transfers through Verimor work).
+- The `verimor` literal should come from config, not be hardcoded. ASSUMPTION:
+  the PJSIP endpoint name is stable per-tenant. The overlay uses `verimor`
+  as the section name; the Dograh config should expose `pjsip_outbound_endpoint`
+  (default `verimor`) so an org using a different trunk name still routes.
+  The Sonnet worker should add this as an optional config field rather than
+  hardcoding.
+
+### 3.4 Test for the fix
+A unit test in the ARI provider test dir (or extend
+api/tests/telephony/ari/... if present) asserting:
+- `initiate_call(to_number="+90 5XX XXX XX XX")` -> endpoint param
+  `PJSIP/05XXXXXXXXX@verimor` (national) or `PJSIP/905XXXXXXXXX@verimor`
+  — decide and document the expected canonical.
+- `initiate_call(to_number="PJSIP/6001@verimor")` -> unchanged.
+- `initiate_call(to_number="8000")` -> `PJSIP/8000@verimor` (bare extension).
+
+---
+
+## 4. Docker build path — guaranteeing required modules
+
+### 4.1 Base image choice
+- ASSUMPTION (operator decision, no cost): `asterisk:22-alpine` is ~150MB and
+  requires `apk add` of `asterisk-modules` + `asterisk-channel-*`. The Debian
+  `asterisk:22` (~600MB) ships more modules but ALSO not necessarily
+  `res_websocket_client`. Either way the image MUST be checked.
+
+### 4.2 Required module set (for the healthcheck + media path)
+At minimum (verified from the overlay healthcheck + Dograh's externalMedia):
+```
+res_ari.so
+res_ari_websocket.so
+res_http_websocket.so   (chan_websocket transport, not the ARI ws)
+chan_websocket.so       (externalMedia transport=websocket)
+res_websocket_client.so (outbound ws client -> Dograh)
+chan_pjsip.so
+res_pjsip.so
+res_pjsip_endpoint_base.so
+res_pjsip_auth.so
+res_pjsip_registrar.so
+res_pjsip_outbound_registration.so
+res_xmpp.so             (not needed; omit)
+```
+The Dockerfile MUST `RUN asterisk -rx "module show like ..." ` post-install
+and FAIL the build (not just warn) if any required module is `Unloaded`/`missing`.
+
+### 4.3 Dockerfile shape (Sonnet writes this)
+```dockerfile
+ARG ASTERISK_VERSION=22
+FROM asterisk:${ASTERISK_VERSION}
+COPY conf/*.template /etc/asterisk/templates/
+COPY conf/modules.conf /etc/asterisk/
+COPY entrypoint.sh /docker-entrypoint.d/00-render-asterisk
+RUN chmod +x /docker-entrypoint.d/00-render-asterisk \
+ && (verify each required module via `asterisk -rx` at runtime is the
+    healthcheck; build-time check is best-effort)
+EXPOSE 5060/udp 10000-10100/udp
+ENTRYPOINT ["/usr/bin/entrypoint"]   # stock asterisk entrypoint + render
+CMD ["asterisk","-f"]
+```
+The official `asterisk:22` image already runs `ENTRYPOINT ["/docker-entrypoint.sh"]`
++ `CMD ["asterisk","-D"]` and executes `/docker-entrypoint.d/*.sh` in order.
+So `00-render-asterisk.sh` (the renamed entrypoint.sh) runs before Asterisk
+starts. CRITICAL: entrypoint.sh currently ends with `exec "$@"` — that is
+correct for the stock entrypoint contract; keep it.
+
+### 4.4 Build-time validation command (gate G3)
+```
+docker compose -f deploy/asterisk/docker-compose.asterisk.yaml \
+  --env-file deploy/asterisk/.env build
+# then inside the built image:
+docker run --rm <image> asterisk -rx 'module show like res_websocket_client'
+docker run --rm <image> asterisk -rx 'module show like chan_websocket'
+docker run --rm <image> asterisk -rx 'module show like res_ari_websocket'
+```
+Pass = each prints `Running` with a non-empty `Use Count`.
+
+---
+
+## 5. Credential discovery and injection (no secrets in git/Kanban)
+
+### 5.1 Verimor SIP creds (VERIMOR_SIP_USERNAME / VERIMOR_SIP_PASSWORD)
+- Already in `deploy/asterisk/.env.example` as placeholders.
+- Discovery: operator edits `deploy/asterisk/.env` (gitignored — must be added
+  to `.gitignore` if not already). CRITICAL: the overlay must NOT be committed
+  with a filled .env.
+- Injection: `docker-compose.asterisk.yaml` loads `.env` via `env_file` (required:false
+  so `docker compose config` works pre-fill). entrypoint.sh substitutes them into
+  pjsip.conf via the envsubst allowlist (VERIFIED — they are in the allowlist).
+- No change to Dograh source needed — Asterisk reads them locally.
+
+### 5.2 ARI creds (ARI_APP_NAME / ARI_PASSWORD)
+- These must be entered in BOTH:
+  1. `deploy/asterisk/.env` (for ari.conf rendering), AND
+  2. Dograh UI Telephony Configuration (ari_endpoint, app_name, app_password,
+     ws_client_name).
+- They are NOT stored in the repo. Dograh stores them in the
+  `telephony_configurations.credentials` JSONB (encrypted at rest per the
+  migration a2355fc6bdc1) — the ari_manager reads them via
+  `load_credentials_for_transport` and never logs them.
+
+### 5.3 OpenAI voice credential
+- This is consumed inside the running pipecat pipeline (services/pipecat/).
+  It is an env var on the `api` container (e.g. `OPENAI_API_KEY`), already
+  part of the base Dograh deployment. The overlay does NOT touch it.
+- Verification: the credential must be present in the `api` container's env
+  at runtime; the overlay's only responsibility is to ensure the Asterisk
+  container can reach the `api` container's WebSocket. No secret handling
+  change required.
+
+### 5.4 TELEPHONY_WS_TOKEN_SECRET (capability token for the media socket)
+- OPTIONAL hardening on the Dograh side (ws_auth.py:33). If set, the
+  externalMedia v() appends `token=<hmac>` and the `/ws/ari` handler
+  verifies it. ASSUMPTION: for the first live call, leave this unset
+  (tokenless, the legacy behavior) to reduce moving parts — but the
+  operator should enable it for any non-test deployment. Document the
+  access-log exposure hazard (token appears in uvicorn + nginx access logs).
+
+### 5.5 .gitignore
+- VERIFIED: `deploy/asterisk/.env` must be ignored. Check `.gitignore`
+  (root) — add `deploy/asterisk/.env` if absent. This is a Sonnet edit to
+  root `.gitignore`.
+
+---
+
+## 6. Staged gates — test commands and observable evidence
+
+All gates run against the overlay + the existing base stack (api/redis/postgres/minio/nginx/coturn).
+
+### G1 — Static checks (read-only, no container)
+- `bash -n deploy/asterisk/entrypoint.sh` → exit 0 (syntax).
+- `docker compose -f deploy/asterisk/docker-compose.asterisk.yaml config -q`
+  → exit 0 (compose parses; works even without .env because env_file
+  required:false and all interpolations have defaults).
+- `docker run --rm -i node:20-alpine -- sh -c 'cat | envsubst' ...` — too heavy;
+  instead: verify each template renders against .env.example with a dry run:
+  ```
+  env $(cat deploy/asterisk/.env.example | grep -v '^#' | xargs) \
+    envsubst '${VERIMOR_SIP_USERNAME} ${ARI_APP_NAME} ...' < \
+    deploy/asterisk/conf/pjsip.conf.template > /tmp/pjsip.conf && \
+    grep -q 'server_uri = sip:sip.verimor.com.tr:5060' /tmp/pjsip.conf
+  ```
+  PASS = no unrendered ${VAR} remain in the output for allowlisted vars.
+- Evidence: shell exit codes + `diff <(grep -o '\${[A-Z_]*}' rendered) /dev/null`.
+
+### G2 — Container build (no secrets, dummy .env)
+- `cp deploy/asterisk/.env.example deploy/asterisk/.env` (placeholders only).
+- `docker compose -f deploy/asterisk/docker-compose.asterisk.yaml --env-file
+  deploy/asterisk/.env build`
+- PASS = build completes; `docker inspect --format '{{.Config.Healthcheck.Test}}'
+  dograh-asterisk:local` shows the res_websocket_client check.
+- Evidence: `docker compose ... build` exit 0 + healthcheck test present.
+
+### G3 — Module availability inside the built image
+- `docker create dograh-asterisk:local` then `docker cp` + `asterisk -rx` OR
+  use the healthcheck semantics:
+  ```
+  docker run --rm --entrypoint '' dograh-asterisk:local \
+    asterisk -rx 'module show like res_websocket_client' | grep -q Running
+  ```
+  (repeat for `chan_websocket`, `res_ari`, `res_ari_websocket`, `chan_pjsip`.)
+- PASS = every required module reports Running.
+- BLOCKER if any module is missing → add `RUN install asterisk-mod-...` in Dockerfile.
+
+### G4 — Container start + config render (dummy .env, base stack up)
+- Requires base Dograh stack running and `dograh_app-network` existing.
+  (Use docker compose up for the base stack first; the overlay is standalone.)
+- `docker compose -f deploy/asterisk/docker-compose.asterisk.yaml --env-file
+  deploy/asterisk/.env up -d`
+- PASS = container is `healthy` (healthcheck passes) AND entrypoint log line
+  `rendered 4 file(s)` appears (renders ari/pjsip/extensions + new http/rtp/ws_client).
+- Evidence: `docker compose ps` → `healthy`; `docker logs dograh_asterisk
+  | grep -q 'rendered'`.
+
+### G5 — SIP registration to Verimor (REAL creds, carrier-billed risk = low)
+- This is the first gate requiring real Verimor credentials. It does NOT place
+  a call — only registers.
+- Operator fills `deploy/asterisk/.env` with real VERIMOR_* + ARI_APP_NAME/
+  ARI_PASSWORD (matching Dograh UI).
+- Restart container: `docker compose ... up -d --build` (env_file reload).
+- `docker exec dograh_asterisk asterisk -rx 'pjsip show registrations'`
+  → `verimor_reg` row; `Registration: Registered` + `Expires:` counter.
+- `docker exec dograh_asterisk asterisk -rx 'pjsip show endpoints'`
+  → `verimor` endpoint; `Auth` = verimor_auth; `Allow: ulaw`.
+- `docker exec dograh_asterisk asterisk -rx 'ari show apps'`
+  → `dograh` listed (Stasis app registered).
+- PASS = Registered + Stasis app listed + ulaw allowed.
+- BLOCKER if not Registered after 60s → fail-closed (NAT address wrong?
+  carrier IP allowlist? Verimor account locked?). STOP before outbound.
+
+### G6 — ARI WebSocket + externalMedia wiring (no audio yet)
+- In Dograh UI: create ARI telephony config with
+  `ari_endpoint=http://dograh_asterisk:8088`, `app_name=dograh`,
+  `app_password=<same as .env>`, `ws_client_name=dograh`.
+- `ari_manager` (api container) connects to `ws://dograh_asterisk:8088/ari/events`.
+- Evidence: api logs show
+  `[ARI org=<id>] WebSocket connected to <ari_endpoint>` and
+  `[ARI org=<id>] StasisStart:` on the next inbound event test.
+- PASS = ari_manager achieves a stable connection (>30s, the
+  `_STABLE_CONNECTION_SECONDS` threshold — ari_manager.py:74).
+- BLOCKER if disconnects → wrong host/port, wrong app_name, wrong password,
+  or 8088 published/blocked.
+
+### G7 — ARI outbound to Verimor (one-digit test number, NOT Ozan yet)
+- Use Dograh's "test call" (telephony routes POST /initiate-call) to a
+  non-human target: a Verimor DID that rings voicemail, or a SIP echo, or
+  `0` (Turkish operator test tone). Pick a number that does NOT bill Ozan
+  or reach a human.
+- PASS = Dograh API returns `Call initiated successfully`; ari_manager logs
+  `StasisStart` for the created externalMedia channel + a `ChannelCreated`
+  for the outbound `PJSIP/<digits>@verimor` leg; call ends cleanly
+  (ChannelDestroyed) without media.
+- Evidence: ari_manager log lines for StasisStart + externalMedia + bridge.
+- This gate validates the outbound endpoint fix (section 3). If the leg shows
+  `PJSIP/<digits>` WITHOUT `@verimor` in the channel name, the fix in 3.3
+  did not land — STOP.
+
+### G8 — Bidirectional media canary (G.711 ulaw loopback)
+- Before the live human call, prove media flows both ways:
+  Option A (preferred): use a local SIP softphone registered to the SAME
+  `verimor` endpoint (add a second `[softphone]` endpoint in pjsip.conf)
+  and place a Dograh outbound call to it; speak and confirm the agent
+  hears + responds. The softphone is the "canary" — no carrier billing.
+  Option B: use Asterisk's built-in `Echo()` — but that bypasses Dograh,
+  so it only validates the SIP trunk, not the Dograh bridge.
+- PASS = ulaw RTP packets observed on the RTP port
+  (`docker exec ... asterisk -rx 'rtp set debug'` or a tcpdump on the
+  published RTP range) AND the agent's TTS is heard at the softphone AND
+  the agent's STT produces a transcript.
+- Evidence: tcpudump capture + a log line showing the externalMedia channel
+  bridged to the caller channel + an agent transcript in the run.
+
+### G9 — Live consented call to Ozan (HUMAN-APPROVAL GATE)
+- Pre-reqs:
+  - Ozan's explicit consent to receive the test call (operator must obtain
+    this BEFORE dialing).
+  - Ozan's phone number registered in Dograh OR dialed as the to_number.
+  - A short, bounded workflow (≤60s) so cost is contained.
+- Execution:
+  - Operator runs the test call from the Dograh UI / API; records timestamp.
+  - Ozan is told: "this is an automated test call from Dograh migration, you
+    may hang up at any time."
+- PASS = Ozan reports a two-way conversation: they spoke, the agent
+  responded with relevant audio, and the call ended cleanly. The Dograh run
+    shows STT transcript + LLM response + TTS output.
+- Evidence: screenshot of the completed run + (operator-collected) audio
+    recording of Ozan's confirmation. NO recording is made by Dograh unless
+    the workflow node enables it — don't auto-record.
+- BLOCKER (human-approval): do NOT place the call until the operator
+    confirms consent. This card must block on kanban if consent is pending.
+
+### G10 — Rollback check
+- `docker compose -f deploy/asterisk/docker-compose.asterisk.yaml down --volumes`
+  (removes the asterisk container + its anonymous volumes; does NOT touch
+  the base `dograh_app-network` or the api/postgres/etc.).
+- PASS = `docker ps` shows no `dograh_asterisk`; base stack unaffected;
+  ari_manager logs show `Stopping ARI connection` for the asterisk endpoint.
+- Evidence: `docker compose ps` (only base services remain).
+
+---
+
+## 7. Firewall, NAT, port requirements (verified)
+
+- UDP 5060 (SIP) — published in compose; must be open to `sip.verimor.com.tr`.
+- UDP 10000-10100 (RTP) — published in compose; must be open inbound from
+  Verimor's media IPs. ASSUMPTION: Verimor sends media to the public IP
+  registered for the trunk — confirm the IP matches
+  EXTERNAL_SIGNALING_ADDRESS / EXTERNAL_MEDIA_ADDRESS.
+- TCP 8088 (ARI HTTP + WebSocket) — NOT published (internal only). Firewall
+  rule: deny 8088 from anything except the `api`/`ari_manager` source on
+  app-network.
+- TCP 8000 (Dograh API) — already exposed by the base stack for the UI;
+  the overlay's websocket_client.conf points the Asterisk container at
+  `api:8000` (service name on app-network). No new host port.
+- NAT: pjsip.conf already sets `external_signaling_address` /
+  `external_media_address` + `local_net` for RFC1918. The overlay's .env
+  requires these be the server's public IPv4. BLOCKER if the server has a
+  dynamic IP — must pin a static IP or fail-closed.
+- ARM64: VERIFIED unknown. `asterisk:22` official image is multi-arch
+  (amd64/arm64). The module set in 4.2 includes `res_websocket_client`
+  which historically had ARM64 build gaps in older Asterisk; Asterisk 22
+  ships it. The Sonnet worker must run G3 on the actual target arch.
+  BLOCKER if `res_websocket_client` is unavailable on arm64 → fall back to
+  building Asterisk from source with menuselect (expensive) or a different
+  image (`asterisk/asterisk` GHCR variants).
+
+---
+
+## 8. Safe rollback
+- The overlay is a SEPARATE compose project (its own file + .env); `docker
+  compose -f ... down` removes only the asterisk service. The base Dograh
+  stack is untouched.
+- Dograh-side ARI config is a DB row (`telephony_configurations`); deleting
+  it from the UI reverts the integration. ari_manager auto-stops reconnecting
+  once the config is inactive.
+- No git changes are required to roll back the asterisk half — it's all
+  untracked files under `deploy/asterisk/`. `rm -rf deploy/asterisk` reverts
+  the entire overlay.
+- ASSUMPTION: the operator confirms Verimor does NOT require a separate
+  "disable SIP trunk" call — registration simply stops when the container is
+  down. Confirm with Verimor ops.
+
+---
+
+## 9. Billing and human-approval gate (BLOCKERS list)
+The operator must affirm each item marked BLOCKER before its gate runs. A
+failure at any BLOCKER halts further progression and blocks the Kanban card.
+
+| # | Gate | Blocker question | Who answers |
+|---|------|------------------|-------------|
+| B1 | G5/G7 (any carrier call) | Verimor credentials + SIP trunk authorized for this DID? | Ozan |
+| B2 | G9 (live call) | Explicit consent obtained from Ozan before dialing a human? | Ozan |
+| B3 | G9 | Caller-ID number Verimor will permit on outbound (VERIMOR_CALLERID)? | Ozan/Verimor |
+| B4 | G3 | res_websocket_client + chan_websocket available on target arch (arm64)? | Sonnet verify |
+| B5 | G4/G5 | Public IP for EXTERNAL_SIGNALING_ADDRESS / EXTERNAL_MEDIA_ADDRESS confirmed static + firewall open? | Ozan |
+| B6 | G7 | Test target number chosen that does NOT bill a real person (voicemail/echo)? | Ozan |
+
+---
+
+## 10. Division of work between Opus and Sonnet (no concurrent writers)
+
+This repo workspace is SHARED (not a worktree). To honor "no concurrent writers,"
+the two child workers are sequenced, NOT parallel:
+
+1. **Sonnet (t_194c2559)** — implements first, as the sole writer:
+   - Add Dockerfile, modules.conf, http.conf, rtp.conf,
+     websocket_client.conf.template, README.md.
+   - Patch .gitignore for deploy/asterisk/.env.
+   - Fix ARIProvider outbound endpoint (provider.py:90-94 + transfer_call 469-472).
+   - Add/extend the unit test for outbound endpoint formation.
+   - Run G1/G2/G3 static + build checks.
+   - Hand off changed file list + results to the Kanban card.
+
+2. **Opus (t_bcb4b510)** — reviews AFTER Sonnet signals done:
+   - Read-only audit of Sonnet's changes against the plan.
+   - Fail-closed review: module availability, NAT/rtp, outbound endpoint
+     correctness, secret handling, ws_client_name contract, rollback.
+   - Returns required fixes + acceptance tests for the integrator (t_e5138dd5).
+
+3. After both are done, the integrator (t_e5138dd5, model unspecified) runs
+   G4–G10 in sequence, blocking on B1–B6 as each gate is reached.
+
+The parent (this) card does NOT write files — it ends with this plan handed off
+to the children. Children are linked: t_194c2559 and t_bcb4b510 both have
+`parents=[t_506c8f5b]`. t_bcb4b510 should add t_194c2559 as a parent dependency
+once it exists (use kanban_link) so Opus waits for Sonnet's output.
+
+### Ordering enforcement
+- t_194c2559 is currently `todo`. It must be marked in-progress before t_bcb4b510
+  can meaningfully review. The integrator t_e5138dd5 (child of both) is gated on
+  BOTH parents being done.
+
+---
+
+## 11. Acceptance criteria (summary — what "done" means at each level)
+
+### Planning card (this one, t_506c8f5b) — DONE when:
+- This document exists at `deploy/asterisk/MIGRATION_PLAN.md` (this file).
+- It names every file to add/modify (section 1).
+- It states the architecture + outbound endpoint fix (sections 2,3).
+- It lists credential handling with no secrets in git (section 5).
+- It enumerates G1–G10 gates with pass/fail evidence (section 6).
+- It lists firewall/NAT/rollback/billing/human gates (sections 7–9).
+- It defines the Sonnet→Opus→integrator handoff ordering (section 10).
+- Every unverified item is labeled ASSUMPTION or BLOCKER, not stated as fact.
+
+### Sonnet (t_194c2559) — DONE when:
+- All files in section 1.1/1.2 added/modified; `.gitignore` updated.
+- Build gate G2 + module gate G3 pass (real `docker build` run, modules verified).
+- Outbound endpoint unit test passes (section 3.4).
+- Static gate G1 passes on all new shell/YAML/templates.
+- Handoff comment with changed_files + command results.
+
+### Opus (t_bcb4b510) — DONE when:
+- A fail-closed review with file:line references is returned.
+- Required fixes + acceptance tests for the integrator are listed.
+- No unverified claim of SIP/media success.
+
+### Integrator (t_e5138dd5) — DONE when:
+- Gates G4–G8 pass (build/start, SIP reg, ARI ws, externalMedia, outbound, media).
+- G9 passes ONLY after B1/B2/B3 human affirmation (block on kanban otherwise).
+- G10 rollback verified.
+- Evidence artifacts attached to the Kanban card (log excerpts, NOT secrets).
+
+---
+
+## 12. Things explicitly NOT in scope here (next cards / out of band)
+- No changes to Dograh's base `docker-compose.yaml` api/postgres/redis services.
+- No changes to the pipecat voice pipeline or OpenAI credential wireup (runtime
+  env on the api container; pre-existing).
+- No Terraform/infra-as-code (this is a manual overlay deploy).
+- No permanent recording of live calls (assumed off by default; not enabled).

--- a/deploy/asterisk/MIGRATION_PLAN.md
+++ b/deploy/asterisk/MIGRATION_PLAN.md
@@ -124,8 +124,8 @@ These are the exact touch points. The Sonnet worker (t_194c2559) owns these.
    by compose; document for reviewer).
 4. `deploy/asterisk/conf/rtp.conf` — `rtpstart=${RTP_START}`,
    `rtpend=${RTP_END}`, plus `rtpenable=yes`. Binds the published UDP range.
-5. `deploy/asterisk/conf/websocket_client.conf.template` — a `[${WS_CLIENT_NAME}]`
-   stanza: `type=client`, `uri=${DOGRAH_WS_SCHEME}://${DOGRAH_API_HOST}:${DOGRAH_API_PORT}/api/v1/telephony/ws/ari`,
+5. `deploy/asterisk/conf/websocket_client.conf.template` — `[${WS_CLIENT_NAME}]`,
+   `type=websocket_client`, `uri=${DOGRAH_WS_SCHEME}://${DOGRAH_API_HOST}:${DOGRAH_API_PORT}/api/v1/telephony/ws/ari`,
    `protocols=media`. (The uri carries no query string; v() is appended at
    externalMedia time per the docs mdx:109-111.)
 6. `deploy/asterisk/README.md` — the missing operator doc (currently

--- a/deploy/asterisk/README.md
+++ b/deploy/asterisk/README.md
@@ -1,0 +1,192 @@
+# Dograh — Self-Hosted Asterisk + Verimor SIP Trunk
+
+This is a standalone Docker overlay for self-hosting Asterisk with a Verimor SIP trunk,
+providing ARI call control and externalMedia audio bridging to the Dograh platform.
+
+## Architecture
+
+```
++-------------------+       UDP 5060        +-------------------+
+|    Verimor SIP    | <--------------------> |   Asterisk 22     |
+|     Trunk         |   IP: sip.verimor.com.tr|  (this overlay)  |
++-------------------+     UDP 10000-10100   +-------------------+
+                                                 |
+                                                 | ARI WebSocket (ws://<asterisk>:8088/ari/events)
+                                                 v
+                                          +---------------+
+                                          |   ari_manager  |
+                                          |   (api process)|
+                                          +---------------+
+                                                 |
+                                                 | externalMedia POST /channels/externalMedia
+                                                 v
+                                          +---------------+
+                                          | Dograh API    |
+                                          | /api/v1/telephony/ws/ari|
+                                          +---------------+
+                                                 |
+                                                 | G.711 ulaw audio (8kHz)
+                                                 v
+                                          +---------------+
+                                          |   OpenAI       |
+                                          |   Voice Runtime|
+                                          +---------------+
+
+## Prerequisites
+
+- Dograh backend running on Docker
+- External Docker network `dograh_app-network` (created by base stack)
+- Verimor SIP trunk credentials (username, password, signaling host, DID, etc.)
+
+## Quick Start
+
+1. Copy the environment template and fill in your credentials:
+   ```bash
+   cp deploy/asterisk/.env.example deploy/asterisk/.env
+   # Edit deploy/asterisk/.env with real values
+   ```
+
+2. Ensure Docker base stack is running and `dograh_app-network` exists:
+   ```bash
+   docker network ls | grep app-network
+   # If not found: docker network create dograh_app-network
+   ```
+
+3. Start the overlay:
+   ```bash
+   docker compose -f deploy/asterisk/docker-compose.asterisk.yaml --env-file deploy/asterisk/.env up -d --build
+   ```
+
+4. View logs:
+   ```bash
+   docker compose -f deploy/asterisk/docker-compose.asterisk.yaml logs -f asterisk
+   ```
+
+## Configuration Fields
+
+### Verimor SIP Trunk
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `VERIMOR_SIP_USERNAME` | Verimor SIP account user | `your_trunk_username` |
+| `VERIMOR_SIP_PASSWORD` | Verimor SIP account password | `your_trunk_password` |
+| `VERIMOR_SIP_HOST` | Verimor signaling host | `sip.verimor.com.tr` |
+| `VERIMOR_SIP_PORT` | UDP SIP signaling port | `5060` |
+| `VERIMOR_DID` | Inbound DID (digits only) | `908500000000` |
+| `VERIMOR_CALLERID` | Outbound caller ID (optional) | `908500000000` |
+
+### Asterisk ARI (internal only)
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `ARI_APP_NAME` | Stasis app name (must match Dograh UI) | `dograh` |
+| `ARI_PASSWORD` | ARI user password | `CHANGE_ME` |
+| `ARI_HTTP_PORT` | ARI local HTTP port | `8088` |
+| `WS_CLIENT_NAME` | WebSocket client section name (shared across config) | `dograh` |
+
+### Dograh Backend (external media target)
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DOGRAH_WS_SCHEME` | WebSocket scheme (`ws` or `wss`) | `ws` |
+| `DOGRAH_API_HOST` | Dograh API hostname inside `dograh_app-network` | `api` |
+| `DOGRAH_API_PORT` | Dograh API port | `8000` |
+
+### Networking / NAT
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `EXTERNAL_SIGNALING_ADDRESS` | Public IPv4 for Verimor signaling (NAT) | `203.0.113.10` |
+| `EXTERNAL_MEDIA_ADDRESS` | Public IPv4 for Verimor RTP (NAT) | `203.0.113.10` |
+| `LOCAL_NET` | Extra local subnets to skip NAT (comma-separated) | `` |
+| `SIP_PORT` | Published SIP signaling port | `5060` |
+| `RTP_START` | Bounded RTP range start | `10000` |
+| `RTP_END` | Bounded RTP range end | `10100` |
+
+### Compose wiring
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DOGRAH_NETWORK_NAME` | Existing Docker network name | `dograh_app-network` |
+| `ASTERISK_VERSION` | Base Asterisk image version | `22` |
+
+## Integration with Dograh
+
+### 1. ARI Configuration in Dograh UI (telephony config)
+
+- **ARI Endpoint**: `http://dograh_asterisk:8088`
+- **Stasis App Name**: Matches `ARI_APP_NAME` from this overlay (default: `dograh`)
+- **App Password**: Matches `ARI_PASSWORD` from `.env`
+- **websocket_client.conf Name**: Matches `WS_CLIENT_NAME` from `.env` (default: `dograh`)
+
+### 2. Inbound Call Routing
+
+- Verimor delivers inbound calls to the `verimor` PJSIP endpoint
+- Calls are routed to the `from-verimor` dialplan context
+- Every inbound call enters the Stasis app (matching `ARI_APP_NAME`)
+- Dograh's inbound worker matches the DID/digits against registered numbers
+
+### 3. Outbound Call Routing via ARI
+
+- Dograh ARI provider originates SIP calls via `ari_manager` → Asterisk ARI REST API
+- Expects a PJSIP endpoint that routes through the Verimor trunk
+- `provider.py` builds endpoints as:
+  - If already SIP/PJSIP: verbatim (`PJSIP/6001@external`)
+  - Else: `PJSIP/<normalized_digits>@verimor` (the Verimor PJSIP endpoint name)
+
+### 4. Audio Path (externalMedia)
+
+- `res_websocket_client` connects OUT to `ws://${DOGRAH_WS_SCHEME}://${DOGRAH_API_HOST}:${DOGRAH_API_PORT}/api/v1/telephony/ws/ari`
+- Uses `protocols=media`
+- Call audio flows G.711 ulaw (8 kHz) in both directions
+- externalMedia `format=ulaw` must be set on Dograh side
+
+## Security Notes
+
+- **ARI/HTTP (8088) is internal-only**: Not published. Do NOT expose to host.
+- `.env` is gitignored. Edit locally.
+- Credentials are environment variables passed via Docker env_file.
+- WebSocket tokenless by default (`TELEPHONY_WS_TOKEN_SECRET` unset for first live call).
+
+## Troubleshooting
+
+### Container fails to start
+
+Run logs and check Asterisk errors:
+- Missing vars: `deploy/asterisk/entrypoint.sh` validates REQUIRED_VARS
+- Module not loaded: `modules.conf` lists explicitly; check log
+- Template render failed: `entrypoint.sh` logs each file
+
+### SIP registration fails
+
+Run `docker exec dograh_asterisk asterisk -rx 'pjsip show registrations'`.
+- Check `EXTERNAL_SIGNALING_ADDRESS` matches your REAL public IP
+- Verify `VERIMOR_SIP_HOST`/`VERIMOR_SIP_PORT` are correct
+- Confirm credentials are correct
+
+### ARI app not registered
+
+Run `docker exec dograh_asterisk asterisk -rx 'ari show apps'`.
+- Verify `ARI_APP_NAME` matches value entered in Dograh UI
+- Confirm `ari.conf` section `${ARI_APP_NAME}` has correct password
+
+### Audio not flowing
+
+Verify loopback:
+- TCP dump on port 10000-10100
+- Dograh logs show `StasisStart:`
+- Dograh run shows STT + TTS
+- G.711 ulaw packets present
+
+## Staging Gates
+
+G1: Static checks (syntax, compose, template render)
+G2: Container build
+G3: Module availability inside built image
+G4: Container start + config render (dummy .env)
+G5: SIP registration to Verimor (requires real credentials)
+G6: ARI WebSocket + externalMedia wiring (no audio)
+G7: ARI outbound to Verimor (test number, not billing)
+G8: Bidirectional media loopback canary
+G9: Live consented call to target (human-approval)
+G10: Rollback check (`down --volumes`)

--- a/deploy/asterisk/conf/ari.conf.template
+++ b/deploy/asterisk/conf/ari.conf.template
@@ -1,0 +1,16 @@
+;
+; ari.conf — rendered from ari.conf.template by entrypoint.sh.
+;
+; The user section name (${ARI_APP_NAME}) is BOTH the ARI username and the
+; Stasis app name Dograh registers. It must match the "Stasis App Name" you
+; enter in Dograh, and ${ARI_PASSWORD} must match the "App Password".
+;
+
+[general]
+enabled = yes
+pretty = yes
+
+[${ARI_APP_NAME}]
+type = user
+read_only = no
+password = ${ARI_PASSWORD}

--- a/deploy/asterisk/conf/extensions.conf.template
+++ b/deploy/asterisk/conf/extensions.conf.template
@@ -1,0 +1,65 @@
+;
+; extensions.conf — rendered from extensions.conf.template by entrypoint.sh.
+;
+; NOTE: Dograh dialplan variables such as ${EXTEN}, ${CALLERID(num)} and
+; ${CHANNEL(...)} are intentionally PRESERVED here — the entrypoint substitutes
+; only the operator allowlist (e.g. ${ARI_APP_NAME}, ${VERIMOR_DID}), never
+; these. Do not add such variables to the allowlist.
+
+[general]
+static = yes
+writeprotect = no
+
+[globals]
+
+;=========================== Inbound from Verimor ==========================
+; Verimor delivers inbound calls to the `verimor` endpoint, whose context is
+; `from-verimor`. Every inbound call is handed to the Dograh Stasis app, which
+; matches the dialed number against the phone numbers you registered in Dograh
+; and runs the assigned inbound workflow. The dialed digits are passed through
+; unchanged so Dograh matches exactly what Verimor sent.
+[from-verimor]
+exten => _X.,1,NoOp(Inbound Verimor call from ${CALLERID(num)} to ${EXTEN})
+ same => n,Stasis(${ARI_APP_NAME})
+ same => n,Hangup()
+
+; Explicit entry for the configured DID (redundant with the pattern above, but
+; documents the number this trunk answers for).
+exten => ${VERIMOR_DID},1,NoOp(Inbound to configured DID ${VERIMOR_DID})
+ same => n,Stasis(${ARI_APP_NAME})
+ same => n,Hangup()
+
+;=========================== Outbound via Verimor ==========================
+; Dialplan-driven / manual outbound. Dograh's ARI provider originates
+; PJSIP/<number> directly into Stasis and BYPASSES this context (see README
+; "Outbound endpoint caveat"), so the Turkish-number normalization below applies
+; to calls originated INTO this context (e.g. Local/<number>@outbound-verimor),
+; not to Dograh-originated outbound calls.
+;
+; Normalization to Verimor's national 0-prefixed format (0 + 10 digits).
+; Confirm the exact format Verimor expects for your account and adjust if needed.
+; Turkish subscriber numbers are 10 digits (e.g. 5XX XXX XX XX). National
+; dialing format is 0 + those 10 digits (11 total).
+[outbound-verimor]
+; +90 5XXXXXXXXX -> 0 5XXXXXXXXX
+exten => _+90NXXXXXXXXX,1,NoOp(Outbound (+90) ${EXTEN})
+ same => n,Set(DEST=0${EXTEN:3})
+ same => n,Goto(dial-verimor,${DEST},1)
+; 90 5XXXXXXXXX  -> 0 5XXXXXXXXX
+exten => _90NXXXXXXXXX,1,NoOp(Outbound (90) ${EXTEN})
+ same => n,Set(DEST=0${EXTEN:2})
+ same => n,Goto(dial-verimor,${DEST},1)
+; 0 5XXXXXXXXX   -> as dialed (already national format)
+exten => _0NXXXXXXXXX,1,NoOp(Outbound (0) ${EXTEN})
+ same => n,Set(DEST=${EXTEN})
+ same => n,Goto(dial-verimor,${DEST},1)
+; 5XXXXXXXXX     -> 0 5XXXXXXXXX (bare 10-digit subscriber number)
+exten => _NXXXXXXXXX,1,NoOp(Outbound (bare) ${EXTEN})
+ same => n,Set(DEST=0${EXTEN})
+ same => n,Goto(dial-verimor,${DEST},1)
+
+[dial-verimor]
+exten => _X.,1,NoOp(Dialing ${EXTEN} out the Verimor trunk)
+ same => n,Set(CALLERID(num)=${VERIMOR_CALLERID})
+ same => n,Dial(PJSIP/${EXTEN}@verimor,60)
+ same => n,Hangup()

--- a/deploy/asterisk/conf/http.conf
+++ b/deploy/asterisk/conf/http.conf
@@ -1,0 +1,17 @@
+; Asterisk HTTP configuration for ARI
+;
+; This enables the ARI REST API on port 8088.
+; NOTE: 8088 is NOT published in docker-compose.asterisk.yaml — it is
+; internal-only and reachable only from the dograh_app-network, i.e. from
+; the Dograh "api" container.
+;
+; The previous `acl = 127.0.0.1/32` line is intentionally omitted: that ACL
+; would block HTTP connections from the api container (which connects from
+; a Docker network IP, not localhost). ARI is protected by the network
+; boundary (unpublished port + external-only Docker network), not by an
+; ACL restricted to loopback.
+
+[general]
+enabled = yes
+bindaddr = 0.0.0.0
+bindport = ${ARI_HTTP_PORT}

--- a/deploy/asterisk/conf/http.conf.template
+++ b/deploy/asterisk/conf/http.conf.template
@@ -1,0 +1,17 @@
+; Asterisk HTTP configuration for ARI
+;
+; This enables the ARI REST API on port 8088.
+; NOTE: 8088 is NOT published in docker-compose.asterisk.yaml — it is
+; internal-only and reachable only from the dograh_app-network, i.e. from
+; the “api” container.
+;
+; The previous `acl = 127.0.0.1/32` line is intentionally omitted: that ACL
+; would block HTTP connections from the api container (which connects from
+; a Docker network IP, not localhost). ARI is protected by the network
+; boundary (unpublished port + external-only Docker network), not by an
+; ACL restricted to loopback.
+
+[general]
+enabled = yes
+bindaddr = 0.0.0.0
+bindport = ${ARI_HTTP_PORT}

--- a/deploy/asterisk/conf/modules.conf
+++ b/deploy/asterisk/conf/modules.conf
@@ -1,0 +1,48 @@
+; modules.conf — required Asterisk modules for ARI + chan_websocket + PJSIP
+;
+; This file guarantees the modules the overlay depends on are loaded.
+; If any listed module is missing, Asterisk logs an ERROR at startup and
+; the healthcheck (res_websocket_client) will fail — surfacing the defect
+; fast rather than silently degrading the media path.
+;
+; Only modules verified present as .so in andrius/asterisk:22 (AS 22.10.1,
+; linux/arm64, 327 modules) are listed here. Modules absent from that image
+; (res_ari_websocket.so, app_answer.so, dtmf_detect.so, res_pjsip_endpoint_base.so,
+; res_pjsip_auth.so, app_hangup.so) are intentionally omitted:
+;   - res_ari_websocket.so → merged into res_ari_events.so (ARL WebSocket)
+;   - app_answer.so         → Stasis uses res_stasis_answer.so for answering
+;   - dtmf_detect.so        → built into res_pjsip_dtmf_info.so
+;   - res_pjsip_endpoint_base.so → merged into res_pjsip.so
+;   - res_pjsip_auth.so     → replaced by res_pjsip_authenticator_digest.so
+;   - app_hangup.so         → Hangup() is a core application, not a loadable module
+;
+; Comment headers use ';' (Asterisk comment style). '#' is a preprocessor
+; directive in modules.conf, NOT a comment, on stock Asterisk 22.
+
+[modules]
+autoload=yes
+
+; === Asterisk core ===
+load => res_ari.so
+load => res_ari_events.so           ; ARL WebSocket (replaces res_ari_websocket.so)
+load => res_http_websocket.so
+load => chan_pjsip.so               ; includes res_pjsip_endpoint_base internally
+load => res_pjsip.so                ; includes endpoint_base/auth submodules
+load => res_pjsip_registrar.so
+load => res_pjsip_outbound_registration.so
+
+; === Media and transport for externalMedia ===
+load => chan_websocket.so           ; ExternalMedia transport=websocket
+load => res_websocket_client.so     ; Outbound WebSocket client to Dograh API
+
+; === Codec support (G.711 for the Verimor / Dograh media path) ===
+load => codec_ulaw.so
+load => codec_alaw.so
+
+; === Dialplan and call control ===
+load => app_dial.so
+load => app_stack.so
+load => app_verbose.so
+load => app_read.so
+load => app_queue.so
+load => func_env.so

--- a/deploy/asterisk/conf/pjsip.conf.template
+++ b/deploy/asterisk/conf/pjsip.conf.template
@@ -1,0 +1,83 @@
+;
+; pjsip.conf — rendered from pjsip.conf.template by entrypoint.sh.
+;
+; Verimor SIP trunk (registration + inbound identify) with NAT-safe, symmetric
+; RTP and G.711 (ulaw/alaw). Dograh's external media path is G.711 ulaw, so the
+; trunk endpoint MUST allow ulaw.
+;
+
+;=============================== Transport ==================================
+
+[transport-udp]
+type = transport
+protocol = udp
+bind = 0.0.0.0:${SIP_PORT}
+; Advertise the public addresses so SDP/Contact are reachable from Verimor
+; even though Asterisk sits on a private Docker/host network (NAT).
+external_signaling_address = ${EXTERNAL_SIGNALING_ADDRESS}
+external_media_address = ${EXTERNAL_MEDIA_ADDRESS}
+; RFC1918 ranges Asterisk should treat as local (not rewrite). LOCAL_NET adds
+; an optional extra range; leave it blank to skip.
+local_net = 10.0.0.0/8
+local_net = 172.16.0.0/12
+local_net = 192.168.0.0/16
+; LOCAL_NET adds an optional extra range; leave it blank to skip.
+; When blank, the empty directive is stripped by entrypoint.sh.
+local_net = ${LOCAL_NET}
+
+;=============================== Verimor trunk =============================
+
+[verimor_reg]
+type = registration
+transport = transport-udp
+outbound_auth = verimor_auth
+server_uri = sip:${VERIMOR_SIP_HOST}:${VERIMOR_SIP_PORT}
+client_uri = sip:${VERIMOR_SIP_USERNAME}@${VERIMOR_SIP_HOST}
+contact_user = ${VERIMOR_SIP_USERNAME}
+retry_interval = 60
+forbidden_retry_interval = 300
+expiration = 3600
+line = yes
+endpoint = verimor
+
+[verimor_auth]
+type = auth
+auth_type = userpass
+username = ${VERIMOR_SIP_USERNAME}
+password = ${VERIMOR_SIP_PASSWORD}
+
+[verimor_aor]
+type = aor
+contact = sip:${VERIMOR_SIP_HOST}:${VERIMOR_SIP_PORT}
+qualify_frequency = 60
+
+[verimor]
+type = endpoint
+transport = transport-udp
+; Inbound calls from Verimor enter the dialplan here.
+context = from-verimor
+disallow = all
+allow = ulaw
+allow = alaw
+outbound_auth = verimor_auth
+aors = verimor_aor
+from_user = ${VERIMOR_SIP_USERNAME}
+from_domain = ${VERIMOR_SIP_HOST}
+; Media must flow through Asterisk (never re-INVITE peer-to-peer) so it can be
+; bridged to the Dograh external-media WebSocket channel.
+direct_media = no
+; NAT-safe, symmetric RTP.
+rtp_symmetric = yes
+force_rport = yes
+rewrite_contact = yes
+rtp_timeout = 30
+rtp_timeout_hold = 60
+dtmf_mode = rfc4733
+
+; Match inbound INVITEs from the Verimor signaling host to this endpoint. If
+; Verimor sends from additional signaling IPs, add more `match =` lines (one
+; per line) here — confirm the current set with Verimor.
+[verimor_identify]
+type = identify
+endpoint = verimor
+match = ${VERIMOR_SIP_HOST}

--- a/deploy/asterisk/conf/rtp.conf
+++ b/deploy/asterisk/conf/rtp.conf
@@ -1,0 +1,17 @@
+; Asterisk RTP configuration
+;
+; Binds to the bounded port range published in docker-compose.asterisk.yaml:
+; - SIP_PORT: 5060 UDP (signaling)
+; - RTP_START/RTP_END: 10000-10100 UDP (media packets)
+
+[general]
+rtpudpbind = 0.0.0.0
+rtpstart = ${RTP_START}
+rtpend = ${RTP_END}
+rtpenable = yes
+
+; Legacy compatibility names (some modules reference these):
+rtpincsvrbind = 0.0.0.0
+
+; Optional: per-audio-format bindpriorities if the carrier requires strict binding
+; bindpriorities = ulaw:1,alaw:1

--- a/deploy/asterisk/conf/websocket_client.conf.template
+++ b/deploy/asterisk/conf/websocket_client.conf.template
@@ -15,7 +15,10 @@
 ; (e.g. "ws://ws://api:8000/..."). The variable already includes the scheme.
 
 [${WS_CLIENT_NAME}]
-type = client
-sock = ${DOGRAH_WS_SCHEME}://${DOGRAH_API_HOST}:${DOGRAH_API_PORT}/api/v1/telephony/ws/ari
+type = websocket_client
+uri = ${DOGRAH_WS_SCHEME}://${DOGRAH_API_HOST}:${DOGRAH_API_PORT}/api/v1/telephony/ws/ari
 protocols = media
-timeout = 10000 ; 10 second connection timeout
+connection_type = per_call_config
+connection_timeout = 10000 ; 10 second connection timeout
+reconnect_interval = 1000
+reconnect_attempts = 5

--- a/deploy/asterisk/conf/websocket_client.conf.template
+++ b/deploy/asterisk/conf/websocket_client.conf.template
@@ -1,0 +1,21 @@
+; WebSocket client configuration for externalMedia
+;
+; This section establishes the outbound WebSocket connection from Asterisk
+; to the Dograh API, which handles call audio over the chan_websocket/externalMedia
+; channel. The `uri` does NOT include the query string — that is appended at
+; runtime by the externalMedia dial string in extensions.conf.
+;
+; The matching section name (`ws_client_name`) is the SHARED key:
+;   - Dograh API ARI config (provider config UI)
+;   - WebSocket connection target (uri in this file)
+;   - externalMedia POST body `external_host` field (generated in ari_manager.py)
+;
+; The scheme (ws or wss) comes from DOGRAH_WS_SCHEME. We do NOT hard-code a
+; "ws://" prefix here because that would produce a double scheme
+; (e.g. "ws://ws://api:8000/..."). The variable already includes the scheme.
+
+[${WS_CLIENT_NAME}]
+type = client
+sock = ${DOGRAH_WS_SCHEME}://${DOGRAH_API_HOST}:${DOGRAH_API_PORT}/api/v1/telephony/ws/ari
+protocols = media
+timeout = 10000 ; 10 second connection timeout

--- a/deploy/asterisk/docker-compose.asterisk.yaml
+++ b/deploy/asterisk/docker-compose.asterisk.yaml
@@ -1,0 +1,71 @@
+# Dograh — self-hosted Asterisk + Verimor SIP trunk overlay.
+#
+# This is a STANDALONE overlay that attaches a single Asterisk container to the
+# Dograh stack's existing "app-network" (referenced here as an external
+# network). It does not touch or restart the base stack.
+#
+# Bring-up (from the repo root, with the base stack already running):
+#
+#   cp deploy/asterisk/.env.example deploy/asterisk/.env   # then fill it in
+#   docker compose \
+#     -f deploy/asterisk/docker-compose.asterisk.yaml \
+#     --env-file deploy/asterisk/.env \
+#     up -d --build
+#
+# The --env-file flag is what lets the ${...} values below (ports, network
+# name) pick up your .env; the container itself also loads .env via env_file.
+#
+# ARI (8088) is deliberately NOT published — it is reachable only from
+# app-network, i.e. from the Dograh "api" container. See README.md.
+
+services:
+  asterisk:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        ASTERISK_VERSION: "${ASTERISK_VERSION:-22}"
+    image: dograh-asterisk:local
+    container_name: dograh_asterisk
+    restart: unless-stopped
+    # Loads all runtime variables (Verimor creds, ARI creds, NAT addresses)
+    # into the container so entrypoint.sh can render the config templates.
+    # required:false keeps `docker compose config` working before .env exists.
+    env_file:
+      - path: .env
+        required: false
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    ports:
+      # SIP signaling to the Verimor trunk (UDP).
+      - "${SIP_PORT:-5060}:${SIP_PORT:-5060}/udp"
+      # Bounded RTP media range for the carrier (UDP). Keep in sync with
+      # RTP_START/RTP_END in .env (they drive rtp.conf inside the container).
+      - "${RTP_START:-10000}-${RTP_END:-10100}:${RTP_START:-10000}-${RTP_END:-10100}/udp"
+    # NOTE: ARI/HTTP (8088) is intentionally omitted from `ports` — it must
+    # stay internal to app-network and must never be exposed to the host.
+    healthcheck:
+      # Confirms Asterisk booted AND the module Dograh's media path depends on
+      # is actually loaded.
+      test:
+        [
+          "CMD-SHELL",
+          "asterisk -rx 'module show like res_websocket_client' | grep -q Running || exit 1",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 45s
+    networks:
+      - app-network
+
+networks:
+  # The Dograh base stack owns this network; we attach to it rather than
+  # create it. Override the name via DOGRAH_NETWORK_NAME if your compose
+  # project name differs (see: docker network ls | grep app-network).
+  app-network:
+    external: true
+    name: "${DOGRAH_NETWORK_NAME:-dograh_app-network}"

--- a/deploy/asterisk/entrypoint-wrapper.sh
+++ b/deploy/asterisk/entrypoint-wrapper.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# entrypoint-wrapper.sh — wrapper that sources /docker-entrypoint.d/ scripts
+# before delegating to the andrius/asterisk:22 base image entrypoint.
+#
+# The base image's /usr/local/bin/entrypoint.sh does NOT source
+# /docker-entrypoint.d/*.sh (unlike the standard docker-entrypoint.sh).
+# This wrapper fills that gap so our config-rendering script runs first.
+#
+# We match any executable file in /docker-entrypoint.d/ (the convention
+# in entrypoint.sh is *.sh, but we also accept extensionless scripts
+# like our 00-render-asterisk that the Dockerfile installs).
+#
+set -euo pipefail
+
+# Source all docker-entrypoint.d scripts (standard ordering)
+shopt -s nullglob
+for f in /docker-entrypoint.d/*; do
+  if [ -f "$f" ] && [ -x "$f" ]; then
+    echo "[docker-entrypoint] executing $f"
+    "$f"
+  fi
+done
+shopt -u nullglob
+
+# Then exec the base image's entrypoint with all received arguments
+# (the base entrypoint does uid/chown setup then execs asterisk)
+exec /usr/local/bin/entrypoint.sh "$@"

--- a/deploy/asterisk/entrypoint.sh
+++ b/deploy/asterisk/entrypoint.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# entrypoint.sh — render Asterisk config from templates, then exec Asterisk.
+#
+# Templates under $CONF_TEMPLATE_DIR are rendered with envsubst using an
+# EXPLICIT variable allowlist, so operator-supplied values are substituted
+# while Asterisk dialplan variables (${EXTEN}, ${CALLERID(num)}, ${CHANNEL(...)}
+# etc.) are preserved verbatim. Required variables are validated up front and
+# the container fails closed if any are missing.
+
+set -euo pipefail
+
+CONF_TEMPLATE_DIR="${CONF_TEMPLATE_DIR:-/etc/asterisk/templates}"
+CONF_OUT_DIR="${CONF_OUT_DIR:-/etc/asterisk}"
+
+log() { printf '[dograh-asterisk] %s\n' "$*" >&2; }
+die() { log "FATAL: $*"; exit 1; }
+
+# --- Defaults for optional variables --------------------------------------
+export VERIMOR_SIP_HOST="${VERIMOR_SIP_HOST:-sip.verimor.com.tr}"
+export VERIMOR_SIP_PORT="${VERIMOR_SIP_PORT:-5060}"
+export VERIMOR_CALLERID="${VERIMOR_CALLERID:-${VERIMOR_DID:-}}"
+export ARI_APP_NAME="${ARI_APP_NAME:-dograh}"
+export ARI_HTTP_PORT="${ARI_HTTP_PORT:-8088}"
+export DOGRAH_WS_SCHEME="${DOGRAH_WS_SCHEME:-ws}"
+export DOGRAH_API_HOST="${DOGRAH_API_HOST:-api}"
+export DOGRAH_API_PORT="${DOGRAH_API_PORT:-8000}"
+export WS_CLIENT_NAME="${WS_CLIENT_NAME:-dograh}"
+export SIP_PORT="${SIP_PORT:-5060}"
+export RTP_START="${RTP_START:-10000}"
+export RTP_END="${RTP_END:-10100}"
+export LOCAL_NET="${LOCAL_NET:-}"
+
+# --- Required variables (fail closed) -------------------------------------
+REQUIRED_VARS=(
+  VERIMOR_SIP_USERNAME
+  VERIMOR_SIP_PASSWORD
+  VERIMOR_SIP_HOST
+  VERIMOR_DID
+  ARI_APP_NAME
+  ARI_PASSWORD
+  WS_CLIENT_NAME
+  EXTERNAL_SIGNALING_ADDRESS
+  EXTERNAL_MEDIA_ADDRESS
+)
+missing=()
+for v in "${REQUIRED_VARS[@]}"; do
+  if [ -z "${!v:-}" ]; then
+    missing+=("$v")
+  fi
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+  die "missing required environment variable(s): ${missing[*]} — set them in deploy/asterisk/.env"
+fi
+
+# --- Explicit substitution allowlist --------------------------------------
+# Only these variables are substituted. Anything else (Asterisk dialplan
+# variables such as ${EXTEN}) is left untouched in the rendered output.
+ALLOWLIST='${VERIMOR_SIP_USERNAME} ${VERIMOR_SIP_PASSWORD} ${VERIMOR_SIP_HOST} ${VERIMOR_SIP_PORT} ${VERIMOR_DID} ${VERIMOR_CALLERID} ${ARI_APP_NAME} ${ARI_PASSWORD} ${ARI_HTTP_PORT} ${DOGRAH_WS_SCHEME} ${DOGRAH_API_HOST} ${DOGRAH_API_PORT} ${WS_CLIENT_NAME} ${EXTERNAL_SIGNALING_ADDRESS} ${EXTERNAL_MEDIA_ADDRESS} ${LOCAL_NET} ${SIP_PORT} ${RTP_START} ${RTP_END}'
+
+[ -d "$CONF_TEMPLATE_DIR" ] || die "template dir not found: $CONF_TEMPLATE_DIR"
+
+shopt -s nullglob
+rendered=0
+for tpl in "$CONF_TEMPLATE_DIR"/*.template; do
+  base="$(basename "$tpl" .template)"
+  out="$CONF_OUT_DIR/$base"
+  # Render into a temp file first so a partial write never yields a broken conf.
+  tmp="$(mktemp "${out}.XXXXXX")"
+  envsubst "$ALLOWLIST" < "$tpl" > "$tmp"
+  mv "$tmp" "$out"
+  chmod 0640 "$out" 2>/dev/null || true
+  # The entrypoint runs as root before Asterisk drops to the asterisk user.
+  # Chown rendered configs so Asterisk (running as asterisk) can read them.
+  chown asterisk:asterisk "$out" 2>/dev/null || true
+  # Strip empty directives that envsubst can't remove (e.g. "local_net = "
+  # when LOCAL_NET is blank). An empty value directive can cause Asterisk to
+  # fail config parsing.
+  sed -i '/^[[:space:]]*[a-z_]\+[[:space:]]*=[[:space:]]*$/d' "$out"
+  log "rendered $(basename "$out")"
+  rendered=$((rendered + 1))
+done
+[ "$rendered" -gt 0 ] || die "no *.template files found in $CONF_TEMPLATE_DIR"
+
+log "configuration rendered ($rendered file(s)); starting Asterisk"
+exec "$@"

--- a/run_validation.sh
+++ b/run_validation.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export VERIMOR_SIP_USERNAME=testuser
+export VERIMOR_SIP_PASSWORD=testpass
+export VERIMOR_SIP_HOST=sip.verimor.com.tr
+export VERIMOR_SIP_PORT=5060
+export VERIMOR_DID=908500000000
+export VERIMOR_CALLERID=908500000000
+export ARI_APP_NAME=dograh
+export ARI_PASSWORD=testpass123
+export ARI_HTTP_PORT=8088
+export DOGRAH_WS_SCHEME=ws
+export DOGRAH_API_HOST=api
+export DOGRAH_API_PORT=8000
+export WS_CLIENT_NAME=dograh
+export EXTERNAL_SIGNALING_ADDRESS=203.0.113.10
+export EXTERNAL_MEDIA_ADDRESS=203.0.113.10
+export LOCAL_NET=""
+export SIP_PORT=5060
+export RTP_START=10000
+export RTP_END=10100
+export DOGRAH_NETWORK_NAME=dograh_app-network
+export ASTERISK_VERSION=22
+
+echo "=== Docker Compose Config Validation ==="
+docker compose -f /home/ubuntu/workspace/dograh/deploy/asterisk/docker-compose.asterisk.yaml config -q 2>&1
+echo "compose config OK (exit 0)"
+
+echo ""
+echo "=== Template Rendering Test (envsubst allowlist) ==="
+# Verify envsubst allowlist works with the entrypoint allowlist
+CONF_TEMPLATE_DIR="/home/ubuntu/workspace/dograh/deploy/asterisk/conf"
+CONF_OUT_DIR="/tmp/asterisk_test_render"
+mkdir -p "$CONF_OUT_DIR"
+
+ALLOWLIST='${VERIMOR_SIP_USERNAME} ${VERIMOR_SIP_PASSWORD} ${VERIMOR_SIP_HOST} ${VERIMOR_SIP_PORT} ${VERIMOR_DID} ${VERIMOR_CALLERID} ${ARI_APP_NAME} ${ARI_PASSWORD} ${ARI_HTTP_PORT} ${DOGRAH_WS_SCHEME} ${DOGRAH_API_HOST} ${DOGRAH_API_PORT} ${WS_CLIENT_NAME} ${EXTERNAL_SIGNALING_ADDRESS} ${EXTERNAL_MEDIA_ADDRESS} ${LOCAL_NET} ${SIP_PORT} ${RTP_START} ${RTP_END}'
+
+shopt -s nullglob
+for tpl in "$CONF_TEMPLATE_DIR"/*.template; do
+  base="$(basename "$tpl" .template)"
+  out="$CONF_OUT_DIR/$base"
+  envsubst "$ALLOWLIST" < "$tpl" > "$out"
+  echo "--- rendered: $base ---"
+  # Do not print rendered credentials or config values. The validation only
+  # needs to prove that the file was produced; later checks inspect syntax and
+  # placeholder preservation without echoing secret-like fields.
+  test -s "$out"
+  echo "rendered: $(basename "$out")"
+  echo ""
+done
+
+echo "=== Verify no unresolved operator vars remain ==="
+for f in "$CONF_OUT_DIR"/*.conf; do
+  # Asterisk dialplan variables (${EXTEN}, ${CALLERID(num)}, ${DEST}, ...)
+  # are intentionally preserved. Only deployment/operator variables must be
+  # fully rendered by the allowlist above.
+  if grep -Eq '\$\{(VERIMOR_|ARI_|DOGRAH_|WS_CLIENT_NAME|EXTERNAL_|LOCAL_NET|SIP_PORT|RTP_)' "$f"; then
+    echo "ERROR: unresolved operator variables in $(basename "$f")"
+    grep -n -E '\$\{(VERIMOR_|ARI_|DOGRAH_|WS_CLIENT_NAME|EXTERNAL_|LOCAL_NET|SIP_PORT|RTP_)' "$f"
+    exit 1
+  fi
+done
+echo "template render check complete (dialplan variables intentionally preserved)"


### PR DESCRIPTION
## Summary
- Added charset=utf-8 to Content-Type: text/event-stream header in MCP server responses

## Root Cause
Without charset in the Content-Type header, HTTP clients (Python requests) fall back to ISO-8859-1 for text/event-stream responses, corrupting non-ASCII characters (Turkish: ş, ğ, ü, ö, ı, ç).

## Fix
Single line change in mcp/server/streamable_http.py:
- CONTENT_TYPE_SSE = "text/event-stream; charset=utf-8"

## Testing
Verified with Turkish characters in workflow prompts:
- Before fix: response.text produced mojibake (Ä, Ã, Å)
- After fix: response.text correctly shows Turkish characters

## Impact
- No breaking changes
- Backward compatible with existing clients
- Fixes encoding for all non-ASCII text in SSE responses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes outbound PSTN calls through the configured PJSIP trunk and adds a self‑hosted Asterisk + Verimor overlay for ARI. Previously, bare numbers dialed as PJSIP/<digits> could misroute; we now dial PJSIP/<digits>@<endpoint> and support number formatting, improving reliability with Turkish carriers.

- Adds `pjsip_outbound_endpoint` (default: verimor) and `outbound_number_format` (default: e164; supports `national_zero`) to the ARI provider. Updates normalization to form the correct PJSIP endpoint string.
- Ships a standalone `deploy/asterisk` overlay (Dockerfile, compose, templates, entrypoints) that ensures required Asterisk modules load (`res_ari_events`, `chan_websocket`, `res_websocket_client`, PJSIP) and exposes ARI internally only.
- Adds focused outbound routing tests for `_normalize_sip_endpoint`; stubs legacy `pipecat` symbols for test collection only.
- Backward compatible: defaults preserve existing behavior if you do not enable the overlay or change provider settings.

**Review focus**
- ARI provider: new config fields and number normalization; verify `_normalize_sip_endpoint` cases in tests cover your expected dialing patterns.
- Templates: `websocket_client.conf.template` uses `type=websocket_client` and `uri=` per Asterisk 22; confirm environment substitution allowlist in `entrypoint.sh`.
- Compose: ARI on 8088 is not published; only the app network can reach it. RTP/SIP ports and external addresses come from `.env`.
- Docs: `README.md` and `MIGRATION_PLAN.md` describe module requirements and bring‑up; `REMEDIATION_REPORT.md` captures current runtime status.
- .gitignore: ignore `deploy/asterisk/.env`.

**Rollout**
- Optional overlay: copy `deploy/asterisk/.env.example` to `.env`, fill values, then `docker compose -f deploy/asterisk/docker-compose.asterisk.yaml --env-file deploy/asterisk/.env up -d --build`.
- In Dograh ARI provider config, set:
  - `ari_endpoint`: http://asterisk:8088
  - `app_name` and `app_password` to match `ARI_APP_NAME`/`ARI_PASSWORD`
  - `ws_client_name` to match `WS_CLIENT_NAME`
  - `pjsip_outbound_endpoint` to your trunk name (verimor by default)
  - `outbound_number_format` to `e164` or `national_zero` per carrier
- No database or API migrations required.

<sup>Written for commit 994ef6bdf8c41a46ceb0d9abe02c8a1c51a43fd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a self-hosted Asterisk/Verimor deployment overlay and configurable ARI outbound dialing. Runtime checks confirmed that RTP environment bounds remain unresolved in Asterisk’s media configuration, so the configured RTP port range is not applied at launch. The provided validation script also stops immediately when run from a normal checkout because it references a developer-specific filesystem path. These issues should be corrected before merging.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the Asterisk RTP configuration is rendered and the validation script derives paths from the checkout.

Two independent, non-security deployment failures were reproduced with focused executions against the checked-out entrypoint and validation script.

**Files Needing Attention:** `deploy/asterisk/Dockerfile` must place `rtp.conf` in the rendering flow, and `run_validation.sh` must replace hard-coded checkout paths with paths derived from the script location.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proofs for four posted P1 findings and prepared them for reviewer validation against the corresponding review comments.
- T-Rex ran the requested contract validations, but its local artifact references were not uploaded.
- Artifacts supporting the P1 finding proofs were created and attached to aid reviewer inspection.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **RTP environment bounds are never rendered into rtp.conf**

   - **Bug**
     - The image ships `rtp.conf` directly to `/etc/asterisk`, but the entrypoint only processes files ending in `.template`. Consequently, even explicit `RTP_START=20000` and `RTP_END=20025` remain as literal strings in `rtpstart` and `rtpend` when the entrypoint reaches Asterisk launch.
   - **Cause**
     - `deploy/asterisk/Dockerfile:23` copies `conf/rtp.conf` outside the template directory, while `deploy/asterisk/entrypoint.sh:65` iterates exclusively over `$CONF_TEMPLATE_DIR/*.template`.
   - **Fix**
     - Make RTP configuration part of the rendering pipeline (for example rename it to `conf/rtp.conf.template` and copy it with the other templates), or explicitly render `rtp.conf` using the same RTP allowlisted substitutions before Asterisk starts.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Validation script is tied to a specific checkout directory**

   - **Bug**
     - `run_validation.sh` cannot validate deployments from checkouts outside `/home/ubuntu/workspace/dograh`. From the actual `/home/user/repo` checkout, it exits in the initial compose-validation command before reaching template rendering.
   - **Cause**
     - Line 27 hard-codes the Compose file path, and line 33 hard-codes the template directory path, instead of deriving both from the script or repository location.
   - **Fix**
     - Derive a repository root from the script location (for example, `SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)`) and construct the compose and configuration paths relative to it.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: correct websocket\_client.conf type ..."](https://github.com/dograh-hq/dograh/commit/994ef6bdf8c41a46ceb0d9abe02c8a1c51a43fd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53431040)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->