### PR TITLE
fix: Enforce met node transition conditions

### DIFF
--- a/api/services/workflow/pipecat_engine_context_composer.py
+++ b/api/services/workflow/pipecat_engine_context_composer.py
@@ -45,6 +45,10 @@ RULES:
 - Use ▸ when you need to generate a dynamic, contextual response.
 - *NEVER* mix modes in a single response, since we rely on the markers to decide whether to play using TTS or Pre-recorded audio."""
 
+NODE_TRANSITION_INSTRUCTIONS = """\
+NODE TRANSITION INSTRUCTIONS - MANDATORY:
+Evaluate the live conversation against the conditions described by the available transition tools. As soon as a condition is met, immediately call the matching transition tool."""
+
 
 def compose_system_prompt_for_node(
     *,
@@ -55,9 +59,9 @@ def compose_system_prompt_for_node(
 ) -> str:
     """Compose the full system prompt text for a workflow node.
 
-    Combines the global prompt, node-specific prompt, and (when recordings
-    are enabled anywhere in the workflow) the recording response mode
-    instructions into a single string.
+    Combines the global prompt, node-specific prompt, transition instructions,
+    and (when recordings are enabled anywhere in the workflow) the recording
+    response mode instructions into a single string.
 
     Args:
         node: The workflow node to compose the prompt for.
@@ -76,6 +80,9 @@ def compose_system_prompt_for_node(
     formatted_node_prompt = format_prompt(node.prompt)
 
     parts = [p for p in (global_prompt, formatted_node_prompt) if p]
+
+    if node.out_edges:
+        parts.append(NODE_TRANSITION_INSTRUCTIONS)
 
     if has_recordings and "RECORDING_ID:" in formatted_node_prompt:
         parts.append(RECORDING_RESPONSE_MODE_INSTRUCTIONS)

--- a/api/tests/test_pipecat_engine_context_composer.py
+++ b/api/tests/test_pipecat_engine_context_composer.py
@@ -1,0 +1,126 @@
+from types import SimpleNamespace
+
+import pytest
+
+from api.services.workflow.pipecat_engine_context_composer import (
+    RECORDING_RESPONSE_MODE_INSTRUCTIONS,
+    compose_functions_for_node,
+    compose_system_prompt_for_node,
+)
+
+
+TRANSITION_GUIDANCE = """\
+NODE TRANSITION INSTRUCTIONS - MANDATORY:
+Evaluate the live conversation against the conditions described by the available transition tools. As soon as a condition is met, immediately call the matching transition tool."""
+
+
+def make_edge(name: str, condition: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        condition=condition,
+        get_function_name=lambda: name,
+    )
+
+
+def make_node(
+    prompt: str,
+    *,
+    out_edges: list[SimpleNamespace],
+    add_global_prompt: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        prompt=prompt,
+        out_edges=out_edges,
+        add_global_prompt=add_global_prompt,
+        document_uuids=None,
+        tool_uuids=None,
+    )
+
+
+def make_workflow(global_prompt: str | None = None) -> SimpleNamespace:
+    global_node_id = "global" if global_prompt else None
+    nodes = {"global": SimpleNamespace(prompt=global_prompt)} if global_prompt else {}
+    return SimpleNamespace(global_node_id=global_node_id, nodes=nodes)
+
+
+def test_prompt_with_outgoing_edge_includes_mandatory_transition_guidance():
+    node = make_node(
+        "Help the caller schedule an appointment.",
+        out_edges=[make_edge("confirm_appointment", "The appointment is confirmed")],
+    )
+
+    prompt = compose_system_prompt_for_node(
+        node=node,
+        workflow=make_workflow(),
+        format_prompt=lambda value: value,
+        has_recordings=False,
+    )
+
+    assert prompt == (
+        f"Help the caller schedule an appointment.\n\n{TRANSITION_GUIDANCE}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_multiple_edges_keep_conditions_in_transition_tool_schemas():
+    conditions = [
+        "The caller wants help with billing",
+        "The caller wants technical support",
+    ]
+    node = make_node(
+        "Determine why the caller contacted us.",
+        out_edges=[
+            make_edge("billing", conditions[0]),
+            make_edge("technical_support", conditions[1]),
+        ],
+    )
+
+    prompt = compose_system_prompt_for_node(
+        node=node,
+        workflow=make_workflow(),
+        format_prompt=lambda value: value,
+        has_recordings=False,
+    )
+    functions = await compose_functions_for_node(
+        node=node,
+        custom_tool_manager=None,
+    )
+
+    assert TRANSITION_GUIDANCE in prompt
+    assert all(condition not in prompt for condition in conditions)
+    assert [function.description for function in functions] == conditions
+
+
+def test_prompt_without_outgoing_edges_omits_transition_guidance():
+    node = make_node("Thank the caller and end the call.", out_edges=[])
+
+    prompt = compose_system_prompt_for_node(
+        node=node,
+        workflow=make_workflow(),
+        format_prompt=lambda value: value,
+        has_recordings=False,
+    )
+
+    assert prompt == "Thank the caller and end the call."
+    assert TRANSITION_GUIDANCE not in prompt
+
+
+def test_transition_guidance_preserves_global_node_and_recording_order():
+    node = make_node(
+        "Play RECORDING_ID: greeting when the caller answers.",
+        out_edges=[make_edge("continue", "The greeting is complete")],
+        add_global_prompt=True,
+    )
+
+    prompt = compose_system_prompt_for_node(
+        node=node,
+        workflow=make_workflow("Always be concise."),
+        format_prompt=lambda value: value,
+        has_recordings=True,
+    )
+
+    global_index = prompt.index("Always be concise.")
+    node_index = prompt.index("Play RECORDING_ID: greeting when the caller answers.")
+    transition_index = prompt.index(TRANSITION_GUIDANCE)
+    recording_index = prompt.index(RECORDING_RESPONSE_MODE_INSTRUCTIONS)
+
+    assert global_index < node_index < transition_index < recording_index


### PR DESCRIPTION
Multi-node agents can remain on the current node after an outgoing edge condition has become true, even when the node prompt also directs the model to move on. The runtime currently exposes each edge condition as a transition tool description, but the composed system prompt contains no explicit rule requiring the model to call a matching transition tool. This makes a documented workflow invariant depend on the model inferring mandatory routing behavior from tool metadata alone. Extraction variables do not provide a routing signal here: project documentation says they are collected after a node completes and are not available in node prompts.

## Summary by cubic

Extend node system-prompt composition with a concise, provider-neutral transition instruction whenever the active node has outgoing edges. The instruction should tell the model to evaluate the live conversation against the available transition conditions and immediately call the matching transition tool once a condition is met, without hardcoding any issue-specific condition or coupling routing to post-node extraction. Keep the existing global prompt, node prompt, and recording-mode instruction ordering intact, and do not add transition guidance to nodes with no outgoing edges.

## T-Rex validation blocked

- Compose a prompt for a node with one outgoing edge and verify the node prompt plus mandatory transition guidance are present.
- Compose a prompt for a node with multiple outgoing edges and verify the guidance remains generic while the edge-specific conditions continue to live in the generated tool schemas.
- Compose a prompt for an end or otherwise edge-less node and verify no transition guidance is appended.
- Compose a prompt with global and recording-mode content enabled and verify the new guidance does not replace or reorder those existing instructions.

Fixes #641

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mandatory transition instruction to node system prompts so agents immediately call a matching transition tool when an outgoing edge condition is met. Previously, prompts did not require a transition call, so agents could stay on the current node after a condition became true.

- Appends `NODE_TRANSITION_INSTRUCTIONS` only when the node has outgoing edges; end or edge-less nodes remain unchanged.
- Preserves prompt ordering: global prompt → node prompt → transition instruction → recording-mode instructions.
- Leaves edge-specific conditions in transition tool schemas; no routing via extraction variables or post-node flow.
- Tests cover single/multiple edges, absence of edges, and prompt ordering to validate behavior.

Fixes Linear issue #641.

<sup>Written for commit a534949c5b87c001a26558177f407f0fbc1d4772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds mandatory transition guidance to workflow-node prompts when outgoing transitions are available. It preserves the existing global prompt, node prompt, and recording-mode instruction order, while keeping transition conditions in the corresponding tool schemas.

A focused runtime harness confirmed that multi-edge nodes receive ordered transition guidance and retain both condition-bearing transition tools. Nodes without outgoing edges receive neither transition guidance nor transition tools. No defects were found, and the change is safe to merge.

### T-Rex validation blocked
The repository’s focused pytest target could not complete collection because the `dotenv` package is missing from the environment. The standalone composition harness executed successfully against the changed implementation.

<h3>Confidence Score: 5/5</h3>

The verified prompt and tool-composition behavior matches the intended workflow transition behavior and is safe to merge.

No independent defects remain. An executed harness loaded the changed composer and exercised prompt ordering, multiple transition conditions, and edge-less nodes; the unavailable pytest collection does not contradict those observed results.

**Files Needing Attention:** No files need follow-up changes. The focused pytest environment needs the missing `dotenv` package before the repository test can be run there.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the transition-composition harness for the PR's Pipecat engine context composer and confirmed the runtime prompt order global → node → transition → recording, with guidance and tools appearing only where transitions exist.
- Verified the exact harness run reported global=0, node=23, transition=76, recording=296, and TRANSITION\_GUIDANCE\_PRESENT=True, confirming the ordered prompt sequence and the presence of two condition-bearing transition tools; this shows the PR preserves the runtime schemas.
- The focused pytest run was blocked by a missing dotenv dependency, preventing test execution and explaining why the runtime path could not complete in this environment.

<a href="https://app.greptile.com/trex/runs/19082604/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Enforce met node transition conditi..."](https://github.com/dograh-hq/dograh/commit/a534949c5b87c001a26558177f407f0fbc1d4772) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53719851)</sub>

<!-- /greptile_comment -->