### PR TITLE
Adds asterisk call ID to initial_context

### DIFF
--- a/api/services/telephony/ari_manager.py
+++ b/api/services/telephony/ari_manager.py
@@ -887,6 +887,7 @@ class ARIConnection:
                     "provider": "ari",
                     "telephony_configuration_id": self.telephony_configuration_id,
                     "external_pbx_call": external_pbx_call,
+                    "call_id": call_id,
                 },
                 gathered_context={
                     "call_id": call_id,


### PR DESCRIPTION
When working with the agents, for some reason the call_id would not populate in the gathered_context.  I believe this gets filled in later in the call.  I have a tool call that requires the call_id in order to interact with the ARI directly but was unable to do so.  I feel like this is a very important variable to have in the initial_context since without it there is no way to associate an inbound channel with an exiting call that was transferred into the system.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `call_id` to `initial_context` for inbound ARI calls so tools and agents can access it immediately. Previously `initial_context` omitted `call_id`; now both `initial_context` and `gathered_context` include it, enabling direct ARI interactions and proper association of inbound channels with transferred calls.

- Review: Change is in `api/services/telephony/ari_manager.py` within `_handle_inbound_stasis_start`, adding `call_id` to `initial_context`. Verify any consumers reading `initial_context` handle the new `call_id` field.
- Migration: If you enforce a strict schema for `initial_context`, add `call_id` to the allowed fields.

<sup>Written for commit 2a57a06c142edc9070fb2fd317bc1a7575757f9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the inbound Asterisk channel identifier to a workflow run’s initial context while preserving the existing gathered-context value. A mocked inbound StasisStart execution compared the parent revision with this change: the updated code created one workflow run with both `initial_context.call_id` and `gathered_context.call_id` set to the stable handler channel ID, rather than the mismatching event value. No defects were found; the change is safe to merge.

<h3>Confidence Score: 5/5</h3>

The inbound ARI workflow-run creation path correctly exposes the stable channel identifier in both initial and gathered context.

A focused mocked execution exercised the changed inbound-call path, captured the workflow-run creation arguments, and confirmed the new context value matches the established gathered-context identifier.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused ARI inbound call validation harness was executed against the parent revision and the PR revision to inspect how call IDs flow into workflow runs.
- Before the PR, the inbound ARI workflow-run creation showed gathered\_context.call\_id set to stable-ari-channel-42 and initial\_context.call\_id was null.
- After the PR, the inbound ARI workflow-run creation showed both gathered\_context.call\_id and initial\_context.call\_id equal to stable-ari-channel-42.
- This confirms that the initial context now uses the stable handler channel identifier.

<a href="https://app.greptile.com/trex/runs/19061708/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Adds asterisk call ID to initial\_context"](https://github.com/dograh-hq/dograh/commit/2a57a06c142edc9070fb2fd317bc1a7575757f9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53675859)</sub>

<!-- /greptile_comment -->