### PR TITLE
fix(api): flag dangling tool refs at publish and fail dead text-chat turns

### DIFF
--- a/api/services/workflow/text_chat_session_service.py
+++ b/api/services/workflow/text_chat_session_service.py
@@ -274,6 +274,25 @@ async def execute_pending_text_chat_turn(
             f"Failed to execute text chat assistant turn: {e}"
         ) from e
 
+    # A user-message turn that produced no assistant text and did not complete
+    # the call is dead air: the turn used to be finalized as "completed" with a
+    # null assistant_message, leaving the visitor staring at silence with no
+    # error and no retry. Surface it as a failed turn instead.
+    pending_turn = session_data["turns"][-1]
+    if (
+        pending_turn.get("user_message") is not None
+        and not execution.assistant_text
+        and not execution.is_completed
+    ):
+        await _mark_pending_turn_failed(
+            run_id=run_id,
+            text_session=text_session,
+            error_message="Assistant produced no response for this turn",
+        )
+        raise TextChatSessionExecutionError(
+            "Failed to execute text chat assistant turn: "
+            "the model returned an empty response"
+        )
     completed_session_data = normalize_text_chat_session_data(text_session.session_data)
     completed_turns = list(completed_session_data.get("turns") or [])
     if not completed_turns or completed_turns[-1].get("status") != "pending":

--- a/api/services/workflow/tool_name_validation.py
+++ b/api/services/workflow/tool_name_validation.py
@@ -53,12 +53,13 @@ async def validate_workflow_tool_name_collisions(
         sorted(all_tool_uuids),
         organization_id,
     )
+    resolved_tool_uuids = {tool.tool_uuid for tool in tools}
     tools_by_uuid = {
         tool.tool_uuid: tool
         for tool in tools
         if tool.category not in _DYNAMIC_SCHEMA_CATEGORIES
     }
-
+ 
     custom_tools_by_node: dict[str, dict[str, list[Any]]] = {}
     errors: list[WorkflowError] = []
     for node_id, tool_uuids in tool_uuids_by_node.items():
@@ -68,6 +69,25 @@ async def validate_workflow_tool_name_collisions(
             if tool is not None:
                 by_function_name[custom_tool_function_name(tool.name)].append(tool)
         custom_tools_by_node[node_id] = by_function_name
+
+        # get_tools_by_uuids only returns ACTIVE tools, and the runtime drops
+        # anything it does not resolve — silently, with no publish-time signal.
+        # Flag dangling references (archived, deleted, or cross-org) here so
+        # saving/publishing fails loudly instead of shipping an agent whose
+        # tools never register.
+        for tool_uuid in sorted(tool_uuids - resolved_tool_uuids):
+            errors.append(
+                WorkflowError(
+                    kind=ItemKind.node,
+                    id=node_id,
+                    field="data.tool_uuids",
+                    message=(
+                        f'Tool "{tool_uuid}" does not exist or is archived, so '
+                        "the agent cannot call it. Restore the tool or remove "
+                        "it from this node."
+                    ),
+                )
+            )
 
         for function_name, matching_tools in by_function_name.items():
             if len(matching_tools) < 2:

--- a/api/tests/test_text_chat_session_service.py
+++ b/api/tests/test_text_chat_session_service.py
@@ -203,6 +203,157 @@ async def test_completed_pending_turn_enqueues_workflow_completion(monkeypatch):
     upload_transcript.assert_awaited_once()
     enqueue_completion.assert_awaited_once_with(42)
 
+@pytest.mark.asyncio
+async def test_user_message_turn_with_empty_reply_fails_loudly(monkeypatch):
+    """A user-message turn whose model output is empty must not be finalized
+    as "completed" with a null assistant_message — that is silent dead air."""
+    session = SimpleNamespace(
+        revision=3,
+        created_at=datetime.now(UTC),
+        session_data={
+            "status": "pending_assistant_turn",
+            "turns": [
+                {
+                    "id": "turn-1",
+                    "status": "pending",
+                    "created_at": "2026-08-05T00:00:00+00:00",
+                    "user_message": {
+                        "text": "10am works",
+                        "created_at": "2026-08-05T00:00:00+00:00",
+                    },
+                    "assistant_message": None,
+                    "events": [],
+                    "usage": {},
+                }
+            ],
+        },
+        checkpoint={},
+        workflow_run=SimpleNamespace(
+            usage_info={},
+            is_completed=False,
+            created_at=datetime.now(UTC),
+        ),
+    )
+    execution = SimpleNamespace(
+        assistant_text=None,
+        assistant_created_at="2026-08-05T00:00:01+00:00",
+        events=[],
+        usage={},
+        checkpoint={},
+        initial_context={},
+        gathered_context={},
+        state="running",
+        is_completed=False,
+    )
+    mark_failed = AsyncMock()
+
+    monkeypatch.setattr(
+        text_chat_session_service,
+        "execute_text_chat_pending_turn",
+        AsyncMock(return_value=execution),
+    )
+    monkeypatch.setattr(
+        text_chat_session_service,
+        "_mark_pending_turn_failed",
+        mark_failed,
+    )
+
+    with pytest.raises(TextChatSessionExecutionError, match="empty response"):
+        await execute_pending_text_chat_turn(
+            workflow_id=2,
+            run_id=42,
+            text_session=session,
+        )
+
+    mark_failed.assert_awaited_once()
+    assert (
+        mark_failed.await_args.kwargs["error_message"]
+        == "Assistant produced no response for this turn"
+    )
+
+
+@pytest.mark.asyncio
+async def test_opening_turn_without_llm_text_still_completes(monkeypatch):
+    """Opening turns (user_message=None) may legitimately produce no text —
+    e.g. a node with no greeting and generate_if_no_greeting=False. Those
+    must keep finalizing normally, not fail."""
+    session = SimpleNamespace(
+        revision=3,
+        created_at=datetime.now(UTC),
+        session_data={
+            "status": "pending_assistant_turn",
+            "turns": [
+                {
+                    "id": "turn-1",
+                    "status": "pending",
+                    "created_at": "2026-08-05T00:00:00+00:00",
+                    "user_message": None,
+                    "assistant_message": None,
+                    "events": [],
+                    "usage": {},
+                }
+            ],
+        },
+        checkpoint={},
+        workflow_run=SimpleNamespace(
+            usage_info={},
+            is_completed=False,
+            created_at=datetime.now(UTC),
+        ),
+    )
+    execution = SimpleNamespace(
+        assistant_text=None,
+        assistant_created_at="2026-08-05T00:00:01+00:00",
+        events=[],
+        usage={"call_duration_seconds": 1},
+        checkpoint={"current_node_id": "1"},
+        initial_context={},
+        gathered_context={},
+        state="running",
+        is_completed=False,
+    )
+    update_text_session = AsyncMock()
+    update_run = AsyncMock()
+    reloaded = SimpleNamespace(workflow_run=SimpleNamespace(is_completed=False))
+
+    monkeypatch.setattr(
+        text_chat_session_service,
+        "execute_text_chat_pending_turn",
+        AsyncMock(return_value=execution),
+    )
+    monkeypatch.setattr(
+        text_chat_session_service.db_client,
+        "update_workflow_run_text_session",
+        update_text_session,
+    )
+    monkeypatch.setattr(
+        text_chat_session_service.db_client,
+        "update_workflow_run",
+        update_run,
+    )
+    monkeypatch.setattr(
+        text_chat_session_service,
+        "_reload_text_chat_session",
+        AsyncMock(return_value=reloaded),
+    )
+    monkeypatch.setattr(
+        text_chat_session_service,
+        "_mark_pending_turn_failed",
+        AsyncMock(),
+    )
+
+    result = await execute_pending_text_chat_turn(
+        workflow_id=2,
+        run_id=42,
+        text_session=session,
+    )
+
+    assert result is reloaded
+    persisted_session = update_text_session.await_args.kwargs["session_data"]
+    assert persisted_session["turns"][-1]["status"] == "completed"
+    assert persisted_session["turns"][-1]["assistant_message"] is None
+    assert persisted_session["status"] == "idle"
+
 
 @pytest.mark.asyncio
 async def test_complete_text_chat_session_marks_user_hangup_and_enqueues(monkeypatch):

--- a/api/tests/test_workflow_tool_name_validation.py
+++ b/api/tests/test_workflow_tool_name_validation.py
@@ -88,3 +88,45 @@ async def test_custom_tool_collision_is_scoped_to_its_node():
         errors = await validate_workflow_tool_name_collisions(definition, 11)
 
     assert errors == []
+
+
+
+@pytest.mark.asyncio
+async def test_unresolved_tool_reference_is_flagged():
+    definition = {
+        "nodes": [
+            {
+                "id": "agent-1",
+                "data": {"tool_uuids": ["tool-1", "tool-archived"]},
+            }
+        ],
+        "edges": [],
+    }
+    tools = [
+        SimpleNamespace(
+            tool_uuid="tool-1",
+            name="Book Appointment",
+            category="http_api",
+        ),
+        # "tool-archived" deliberately absent: get_tools_by_uuids only returns
+        # ACTIVE tools, so archived tools resolve to nothing.
+    ]
+
+    with patch(
+        "api.services.workflow.tool_name_validation.db_client.get_tools_by_uuids",
+        AsyncMock(return_value=tools),
+    ):
+        errors = await validate_workflow_tool_name_collisions(definition, 11)
+
+    assert errors == [
+        {
+            "kind": "node",
+            "id": "agent-1",
+            "field": "data.tool_uuids",
+            "message": (
+                'Tool "tool-archived" does not exist or is archived, so '
+                "the agent cannot call it. Restore the tool or remove "
+                "it from this node."
+            ),
+        }
+    ]


### PR DESCRIPTION
## Problem

Two silent-failure modes found while debugging a self-hosted deployment's demo booking agent:

**1. Archived tools drop out of the agent silently.** `get_tools_by_uuids` only returns `ACTIVE` tools, and both tool-schema registration (`pipecat_engine_context_composer` / `pipecat_engine_custom_tools`) and the publish-time validation gate resolve `data.tool_uuids` through it. Archiving a tool that a workflow still references therefore:

- removes it from the LLM's function registry with no warning, so the model **hallucinates tool results** instead of calling them (observed: the agent invented a booking reference `A1B2C3` while the real webhook returns `BK-…`), and
- passes the publish validation gate, so nothing surfaces until the agent misbehaves in production.

**2. Empty model output finalizes as a silent dead turn.** In `execute_pending_text_chat_turn`, a turn is unconditionally marked `completed` and `assistant_message` is set to `None` whenever `execution.assistant_text` is falsy. When the model returns empty content (e.g. at the tool-call decision point in a booking flow), the visitor gets dead air: no reply, no error, no retry. Reproduced 9 dead turns out of 20 on a 4-turn booking script; the turns stay `completed`/`assistant_message: null` in persisted session state indefinitely.

## Changes

- `tool_name_validation.py`: report a `WorkflowError` for every `tool_uuid` that does not resolve to an ACTIVE tool (archived, deleted, or cross-org), so save/publish fails loudly with the node id and uuid. This rides the existing blocking validation used by the REST routes and MCP save paths.
- `text_chat_session_service.py`: when a **user-message** turn yields no assistant text and the call is not completed, mark the turn `failed` with an `execution_error` event and raise `TextChatSessionExecutionError` (→ HTTP 500 with detail) instead of finalizing silent dead air. Opening turns (`user_message is None`) may legitimately produce no text (no greeting, `generate_if_no_greeting=False`) and still finalize normally. After a failed turn the session remains usable — the messages route only rejects `completed` sessions, and the next message resumes from the last completed turn's checkpoint.

## Verification

On a live self-hosted instance (fork of this repo at v1.43/1.44):

- Before: 9/20 scripted turns ended `completed` with `assistant_message: null`; booking tool never registered; LLM fabricated booking references.
- After unarchiving the tool (config-level; code unchanged): 20/20 turns complete, `tool_call_started`/`tool_call_result` events present, real `BK-…` booking ids from the webhook, across the base agent and two clones (one Hindi).

Tests (both against this branch's base):

- `tests/test_workflow_tool_name_validation.py` — new `test_unresolved_tool_reference_is_flagged` (dangling uuid → blocking error; resolved sibling unaffected).
- `tests/test_text_chat_session_service.py` — new `test_user_message_turn_with_empty_reply_fails_loudly` and `test_opening_turn_without_llm_text_still_completes` (boundary: greeting-less openings still persist normally).
- Full files pass: 17 + 38 (adjacent `test_public_embed_chat.py`, `test_workflow_create_route.py`) green via `pytest`, CI env.

## Notes

- The runtime drop of archived tools is pre-existing behavior; this PR only makes it impossible to publish into that state and impossible to confuse dead air with a completed turn.
- Fork sync: `0repeat-lab/dograh` syncs from this repo daily, so once merged the fix propagates to that deployment's base automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks publishing workflows with dangling tool references and fails dead text-chat turns instead of finalizing silent “completed” turns. Previously, archived/deleted tools were silently dropped at runtime and user-message turns with empty model output were marked completed with no reply; now publish/save raises a validation error and such turns are marked failed and surface an error.

- Tool validation: For each `tool_uuid` that does not resolve to an ACTIVE tool, publish/save returns a `WorkflowError` on the node field `data.tool_uuids`.
- Text chat: If a user-message turn yields no assistant text and the call is not completed, the turn is marked failed and the server raises an execution error. Opening turns without a greeting may still complete with no assistant text.

**Rollout/Migration**
- Workflows that reference archived/deleted/cross-org tools will not save or publish. Unarchive the tool or remove it from the node. 
- Clients must handle an HTTP 500 for failed user-message turns and allow the user to retry.

<sup>Written for commit 070917a66c3dad4b9056a21a3d87ee6a3bc0879c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change rejects workflow references to unavailable tools and treats user-message turns with an empty model response as failed rather than silently completing them.

A failed empty-response turn can discard checkpoint and tool-event state that was produced before the response became empty. The next user message can then resume from an older checkpoint and repeat a non-idempotent external operation, such as creating a duplicate booking or write. Do not merge until failed turns retain replay-safe execution state.

### T-Rex validation blocked

The focused regression could not run because the prepared Python 3.13 interpreter at `/tmp/trex-setup/api-venv/bin/python` was missing. The captured check targets a tool-executed, empty-response turn and its follow-up retry path.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until the failed-turn path persists the execution checkpoint and events needed to prevent repeated external actions.

There is one independent non-security P1 finding, which maps to a score of 4. The affected control flow is directly visible, but the focused runtime regression could not start because its required Python interpreter was unavailable.

**Files Needing Attention:** api/services/workflow/text_chat_session_service.py needs to preserve execution events and checkpoint state when an empty user-turn response is marked failed.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to start an isolated regression command but could not proceed because the prepared Python interpreter in the regression environment was missing.
- The regression source was captured as a mock of a non-idempotent tool action followed by an empty assistant response, and the test checked whether failed-turn persistence retained the tool event and checkpoint.

<a href="https://app.greptile.com/trex/runs/19022971/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): flag dangling tool refs at pub..."](https://github.com/dograh-hq/dograh/commit/070917a66c3dad4b9056a21a3d87ee6a3bc0879c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53597626)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->