### PR TITLE
fix(docker): add charset=utf-8 patch for MCP SSE Content-Type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,142 @@
+# syntax=docker/dockerfile:1
+# Multi-stage Dockerfile
+# Stage 1: Builder - Install Python dependencies into a venv via uv
+# (mirrors .devcontainer/Dockerfile's venv-builder stage).
+FROM python:3.13-slim AS builder
+
+WORKDIR /app
+
+# Install git in builder stage (needed for any pip install from git URLs)
+RUN apt-get update && apt-get install -y \
+    git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv (https://github.com/astral-sh/uv) for ~5-10x faster installs than pip.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+# Build the venv at the path it will live at in the final image, so shebangs
+# and console-scripts inside the venv reference the correct runtime location
+# after COPY --from.
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:$PATH
+RUN python -m venv "$VIRTUAL_ENV"
+
+# Layer 1: API deps. Cache invalidates only when requirements.txt changes.
+RUN --mount=type=bind,source=api/requirements.txt,target=/tmp/req.txt \
+    --mount=type=cache,target=/root/.cache/uv \
+    uv pip install -r /tmp/req.txt
+
+# Layer 2: pipecat deps. Cache invalidates when pipecat source changes.
+# After installing pipecat, two hardening tweaks:
+#   1. Swap opencv-python (pulled by pipecat[webrtc]) for opencv-python-headless.
+#      The non-headless build links against X11/Qt (libxcb*); without those
+#      shared libs in the image, `import cv2` fails at runtime.
+#   2. Pre-download NLTK's punkt_tab tokenizer so pipecat's text processing
+#      doesn't hit the network on first agent run. NLTK auto-finds it under
+#      sys.prefix/nltk_data, so it travels with the venv on COPY.
+RUN --mount=type=bind,source=pipecat,target=/tmp/pipecat,rw \
+    --mount=type=cache,target=/root/.cache/uv \
+    uv pip install '/tmp/pipecat[cartesia,deepgram,openai,elevenlabs,groq,google,azure,sarvam,soundfile,silero,webrtc,speechmatics,openrouter,camb,mcp,inworld,smallest]' \
+ && uv pip uninstall opencv-python \
+ && uv pip install opencv-python-headless \
+ && python -c "import nltk; nltk.download('punkt_tab', download_dir='/opt/venv/nltk_data', quiet=True)"
+
+# Layer 3: Patch mcp SSE charset
+# Fix: without charset=utf-8 in Content-Type, HTTP clients fallback to ISO-8859-1
+# and corrupt non-ASCII characters (Turkish: ş, ğ, ü, ö, ı, ç).
+RUN sed -i 's/CONTENT_TYPE_SSE = "text\/event-stream"/CONTENT_TYPE_SSE = "text\/event-stream; charset=utf-8"/' \
+    /opt/venv/lib/python3.13/site-packages/mcp/server/streamable_http.py
+
+# Strip cache files, test/example dirs, and type stubs from the venv
+RUN find /opt/venv -type f -name '*.pyc' -delete && \
+    find /opt/venv -type d -name '__pycache__' -prune -exec rm -rf {} + && \
+    find /opt/venv -type f -name '*.pyo' -delete && \
+    find /opt/venv -type d \( -name tests -o -name test -o -name examples \) -prune -exec rm -rf {} + && \
+    find /opt/venv -name '*.pyi' -delete
+
+# Stage 2: Node deps for ts_validator (built with full node:22-slim, only
+# node_modules is copied into the runner).
+FROM node:22-slim AS ts-deps
+WORKDIR /ts_validator
+COPY api/mcp_server/ts_validator/package*.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+# Stage 3: Static ffmpeg binary
+FROM debian:trixie-slim AS ffmpeg-static
+ARG TARGETARCH
+ARG BTBN_TAG=autobuild-2026-05-31-13-22
+ARG BTBN_REV=N-124714-g49a77d37be
+RUN set -eu ; \
+    apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates xz-utils ; \
+    rm -rf /var/lib/apt/lists/* ; \
+    case "${TARGETARCH}" in \
+      amd64) btbn_arch=linux64 ; \
+             sha256=ee052121296e6479325e09c6097d48e72a4af472d18c2b94388b5405dcde6cce ;; \
+      arm64) btbn_arch=linuxarm64 ; \
+             sha256=e97545305043794cdf7b698d713e29291464e0c35bb8e0f3ff1f62e4c56eedd6 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2 ; exit 1 ;; \
+    esac ; \
+    url="https://github.com/BtbN/FFmpeg-Builds/releases/download/${BTBN_TAG}/ffmpeg-${BTBN_REV}-${btbn_arch}-gpl.tar.xz" ; \
+    mkdir -p /tmp/ffmpeg ; cd /tmp/ffmpeg ; \
+    echo "Downloading ffmpeg (${BTBN_TAG}) from ${url}" ; \
+    curl -fsSL --connect-timeout 20 --speed-limit 1024 --speed-time 30 \
+         --max-time 600 --retry 3 --retry-delay 5 --retry-all-errors \
+         -o ffmpeg.tar.xz "${url}" ; \
+    echo "${sha256}  ffmpeg.tar.xz" | sha256sum -c - ; \
+    tar -xJf ffmpeg.tar.xz ; \
+    ffmpeg_bin="$(find /tmp/ffmpeg -type f -name ffmpeg | head -n1)" ; \
+    ffprobe_bin="$(find /tmp/ffmpeg -type f -name ffprobe | head -n1)" ; \
+    [ -n "${ffmpeg_bin}" ] && [ -n "${ffprobe_bin}" ] ; \
+    mv "${ffmpeg_bin}" "${ffprobe_bin}" /usr/local/bin/ ; \
+    chmod +x /usr/local/bin/ffmpeg /usr/local/bin/ffprobe ; \
+    rm -rf /tmp/ffmpeg
+
+# Stage 4: Runtime - Minimal image with only runtime dependencies
+FROM python:3.13-slim AS runner
+
+WORKDIR /app
+
+RUN groupadd --system dograh \
+ && useradd --system --gid dograh --no-log-init --home-dir /app --shell /usr/sbin/nologin dograh \
+ && chown dograh:dograh /app
+
+COPY --from=ffmpeg-static /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
+COPY --from=ffmpeg-static /usr/local/bin/ffprobe /usr/local/bin/ffprobe
+
+COPY --from=node:22-slim /usr/local/bin/node /usr/local/bin/node
+
+COPY --from=builder /opt/venv /opt/venv
+
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:$PATH
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+COPY --chown=dograh:dograh ./api ./api
+
+COPY --chown=dograh:dograh \
+     ./scripts/start_services_docker.sh \
+     ./scripts/run_migrate.sh \
+     ./scripts/run_web.sh \
+     ./scripts/run_arq_worker.sh \
+     ./scripts/run_ari_manager.sh \
+     ./scripts/run_campaign_orchestrator.sh \
+     ./scripts/drain_web.sh \
+     ./scripts/
+
+COPY --from=ts-deps --chown=dograh:dograh /ts_validator/node_modules ./api/mcp_server/ts_validator/node_modules
+
+COPY --chown=dograh:dograh ./docs ./docs
+
+ENV PYTHONPATH=/app
+
+ENV LOG_TO_FILE=false
+
+USER dograh
+
+EXPOSE 8000
+
+CMD ["./scripts/start_services_docker.sh"]


### PR DESCRIPTION
## Summary
Add  patch for MCP SSE Content-Type header during Docker build.

## Problem
Without charset in the Content-Type header, HTTP clients (Python requests) fall back to ISO-8859-1 for text/event-stream responses, corrupting non-ASCII characters (Turkish: ş, ğ, ü, ö, ı, ç).

## Fix
Dockerfile'da Error: typer is required. Install with 'pip install mcp[cli]' paketi kurulduktan sonra  dosyasına  ile tek satır patch uygulanır:



## Scope
- Sadece Dockerfile değişikliği
- Tek satır patch
- Başka hiçbir dosya etkilenmez

## Testing
- ✅ Build başarılı
- ✅ Container'da  doğrulandı
- ✅ Türkçe karakterler düzün çalışıyor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-ASCII corruption in `mcp` SSE responses by sending Content-Type as "text/event-stream; charset=utf-8" instead of "text/event-stream". Clients no longer default to ISO-8859-1 for SSE, so Turkish characters render correctly.

- Patch is a single `sed` line in the Dockerfile that updates `/opt/venv/lib/python3.13/site-packages/mcp/server/streamable_http.py` to include `; charset=utf-8`.
- Scope is Docker-only. No app code changes.
- Dockerfile is multi-stage: builds a venv with `uv`, installs API and `pipecat` deps, swaps to `opencv-python-headless`, pre-downloads NLTK `punkt_tab`, adds static `ffmpeg` (SHA-256 pinned), and copies Node 22 runtime for the TS validator.
- Risk: the patch path is tied to Python 3.13 and `mcp`’s module layout; version bumps may require updating the `sed` target.

- Rebuild and deploy the Docker image. Verify SSE responses advertise "text/event-stream; charset=utf-8" and non-ASCII text streams correctly.

<sup>Written for commit d6f7e8593f5c030e652282a17ea5a22b33c299a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The change adds an MCP SSE `charset=utf-8` patch to the new root Dockerfile. The published `dograh-api` image is still built from `api/Dockerfile`, which does not contain that patch, so released images will not include the intended response encoding correction.

<h3>Confidence Score: 4/5</h3>

Not safe to merge as the intended MCP response encoding fix is absent from the Dockerfile used for released API images.

An executable repository check confirmed both the workflow-to-Dockerfile selection and the missing equivalent patch in the selected Dockerfile.

**Files Needing Attention:** Add the MCP SSE charset patch to `api/Dockerfile`, or change `.github/workflows/docker-image.yml` to publish from the root `Dockerfile`.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proof for a posted P1 finding.
- T-Rex produced an additional proof for the posted P1 finding, including the executable MCP SSE image-path validation source and its validation output.
- T-Rex performed general contract validation and confirmed a patch in Dockerfile lines 45-49, noted an omission in api/Dockerfile lines 38-50, and reported that the check exited with RESULT=VERIFIED.

<a href="https://app.greptile.com/trex/runs/18945841/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `api/Dockerfile`, line 45 ([link](https://github.com/dograh-hq/dograh/blob/d6f7e8593f5c030e652282a17ea5a22b33c299a8/api/Dockerfile#L45)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Published dograh-api image excludes the MCP SSE charset patch**

   - **Bug**
     - The patch exists only in the root `Dockerfile` at lines 45-49, but the image workflow's `dograh-api` matrix entry selects `api/Dockerfile` at `.github/workflows/docker-image.yml:65-67`. `api/Dockerfile:38-50` contains no `charset=utf-8` patch, so published API images do not receive the intended Content-Type correction.
   - **Cause**
     - The change was applied to a Dockerfile that is not selected by the `dograh-api` CI image build matrix.
   - **Fix**
     - Add the equivalent MCP SSE `sed` patch to `api/Dockerfile` after pipecat/MCP installation, or change the publishing workflow to build the Dockerfile that contains the patch.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Executable MCP SSE image-path validation source](https://app.greptile.com/trex/artifacts/753c7569-e3b0-48ab-8d0f-cbf524a4d3d0)**

   - Captured source of the executable assertion that reads the workflow-selected Dockerfile and checks both Dockerfiles; takeaway: the validation explicitly verifies the publication configuration path.

   **[MCP SSE image-path validation output](https://app.greptile.com/trex/artifacts/7b5245bc-8a99-48d3-89e3-e710d28dc233)**

   - Output from running \`./trex-artifacts/mcp-sse-image-path-check.sh\` in \`/home/user/repo\`, exiting 0 with the selected Dockerfile and missing-patch result; takeaway: CI selects \`api/Dockerfile\` and it lacks the root-only charset patch.

   <a href="https://app.greptile.com/trex/runs/18945841/artifacts?artifact=753c7569-e3b0-48ab-8d0f-cbf524a4d3d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(docker): add charset=utf-8 patch for..."](https://github.com/dograh-hq/dograh/commit/d6f7e8593f5c030e652282a17ea5a22b33c299a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53440775)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->