### PR TITLE
feat(integrations): let a package contribute context to a call

### DIFF
--- a/api/services/integrations/AGENTS.md
+++ b/api/services/integrations/AGENTS.md
@@ -107,6 +107,33 @@ Integration nodes are resolved dynamically through:
 `RFNodeDTO` validates integration nodes by `type` through the registry. That is
 the intended extension path.
 
+## Pre-Call Path
+
+The runtime and completion hooks below let an integration *observe* a call and
+deliver data afterwards. `create_call_capabilities(...)` is the other direction:
+contributing to the call before it starts.
+
+Implement it in `capabilities.py` and return an `IntegrationCallCapabilities`,
+or `None` to opt out of this call. Both fields are optional:
+
+- `run_pre_call()` — async, returns a dict merged into `initial_context` before
+  the first agent turn, so node prompts can reference the values as
+  `{{variable}}`. It rides the same machinery as the start node's pre-call
+  fetch: fired concurrently with the rest of pipeline setup, awaited with the
+  ringer, and bounded by `PRE_CALL_FETCH_TIMEOUT_SECONDS`.
+- `prompt_addendum(call_context_vars)` — returns text appended to every node's
+  system prompt, the same way recording-mode instructions are appended. Return
+  `None` to append nothing.
+
+Both are best-effort by design. A hook that hangs is cancelled at the budget, one
+that raises is logged, and a non-dict result is ignored — in every case the call
+proceeds without the enrichment. Do not use this path for anything the call
+cannot start without.
+
+The generic wiring lives in `run_pipeline.py` (fires the hooks and sets the
+capabilities on the engine), `event_handlers.py` (awaits and merges them), and
+`pipecat_engine_context_composer.py` (appends the addenda).
+
 ## Live Call Path
 
 If the integration needs live call data, implement `create_runtime_sessions(...)`

--- a/api/services/integrations/__init__.py
+++ b/api/services/integrations/__init__.py
@@ -1,4 +1,5 @@
 from api.services.integrations.base import (
+    IntegrationCallCapabilities,
     IntegrationCompletionContext,
     IntegrationNodeRegistration,
     IntegrationPackageSpec,
@@ -9,6 +10,7 @@ from api.services.integrations.registry import (
     all_node_specs,
     all_packages,
     all_routers,
+    create_call_capabilities,
     create_runtime_sessions,
     get_node_data_model,
     get_node_registration,
@@ -20,6 +22,7 @@ from api.services.integrations.registry import (
 )
 
 __all__ = [
+    "IntegrationCallCapabilities",
     "IntegrationCompletionContext",
     "IntegrationNodeRegistration",
     "IntegrationPackageSpec",
@@ -28,6 +31,7 @@ __all__ = [
     "all_node_specs",
     "all_packages",
     "all_routers",
+    "create_call_capabilities",
     "create_runtime_sessions",
     "get_node_data_model",
     "get_node_registration",

--- a/api/services/integrations/base.py
+++ b/api/services/integrations/base.py
@@ -79,5 +79,7 @@ class IntegrationPackageSpec:
     nodes: tuple[IntegrationNodeRegistration, ...] = ()
     routers: tuple[APIRouter, ...] = ()
     create_runtime_sessions: RuntimeFactory | None = None
-    create_call_capabilities: CallCapabilitiesFactory | None = None
     run_completion: CompletionHandler | None = None
+    # Appended last on purpose: inserting it earlier would shift the meaning of
+    # every positional argument after it for packages already constructing this.
+    create_call_capabilities: CallCapabilitiesFactory | None = None

--- a/api/services/integrations/base.py
+++ b/api/services/integrations/base.py
@@ -33,6 +33,15 @@ class IntegrationRuntimeContext:
 
 
 @dataclass(frozen=True)
+class IntegrationCallCapabilities:
+    # What an integration contributes to a call, rather than collects from it.
+    # Both fields are optional. See AGENTS.md "Pre-Call Path".
+    name: str
+    run_pre_call: Callable[[], Awaitable[dict[str, Any]]] | None = None
+    prompt_addendum: Callable[[dict[str, Any]], str | None] | None = None
+
+
+@dataclass(frozen=True)
 class IntegrationCompletionContext:
     workflow_run_id: int
     workflow_run: Any
@@ -45,6 +54,10 @@ class IntegrationCompletionContext:
 RuntimeFactory = Callable[
     [IntegrationRuntimeContext],
     list[IntegrationRuntimeSession],
+]
+CallCapabilitiesFactory = Callable[
+    [IntegrationRuntimeContext],
+    IntegrationCallCapabilities | None,
 ]
 CompletionHandler = Callable[
     [list[dict[str, Any]], IntegrationCompletionContext],
@@ -66,4 +79,5 @@ class IntegrationPackageSpec:
     nodes: tuple[IntegrationNodeRegistration, ...] = ()
     routers: tuple[APIRouter, ...] = ()
     create_runtime_sessions: RuntimeFactory | None = None
+    create_call_capabilities: CallCapabilitiesFactory | None = None
     run_completion: CompletionHandler | None = None

--- a/api/services/integrations/registry.py
+++ b/api/services/integrations/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from typing import Any
 
 from loguru import logger
@@ -130,6 +131,11 @@ def create_call_capabilities(
                 f"returned {type(capability).__name__}, expected "
                 f"IntegrationCallCapabilities or None; skipping"
             )
+            if inspect.iscoroutine(capability):
+                # An accidentally `async def` factory: the coroutine was
+                # never awaited, so close it explicitly or Python warns
+                # about it later at an unrelated garbage-collection point.
+                capability.close()
             continue
         capabilities.append(capability)
     return capabilities

--- a/api/services/integrations/registry.py
+++ b/api/services/integrations/registry.py
@@ -96,6 +96,22 @@ def create_runtime_sessions(
     return sessions
 
 
+def _first_non_callable_hook(
+    capability: IntegrationCallCapabilities,
+) -> tuple[str, Any] | None:
+    """Return the first hook that is set but not callable, or ``None``.
+
+    ``IntegrationCallCapabilities`` is a plain dataclass, so its ``Callable``
+    annotations are documentation, not enforcement — a package can set a hook
+    to any object at all.
+    """
+    for field in ("run_pre_call", "prompt_addendum"):
+        value = getattr(capability, field, None)
+        if value is not None and not callable(value):
+            return field, value
+    return None
+
+
 def create_call_capabilities(
     context: IntegrationRuntimeContext,
 ) -> list[IntegrationCallCapabilities]:
@@ -136,6 +152,18 @@ def create_call_capabilities(
                 # never awaited, so close it explicitly or Python warns
                 # about it later at an unrelated garbage-collection point.
                 capability.close()
+            continue
+        invalid_hook = _first_non_callable_hook(capability)
+        if invalid_hook is not None:
+            # The dataclass only *type-hints* these as callables; nothing
+            # enforces it at runtime. run_pre_call in particular is invoked
+            # while the pipeline is still being built, where a TypeError
+            # would abort call setup rather than degrade.
+            field, value = invalid_hook
+            logger.warning(
+                f"Integration {capability.name!r} set {field} to "
+                f"{type(value).__name__}, which is not callable; skipping"
+            )
             continue
         capabilities.append(capability)
     return capabilities

--- a/api/services/integrations/registry.py
+++ b/api/services/integrations/registry.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from loguru import logger
+
 from api.errors.failure import ErrorSource, classify_exception, log_failure
 from api.services.integrations.base import (
     IntegrationCallCapabilities,
@@ -116,8 +118,20 @@ def create_call_capabilities(
                 integration_package=package.name,
             )
             continue
-        if capability is not None:
-            capabilities.append(capability)
+        if capability is None:
+            continue
+        if not isinstance(capability, IntegrationCallCapabilities):
+            # Guarding the call is not enough — a factory that *returns* the
+            # wrong thing (a dict, or the coroutine of an accidentally async
+            # factory) would only fail later, on attribute access, past the
+            # point where the call can still degrade gracefully.
+            logger.warning(
+                f"Integration {package.name!r} call-capabilities factory "
+                f"returned {type(capability).__name__}, expected "
+                f"IntegrationCallCapabilities or None; skipping"
+            )
+            continue
+        capabilities.append(capability)
     return capabilities
 
 

--- a/api/services/integrations/registry.py
+++ b/api/services/integrations/registry.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from api.errors.failure import ErrorSource, classify_exception, log_failure
 from api.services.integrations.base import (
+    IntegrationCallCapabilities,
     IntegrationCompletionContext,
     IntegrationNodeRegistration,
     IntegrationPackageSpec,
@@ -90,6 +91,34 @@ def create_runtime_sessions(
             continue
         sessions.extend(package.create_runtime_sessions(context))
     return sessions
+
+
+def create_call_capabilities(
+    context: IntegrationRuntimeContext,
+) -> list[IntegrationCallCapabilities]:
+    _ensure_loaded()
+    capabilities: list[IntegrationCallCapabilities] = []
+    for package in all_packages():
+        if package.create_call_capabilities is None:
+            continue
+        try:
+            capability = package.create_call_capabilities(context)
+        except Exception as exc:
+            # A package failing to describe itself must not stop the call.
+            log_failure(
+                classify_exception(
+                    exc,
+                    source=ErrorSource.INTEGRATION,
+                    provider=package.name,
+                    error_owner="user",
+                ),
+                workflow_run_id=context.workflow_run_id,
+                integration_package=package.name,
+            )
+            continue
+        if capability is not None:
+            capabilities.append(capability)
+    return capabilities
 
 
 def iter_completion_packages(

--- a/api/services/integrations/registry.py
+++ b/api/services/integrations/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import inspect
 from typing import Any
 
@@ -96,20 +97,41 @@ def create_runtime_sessions(
     return sessions
 
 
-def _first_non_callable_hook(
+def _sanitize_hooks(
     capability: IntegrationCallCapabilities,
-) -> tuple[str, Any] | None:
-    """Return the first hook that is set but not callable, or ``None``.
+) -> IntegrationCallCapabilities:
+    """Drop any hook that is set but not callable, keeping the rest.
 
     ``IntegrationCallCapabilities`` is a plain dataclass, so its ``Callable``
     annotations are documentation, not enforcement — a package can set a hook
     to any object at all.
+
+    Only the malformed hook is discarded. A package that gets its addendum
+    wrong should still get its pre-call recall, which is the more valuable
+    half; dropping the whole capability would cost the caller more than the
+    mistake does.
     """
-    for field in ("run_pre_call", "prompt_addendum"):
-        value = getattr(capability, field, None)
-        if value is not None and not callable(value):
-            return field, value
-    return None
+    invalid = {
+        field: value
+        for field in ("run_pre_call", "prompt_addendum")
+        if (value := getattr(capability, field, None)) is not None
+        and not callable(value)
+    }
+    if not invalid:
+        return capability
+
+    for field, value in invalid.items():
+        logger.warning(
+            f"Integration {capability.name!r} set {field} to "
+            f"{type(value).__name__}, which is not callable; ignoring that hook"
+        )
+        if inspect.iscoroutine(value):
+            # `run_pre_call=fetch()` instead of `run_pre_call=fetch` — the
+            # coroutine is never awaited, so close it here rather than let it
+            # surface as a warning at an unrelated collection point.
+            value.close()
+
+    return dataclasses.replace(capability, **dict.fromkeys(invalid))
 
 
 def create_call_capabilities(
@@ -153,19 +175,7 @@ def create_call_capabilities(
                 # about it later at an unrelated garbage-collection point.
                 capability.close()
             continue
-        invalid_hook = _first_non_callable_hook(capability)
-        if invalid_hook is not None:
-            # The dataclass only *type-hints* these as callables; nothing
-            # enforces it at runtime. run_pre_call in particular is invoked
-            # while the pipeline is still being built, where a TypeError
-            # would abort call setup rather than degrade.
-            field, value = invalid_hook
-            logger.warning(
-                f"Integration {capability.name!r} set {field} to "
-                f"{type(value).__name__}, which is not callable; skipping"
-            )
-            continue
-        capabilities.append(capability)
+        capabilities.append(_sanitize_hooks(capability))
     return capabilities
 
 

--- a/api/services/pipecat/event_handlers.py
+++ b/api/services/pipecat/event_handlers.py
@@ -14,6 +14,7 @@ from api.services.pipecat.in_memory_buffers import (
     InMemoryRecordingBuffers,
 )
 from api.services.pipecat.pipeline_metrics_aggregator import PipelineMetricsAggregator
+from api.services.pipecat.pre_call_fetch import PRE_CALL_FETCH_TIMEOUT_SECONDS
 from api.services.pipecat.termination_funnel_processor import (
     TerminationFunnelProcessor,
 )
@@ -65,6 +66,36 @@ async def _capture_call_event(
         logger.exception(f"Background PostHog capture failed for '{event}'")
 
 
+def _resolve_pre_call_task(label: str, task: asyncio.Task) -> dict:
+    """Read a finished pre-call task, or give up on it.
+
+    Every failure mode degrades to "no variables from this source" — pre-call
+    enrichment improves a call, it is never a precondition for one.
+    """
+    if not task.done():
+        logger.warning(f"{label} exceeded the pre-call budget, continuing without it")
+        task.cancel()
+        return {}
+
+    if task.cancelled():
+        logger.warning(f"{label} was cancelled, continuing without it")
+        return {}
+
+    error = task.exception()
+    if error is not None:
+        logger.error(f"{label} failed, continuing without it: {error}")
+        return {}
+
+    result = task.result()
+    if not isinstance(result, dict):
+        if result is not None:
+            logger.warning(
+                f"{label} returned {type(result).__name__}, expected a dict; ignoring"
+            )
+        return {}
+    return result
+
+
 def register_event_handlers(
     task: PipelineWorker,
     transport,
@@ -79,6 +110,7 @@ def register_event_handlers(
     pre_call_fetch_task: asyncio.Task | None = None,
     user_provider_id: str | None = None,
     integration_runtime_sessions: list[IntegrationRuntimeSession] | None = None,
+    integration_pre_call_tasks: list[asyncio.Task] | None = None,
     include_transcript_end_timestamps: bool = False,
 ):
     """Register all event handlers for transport and task events.
@@ -126,11 +158,21 @@ def register_event_handlers(
                 )
             )
 
-            # Wait for pre-call fetch if in progress, playing ringer meanwhile
+            # Wait for pre-call work if in progress, playing ringer meanwhile.
+            # The start node's fetch and any integration pre-call hooks resolve
+            # concurrently, so the caller waits for the slowest, not the sum.
+            pre_call_sources: list[tuple[str, asyncio.Task]] = []
             if pre_call_fetch_task is not None:
-                if not pre_call_fetch_task.done():
+                pre_call_sources.append(("pre-call fetch", pre_call_fetch_task))
+            for index, task in enumerate(integration_pre_call_tasks or []):
+                pre_call_sources.append((f"integration pre-call #{index}", task))
+
+            if pre_call_sources:
+                pending = [task for _label, task in pre_call_sources if not task.done()]
+                if pending:
                     logger.info(
-                        "Pre-call fetch still in progress, playing ringer while waiting"
+                        f"Pre-call work still in progress ({len(pending)} pending), "
+                        "playing ringer while waiting"
                     )
                     stop_ringer = asyncio.Event()
                     sample_rate = audio_config.pipeline_sample_rate or 16000
@@ -142,16 +184,29 @@ def register_event_handlers(
                         )
                     )
                     try:
-                        fetch_result = await pre_call_fetch_task
+                        # Bounded so a hanging hook cannot hold the caller on the
+                        # ringer; stragglers are cancelled below.
+                        await asyncio.wait(
+                            pending, timeout=PRE_CALL_FETCH_TIMEOUT_SECONDS
+                        )
                     finally:
                         stop_ringer.set()
                         await ringer_task
-                else:
-                    fetch_result = pre_call_fetch_task.result()
 
-                if fetch_result:
+                merged_result: dict = {}
+                for label, task in pre_call_sources:
+                    result = _resolve_pre_call_task(label, task)
+                    if result:
+                        merged_result = merge_external_initial_context(
+                            merged_result, result
+                        )
+                        logger.info(
+                            f"{label} complete, merged keys: {list(result.keys())}"
+                        )
+
+                if merged_result:
                     engine._call_context_vars = merge_external_initial_context(
-                        engine._call_context_vars, fetch_result
+                        engine._call_context_vars, merged_result
                     )
                     try:
                         await db_client.update_workflow_run(
@@ -159,11 +214,7 @@ def register_event_handlers(
                             initial_context={**engine._call_context_vars},
                         )
                     except Exception as e:
-                        logger.error(f"Failed to persist pre-call fetch context: {e}")
-                    logger.info(
-                        f"Pre-call fetch complete, merged keys: "
-                        f"{list(fetch_result.keys())}"
-                    )
+                        logger.error(f"Failed to persist pre-call context: {e}")
 
             # Set the start node now (after pre-call fetch data is merged)
             # so that render_template() has the complete _call_context_vars.

--- a/api/services/pipecat/event_handlers.py
+++ b/api/services/pipecat/event_handlers.py
@@ -110,7 +110,7 @@ def register_event_handlers(
     pre_call_fetch_task: asyncio.Task | None = None,
     user_provider_id: str | None = None,
     integration_runtime_sessions: list[IntegrationRuntimeSession] | None = None,
-    integration_pre_call_tasks: list[asyncio.Task] | None = None,
+    integration_pre_call_tasks: list[asyncio.Future] | None = None,
     include_transcript_end_timestamps: bool = False,
 ):
     """Register all event handlers for transport and task events.
@@ -161,7 +161,7 @@ def register_event_handlers(
             # Wait for pre-call work if in progress, playing ringer meanwhile.
             # The start node's fetch and any integration pre-call hooks resolve
             # concurrently, so the caller waits for the slowest, not the sum.
-            pre_call_sources: list[tuple[str, asyncio.Task]] = []
+            pre_call_sources: list[tuple[str, asyncio.Future]] = []
             if pre_call_fetch_task is not None:
                 pre_call_sources.append(("pre-call fetch", pre_call_fetch_task))
             for index, task in enumerate(integration_pre_call_tasks or []):

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -886,13 +886,16 @@ async def _run_pipeline_impl(
 
     # Fired now so they resolve while the rest of the pipeline is still being
     # built; awaited before the first turn in event_handlers.
-    integration_pre_call_tasks = []
+    integration_pre_call_tasks: list[asyncio.Future] = []
     for capability in integration_capabilities:
         if capability.run_pre_call is None:
             continue
         try:
+            # ensure_future, not create_task: the hook is declared to return an
+            # Awaitable, and create_task accepts only coroutines — it would
+            # reject a Future that satisfies that contract.
             integration_pre_call_tasks.append(
-                asyncio.create_task(capability.run_pre_call())
+                asyncio.ensure_future(capability.run_pre_call())
             )
         except Exception as e:
             # Starting the hook is part of building the pipeline, so anything

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -19,6 +19,7 @@ from api.services.call_concurrency import call_concurrency
 from api.services.configuration.registry import ServiceProviders
 from api.services.integrations import (
     IntegrationRuntimeContext,
+    create_call_capabilities,
     create_runtime_sessions,
 )
 from api.services.observability.active_calls import (
@@ -869,21 +870,37 @@ async def _run_pipeline_impl(
     # Create pipeline components
     audio_buffer, context = create_pipeline_components(audio_config)
 
-    integration_runtime_sessions = create_runtime_sessions(
-        IntegrationRuntimeContext(
-            workflow_run_id=workflow_run_id,
-            workflow_run=workflow_run,
-            workflow_graph=workflow_graph,
-            run_definition=run_definition,
-            user_config=user_config,
-            is_realtime=is_realtime,
-            context_messages_provider=lambda: context.messages,
-        )
+    integration_runtime_context = IntegrationRuntimeContext(
+        workflow_run_id=workflow_run_id,
+        workflow_run=workflow_run,
+        workflow_graph=workflow_graph,
+        run_definition=run_definition,
+        user_config=user_config,
+        is_realtime=is_realtime,
+        context_messages_provider=lambda: context.messages,
     )
+
+    integration_runtime_sessions = create_runtime_sessions(integration_runtime_context)
+
+    integration_capabilities = create_call_capabilities(integration_runtime_context)
+
+    # Fired now so they resolve while the rest of the pipeline is still being
+    # built; awaited before the first turn in event_handlers.
+    integration_pre_call_tasks = [
+        asyncio.create_task(capability.run_pre_call())
+        for capability in integration_capabilities
+        if capability.run_pre_call is not None
+    ]
+    if integration_pre_call_tasks:
+        logger.info(
+            f"Started {len(integration_pre_call_tasks)} integration pre-call "
+            f"hook(s) for workflow run {workflow_run_id}"
+        )
 
     # Set the context, audio_config, and audio_buffer after creation
     engine.set_context(context)
     engine.set_audio_config(audio_config)
+    engine.set_integration_capabilities(integration_capabilities)
 
     assistant_params = LLMAssistantAggregatorParams(
         correct_aggregation_callback=engine.create_aggregation_correction_callback(),
@@ -1164,6 +1181,7 @@ async def _run_pipeline_impl(
         pre_call_fetch_task=pre_call_fetch_task,
         user_provider_id=user_provider_id,
         integration_runtime_sessions=integration_runtime_sessions,
+        integration_pre_call_tasks=integration_pre_call_tasks,
         include_transcript_end_timestamps=include_transcript_end_timestamps,
     )
 

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -886,11 +886,23 @@ async def _run_pipeline_impl(
 
     # Fired now so they resolve while the rest of the pipeline is still being
     # built; awaited before the first turn in event_handlers.
-    integration_pre_call_tasks = [
-        asyncio.create_task(capability.run_pre_call())
-        for capability in integration_capabilities
-        if capability.run_pre_call is not None
-    ]
+    integration_pre_call_tasks = []
+    for capability in integration_capabilities:
+        if capability.run_pre_call is None:
+            continue
+        try:
+            integration_pre_call_tasks.append(
+                asyncio.create_task(capability.run_pre_call())
+            )
+        except Exception as e:
+            # Starting the hook is part of building the pipeline, so anything
+            # raised here would abort call setup rather than degrade. A hook
+            # that is synchronous, or that raises on the way in, costs the
+            # caller its enrichment and nothing more.
+            logger.warning(
+                f"[{capability.name}] pre-call hook could not be started, "
+                f"continuing without it: {e}"
+            )
     if integration_pre_call_tasks:
         logger.info(
             f"Started {len(integration_pre_call_tasks)} integration pre-call "

--- a/api/services/workflow/pipecat_engine.py
+++ b/api/services/workflow/pipecat_engine.py
@@ -1325,8 +1325,20 @@ class PipecatEngine:
                     f"skipping: {e}"
                 )
                 continue
-            if text and text.strip():
-                addenda.append(text.strip())
+            if text is None:
+                continue
+            if not isinstance(text, str):
+                # Checked rather than assumed: .strip() on a non-string would
+                # raise here, outside the guard above, and take the node's
+                # prompt down with it.
+                logger.warning(
+                    f"Integration {capability.name!r} prompt addendum returned "
+                    f"{type(text).__name__}, expected str; skipping"
+                )
+                continue
+            stripped = text.strip()
+            if stripped:
+                addenda.append(stripped)
         return addenda
 
     def set_transport_output(self, transport_output) -> None:

--- a/api/services/workflow/pipecat_engine.py
+++ b/api/services/workflow/pipecat_engine.py
@@ -43,6 +43,8 @@ if TYPE_CHECKING:
     from pipecat.services.openai.llm import OpenAILLMService
     from pipecat.utils.tracing.tracing_context import TracingContext
 
+    from api.services.integrations.base import IntegrationCallCapabilities
+
     LLMService = Union[OpenAILLMService, AnthropicLLMService, GoogleLLMService]
 
 import asyncio
@@ -226,6 +228,10 @@ class PipecatEngine:
         # True when the workflow has active recordings; enables recording
         # response mode instructions on all nodes for in-context learning.
         self._has_recordings: bool = has_recordings
+
+        # Contributions from enabled integrations, set after construction by
+        # run_pipeline once the integration runtime context exists.
+        self._integration_capabilities: list["IntegrationCallCapabilities"] = []
 
         # Background context summarization on node transitions
         self._context_compaction_enabled: bool = context_compaction_enabled
@@ -753,6 +759,7 @@ class PipecatEngine:
             workflow=self.workflow,
             format_prompt=self._format_prompt,
             has_recordings=self._has_recordings,
+            integration_addenda=self._resolve_integration_addenda(),
         )
         functions = await compose_functions_for_node(
             node=node,
@@ -1295,6 +1302,32 @@ class PipecatEngine:
     def set_audio_config(self, audio_config) -> None:
         """Set the audio configuration for the pipeline."""
         self._audio_config = audio_config
+
+    def set_integration_capabilities(self, capabilities) -> None:
+        """Set the call capabilities contributed by enabled integrations.
+
+        Set after construction, like the context: the integration runtime
+        context is built alongside the pipeline components.
+        """
+        self._integration_capabilities = list(capabilities or [])
+
+    def _resolve_integration_addenda(self) -> list[str]:
+        """Render each integration's prompt addendum for the current context."""
+        addenda: list[str] = []
+        for capability in self._integration_capabilities:
+            if capability.prompt_addendum is None:
+                continue
+            try:
+                text = capability.prompt_addendum(self._call_context_vars)
+            except Exception as e:
+                logger.warning(
+                    f"Integration {capability.name!r} prompt addendum failed, "
+                    f"skipping: {e}"
+                )
+                continue
+            if text and text.strip():
+                addenda.append(text.strip())
+        return addenda
 
     def set_transport_output(self, transport_output) -> None:
         """Set the transport output processor for direct audio playback.

--- a/api/services/workflow/pipecat_engine_context_composer.py
+++ b/api/services/workflow/pipecat_engine_context_composer.py
@@ -4,7 +4,7 @@ Extracts prompt and function composition logic from PipecatEngine into
 reusable functions. Defines recording response mode markers and instructions.
 """
 
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional, Sequence
 
 if TYPE_CHECKING:
     from api.services.workflow.pipecat_engine_custom_tools import CustomToolManager
@@ -52,6 +52,7 @@ def compose_system_prompt_for_node(
     workflow: "WorkflowGraph",
     format_prompt: Callable[[str], str],
     has_recordings: bool,
+    integration_addenda: Sequence[str] = (),
 ) -> str:
     """Compose the full system prompt text for a workflow node.
 
@@ -64,6 +65,9 @@ def compose_system_prompt_for_node(
         workflow: The full workflow graph (needed for global node prompt).
         format_prompt: Callable to render template variables in prompts.
         has_recordings: Whether any node in the workflow uses recordings.
+        integration_addenda: Already-resolved text blocks contributed by
+            enabled integrations, appended last. Resolved by the caller so this
+            stays a pure function of its inputs.
 
     Returns:
         The composed system prompt text.
@@ -79,6 +83,8 @@ def compose_system_prompt_for_node(
 
     if has_recordings and "RECORDING_ID:" in formatted_node_prompt:
         parts.append(RECORDING_RESPONSE_MODE_INSTRUCTIONS)
+
+    parts.extend(addendum for addendum in integration_addenda if addendum)
 
     return "\n\n".join(parts)
 

--- a/api/tests/test_integration_call_capabilities.py
+++ b/api/tests/test_integration_call_capabilities.py
@@ -158,6 +158,39 @@ def test_an_async_factory_mistake_is_skipped_not_stored(fake_packages):
     assert coroutine.cr_frame is None  # closed, not left dangling
 
 
+@pytest.mark.parametrize("field", ["run_pre_call", "prompt_addendum"])
+@pytest.mark.parametrize(
+    "junk", ["not-callable", 42, {"a": 1}], ids=["str", "int", "dict"]
+)
+def test_a_non_callable_hook_is_skipped(fake_packages, field, junk):
+    """The dataclass only type-hints these as callables; nothing enforces it.
+
+    run_pre_call is invoked while the pipeline is still being built, so a
+    non-callable there would raise TypeError and abort call setup rather than
+    cost the caller only its enrichment.
+    """
+    healthy = IntegrationCallCapabilities(name="healthy")
+    broken = IntegrationCallCapabilities(name="broken", **{field: junk})
+    fake_packages(
+        _package("broken", lambda _ctx: broken),
+        _package("healthy", lambda _ctx: healthy),
+    )
+
+    assert registry.create_call_capabilities(context=_runtime_context()) == [healthy]
+
+
+def test_a_callable_hook_is_kept(fake_packages):
+    """The guard rejects non-callables only — real hooks must still pass."""
+    capability = IntegrationCallCapabilities(
+        name="memory",
+        run_pre_call=lambda: None,
+        prompt_addendum=lambda _vars: "block",
+    )
+    fake_packages(_package("memory", lambda _ctx: capability))
+
+    assert registry.create_call_capabilities(context=_runtime_context()) == [capability]
+
+
 # ──────────────────────────── prompt composition ────────────────────────────
 
 

--- a/api/tests/test_integration_call_capabilities.py
+++ b/api/tests/test_integration_call_capabilities.py
@@ -114,6 +114,50 @@ def test_no_packages_at_all_is_not_an_error(fake_packages):
     assert registry.create_call_capabilities(context=_runtime_context()) == []
 
 
+@pytest.mark.parametrize(
+    "junk",
+    [
+        {"name": "memory"},  # right shape, wrong type
+        "memory",
+        42,
+        object(),
+    ],
+    ids=["dict", "str", "int", "object"],
+)
+def test_a_factory_returning_the_wrong_type_is_skipped(fake_packages, junk):
+    """Returning nonsense must be caught here, not on a later attribute access.
+
+    Guarding only the call would let a wrong-typed return through to
+    run_pipeline and pipecat_engine, where reading .run_pre_call or
+    .prompt_addendum off it raises far from anything that can recover.
+    """
+    healthy = IntegrationCallCapabilities(name="healthy")
+    fake_packages(
+        _package("junk", lambda _ctx: junk),
+        _package("healthy", lambda _ctx: healthy),
+    )
+
+    assert registry.create_call_capabilities(context=_runtime_context()) == [healthy]
+
+
+def test_an_async_factory_mistake_is_skipped_not_stored(fake_packages):
+    """An `async def` factory returns a coroutine — caught, not stored.
+
+    The likeliest way to hit the wrong-type path in practice.
+    """
+
+    async def accidentally_async(_ctx):
+        return IntegrationCallCapabilities(name="memory")
+
+    coroutine = accidentally_async(None)
+    try:
+        fake_packages(_package("memory", lambda _ctx: coroutine))
+
+        assert registry.create_call_capabilities(context=_runtime_context()) == []
+    finally:
+        coroutine.close()
+
+
 # ──────────────────────────── prompt composition ────────────────────────────
 
 
@@ -233,6 +277,27 @@ def test_addendum_text_is_stripped():
     )
 
     assert engine._resolve_integration_addenda() == ["block"]
+
+
+@pytest.mark.parametrize(
+    "junk",
+    [{"text": "block"}, 42, ["block"], object()],
+    ids=["dict", "int", "list", "object"],
+)
+def test_addendum_returning_a_non_string_is_skipped(junk):
+    """Wrong-typed text must not reach .strip().
+
+    That call sits outside the try above, so an AttributeError there would
+    escape _resolve_integration_addenda and leave the node with no prompt.
+    """
+    engine = _engine_with(
+        [
+            IntegrationCallCapabilities(name="junk", prompt_addendum=lambda _v: junk),
+            IntegrationCallCapabilities(name="ok", prompt_addendum=lambda _v: "kept"),
+        ]
+    )
+
+    assert engine._resolve_integration_addenda() == ["kept"]
 
 
 def test_a_raising_addendum_does_not_cost_the_caller_a_system_prompt():

--- a/api/tests/test_integration_call_capabilities.py
+++ b/api/tests/test_integration_call_capabilities.py
@@ -162,24 +162,79 @@ def test_an_async_factory_mistake_is_skipped_not_stored(fake_packages):
 @pytest.mark.parametrize(
     "junk", ["not-callable", 42, {"a": 1}], ids=["str", "int", "dict"]
 )
-def test_a_non_callable_hook_is_skipped(fake_packages, field, junk):
+def test_a_non_callable_hook_is_dropped(fake_packages, field, junk):
     """The dataclass only type-hints these as callables; nothing enforces it.
 
     run_pre_call is invoked while the pipeline is still being built, so a
     non-callable there would raise TypeError and abort call setup rather than
     cost the caller only its enrichment.
     """
-    healthy = IntegrationCallCapabilities(name="healthy")
-    broken = IntegrationCallCapabilities(name="broken", **{field: junk})
     fake_packages(
-        _package("broken", lambda _ctx: broken),
-        _package("healthy", lambda _ctx: healthy),
+        _package(
+            "broken",
+            lambda _ctx: IntegrationCallCapabilities(name="broken", **{field: junk}),
+        )
     )
 
-    assert registry.create_call_capabilities(context=_runtime_context()) == [healthy]
+    (capability,) = registry.create_call_capabilities(context=_runtime_context())
+
+    assert getattr(capability, field) is None
 
 
-def test_a_callable_hook_is_kept(fake_packages):
+def test_only_the_malformed_hook_is_dropped(fake_packages):
+    """A bad addendum must not cost the caller its pre-call recall.
+
+    Both consumers already degrade a bad hook on their own, so discarding the
+    whole capability would throw away working enrichment over a typo.
+    """
+
+    async def recall():
+        return {"known": True}
+
+    fake_packages(
+        _package(
+            "memory",
+            lambda _ctx: IntegrationCallCapabilities(
+                name="memory",
+                run_pre_call=recall,
+                prompt_addendum="not-callable",
+            ),
+        )
+    )
+
+    (capability,) = registry.create_call_capabilities(context=_runtime_context())
+
+    assert capability.run_pre_call is recall  # the good half survives
+    assert capability.prompt_addendum is None
+
+
+def test_a_coroutine_valued_hook_is_closed(fake_packages):
+    """`run_pre_call=fetch()` instead of `run_pre_call=fetch`.
+
+    A coroutine object is not callable, so it is dropped — and it was never
+    awaited, so it must be closed rather than left to warn at collection time.
+    """
+
+    async def fetch():
+        return {}
+
+    coroutine = fetch()
+    fake_packages(
+        _package(
+            "memory",
+            lambda _ctx: IntegrationCallCapabilities(
+                name="memory", run_pre_call=coroutine
+            ),
+        )
+    )
+
+    (capability,) = registry.create_call_capabilities(context=_runtime_context())
+
+    assert capability.run_pre_call is None
+    assert coroutine.cr_frame is None  # closed, not left dangling
+
+
+def test_callable_hooks_are_kept(fake_packages):
     """The guard rejects non-callables only — real hooks must still pass."""
     capability = IntegrationCallCapabilities(
         name="memory",

--- a/api/tests/test_integration_call_capabilities.py
+++ b/api/tests/test_integration_call_capabilities.py
@@ -143,19 +143,19 @@ def test_a_factory_returning_the_wrong_type_is_skipped(fake_packages, junk):
 def test_an_async_factory_mistake_is_skipped_not_stored(fake_packages):
     """An `async def` factory returns a coroutine — caught, not stored.
 
-    The likeliest way to hit the wrong-type path in practice.
+    The likeliest way to hit the wrong-type path in practice. The coroutine
+    is also never awaited, so it must be closed here rather than left for
+    the garbage collector to warn about at some unrelated point later.
     """
 
     async def accidentally_async(_ctx):
         return IntegrationCallCapabilities(name="memory")
 
     coroutine = accidentally_async(None)
-    try:
-        fake_packages(_package("memory", lambda _ctx: coroutine))
+    fake_packages(_package("memory", lambda _ctx: coroutine))
 
-        assert registry.create_call_capabilities(context=_runtime_context()) == []
-    finally:
-        coroutine.close()
+    assert registry.create_call_capabilities(context=_runtime_context()) == []
+    assert coroutine.cr_frame is None  # closed, not left dangling
 
 
 # ──────────────────────────── prompt composition ────────────────────────────

--- a/api/tests/test_integration_call_capabilities.py
+++ b/api/tests/test_integration_call_capabilities.py
@@ -1,0 +1,325 @@
+"""Framework tests for integration call capabilities.
+
+``IntegrationCallCapabilities`` lets an integration contribute *to* a call —
+variables resolved before the first turn, and text appended to every node's
+system prompt — where the existing hooks only observe a call and deliver data
+afterwards.
+
+The property these tests exist to protect is that the contribution is always
+optional. An integration that is slow, raises, returns nonsense, or is not
+implemented at all must cost the caller nothing but the enrichment itself: the
+call still connects, the prompt is still composed, and the first turn still
+fires. Anything less would make a third-party package able to break calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import ClassVar
+
+import pytest
+
+from api.services.integrations import registry
+from api.services.integrations.base import (
+    IntegrationCallCapabilities,
+    IntegrationPackageSpec,
+    IntegrationRuntimeContext,
+)
+from api.services.pipecat.event_handlers import _resolve_pre_call_task
+from api.services.workflow.pipecat_engine import PipecatEngine
+from api.services.workflow.pipecat_engine_context_composer import (
+    RECORDING_RESPONSE_MODE_INSTRUCTIONS,
+    compose_system_prompt_for_node,
+)
+
+# ─────────────────────────── registry collection ───────────────────────────
+
+
+def _package(name: str, factory) -> IntegrationPackageSpec:
+    return IntegrationPackageSpec(name=name, create_call_capabilities=factory)
+
+
+def _runtime_context() -> IntegrationRuntimeContext:
+    """A minimal real context.
+
+    The factories under test ignore it, but the registry's failure path reads
+    ``workflow_run_id`` off it to attribute the error — so a ``None`` stand-in
+    would turn a broken integration into a crash the tests never see.
+    """
+    return IntegrationRuntimeContext(
+        workflow_run_id=1,
+        workflow_run=None,
+        workflow_graph=None,
+        run_definition=None,
+        user_config=None,
+        is_realtime=False,
+        context_messages_provider=list,
+    )
+
+
+@pytest.fixture
+def fake_packages(monkeypatch):
+    """Swap the real package registry for whatever a test declares."""
+
+    def install(*packages: IntegrationPackageSpec):
+        monkeypatch.setattr(registry, "_ensure_loaded", lambda: None)
+        monkeypatch.setattr(registry, "all_packages", lambda: list(packages))
+
+    return install
+
+
+def test_collects_capabilities_from_packages_that_implement_the_hook(fake_packages):
+    capability = IntegrationCallCapabilities(name="memory")
+    fake_packages(_package("memory", lambda _ctx: capability))
+
+    assert registry.create_call_capabilities(context=_runtime_context()) == [capability]
+
+
+def test_packages_without_the_hook_are_skipped(fake_packages):
+    """The hook is opt-in: existing export-only integrations are unaffected."""
+    capability = IntegrationCallCapabilities(name="memory")
+    fake_packages(
+        IntegrationPackageSpec(name="tuner"),  # no create_call_capabilities
+        _package("memory", lambda _ctx: capability),
+    )
+
+    assert registry.create_call_capabilities(context=_runtime_context()) == [capability]
+
+
+def test_factory_returning_none_contributes_nothing(fake_packages):
+    """An integration that is installed but disabled for this call opts out."""
+    fake_packages(_package("memory", lambda _ctx: None))
+
+    assert registry.create_call_capabilities(context=_runtime_context()) == []
+
+
+def test_a_raising_factory_cannot_abort_call_setup(fake_packages):
+    """One broken integration must not stop the others, or the call."""
+
+    def explode(_ctx):
+        raise RuntimeError("integration is misconfigured")
+
+    healthy = IntegrationCallCapabilities(name="healthy")
+    fake_packages(
+        _package("broken", explode),
+        _package("healthy", lambda _ctx: healthy),
+    )
+
+    assert registry.create_call_capabilities(context=_runtime_context()) == [healthy]
+
+
+def test_no_packages_at_all_is_not_an_error(fake_packages):
+    fake_packages()
+
+    assert registry.create_call_capabilities(context=_runtime_context()) == []
+
+
+# ──────────────────────────── prompt composition ────────────────────────────
+
+
+class _Node:
+    def __init__(self, prompt: str, add_global_prompt: bool = False):
+        self.prompt = prompt
+        self.add_global_prompt = add_global_prompt
+        self.out_edges = []
+        self.document_uuids = None
+
+
+class _Workflow:
+    global_node_id = None
+    nodes: ClassVar[dict] = {}
+
+
+def _compose(**kwargs) -> str:
+    return compose_system_prompt_for_node(
+        node=_Node("Node prompt."),
+        workflow=_Workflow(),
+        format_prompt=lambda text: text,
+        has_recordings=False,
+        **kwargs,
+    )
+
+
+def test_prompt_is_unchanged_when_no_integration_contributes():
+    """The default must be byte-identical to the pre-hook behaviour."""
+    assert _compose() == "Node prompt."
+
+
+def test_addendum_is_appended_after_the_node_prompt():
+    composed = _compose(integration_addenda=["## CALLER MEMORY\nRepeat caller."])
+
+    assert composed == "Node prompt.\n\n## CALLER MEMORY\nRepeat caller."
+
+
+def test_multiple_addenda_are_appended_in_order():
+    composed = _compose(integration_addenda=["First.", "Second."])
+
+    assert composed == "Node prompt.\n\nFirst.\n\nSecond."
+
+
+def test_empty_addenda_do_not_introduce_blank_sections():
+    """A blank contribution must not leave stray separators in the prompt."""
+    composed = _compose(integration_addenda=["", None, "Real."])
+
+    assert composed == "Node prompt.\n\nReal."
+
+
+def test_addendum_follows_the_recording_instructions():
+    """Recording instructions are engine-critical, so they keep their position."""
+    composed = compose_system_prompt_for_node(
+        node=_Node("Say RECORDING_ID: abc"),
+        workflow=_Workflow(),
+        format_prompt=lambda text: text,
+        has_recordings=True,
+        integration_addenda=["## CALLER MEMORY"],
+    )
+
+    assert composed.index(RECORDING_RESPONSE_MODE_INSTRUCTIONS) < composed.index(
+        "## CALLER MEMORY"
+    )
+
+
+# ─────────────────── engine-side addendum resolution ───────────────────
+
+
+def _engine_with(capabilities, call_context_vars=None) -> PipecatEngine:
+    """A bare engine carrying only what addendum resolution reads.
+
+    Built without __init__ deliberately: constructing a real engine needs the
+    whole pipeline, and this logic depends on exactly two attributes.
+    """
+    engine = PipecatEngine.__new__(PipecatEngine)
+    engine._integration_capabilities = capabilities
+    engine._call_context_vars = call_context_vars or {}
+    return engine
+
+
+def test_addendum_receives_the_call_context_variables():
+    seen: dict = {}
+
+    def addendum(context_vars):
+        seen.update(context_vars)
+        return "block"
+
+    engine = _engine_with(
+        [IntegrationCallCapabilities(name="memory", prompt_addendum=addendum)],
+        {"caller_number": "+15551234567"},
+    )
+
+    assert engine._resolve_integration_addenda() == ["block"]
+    assert seen == {"caller_number": "+15551234567"}
+
+
+def test_capability_without_an_addendum_is_skipped():
+    engine = _engine_with([IntegrationCallCapabilities(name="pre-call-only")])
+
+    assert engine._resolve_integration_addenda() == []
+
+
+def test_addendum_returning_none_or_blank_contributes_nothing():
+    engine = _engine_with(
+        [
+            IntegrationCallCapabilities(name="none", prompt_addendum=lambda _v: None),
+            IntegrationCallCapabilities(name="blank", prompt_addendum=lambda _v: "   "),
+        ]
+    )
+
+    assert engine._resolve_integration_addenda() == []
+
+
+def test_addendum_text_is_stripped():
+    engine = _engine_with(
+        [IntegrationCallCapabilities(name="m", prompt_addendum=lambda _v: "  block  ")]
+    )
+
+    assert engine._resolve_integration_addenda() == ["block"]
+
+
+def test_a_raising_addendum_does_not_cost_the_caller_a_system_prompt():
+    def explode(_vars):
+        raise RuntimeError("template blew up")
+
+    engine = _engine_with(
+        [
+            IntegrationCallCapabilities(name="broken", prompt_addendum=explode),
+            IntegrationCallCapabilities(name="ok", prompt_addendum=lambda _v: "kept"),
+        ]
+    )
+
+    assert engine._resolve_integration_addenda() == ["kept"]
+
+
+# ──────────────────────── pre-call task resolution ────────────────────────
+
+
+async def test_completed_task_result_is_returned():
+    async def hook():
+        return {"memory_context": "Repeat caller."}
+
+    task = asyncio.create_task(hook())
+    await task
+
+    assert _resolve_pre_call_task("memory", task) == {
+        "memory_context": "Repeat caller."
+    }
+
+
+async def test_still_running_task_is_cancelled_and_yields_nothing():
+    """A hook past the budget must not hold the caller on the ringer."""
+
+    async def slow_hook():
+        await asyncio.sleep(30)
+        return {"never": "arrives"}
+
+    task = asyncio.create_task(slow_hook())
+    await asyncio.sleep(0)  # let it start
+
+    assert _resolve_pre_call_task("memory", task) == {}
+    assert task.cancelled() or task.cancelling()
+
+
+async def test_raising_task_yields_nothing():
+    async def failing_hook():
+        raise RuntimeError("memory service is down")
+
+    task = asyncio.create_task(failing_hook())
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert _resolve_pre_call_task("memory", task) == {}
+
+
+async def test_cancelled_task_yields_nothing():
+    async def hook():
+        await asyncio.sleep(30)
+
+    task = asyncio.create_task(hook())
+    await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert _resolve_pre_call_task("memory", task) == {}
+
+
+@pytest.mark.parametrize("bad_result", ["a string", 42, ["a", "list"]])
+async def test_non_dict_results_are_ignored(bad_result):
+    """initial_context is a mapping; anything else would corrupt the merge."""
+
+    async def hook():
+        return bad_result
+
+    task = asyncio.create_task(hook())
+    await task
+
+    assert _resolve_pre_call_task("memory", task) == {}
+
+
+async def test_none_result_is_ignored_quietly():
+    """Returning nothing is a normal way to say 'no variables this call'."""
+
+    async def hook():
+        return None
+
+    task = asyncio.create_task(hook())
+    await task
+
+    assert _resolve_pre_call_task("memory", task) == {}


### PR DESCRIPTION
Follow-up to my email to the team on 3 Aug re: integrating a memory layer with Dograh, and Abhishek's reply on that thread:

> Please feel free to extend the integration framework to hook into the pre-call fetch and allow modifications to the global system prompt.

This PR is exactly those two things and nothing more.

The integrations framework today supports live collection and post-call export, but a package can't contribute anything *before* a call. Memory and CRM integrations need exactly that — recognise the caller, and tell the agent who it's talking to.

## What this adds

An optional `IntegrationCallCapabilities` a package may return from `create_call_capabilities(context)`:

- **`run_pre_call()`** — resolves `initial_context` variables before the first turn, reusing the existing `pre_call_fetch` machinery, timeout and ringer path. A slow or failing integration just means the call proceeds without the enrichment.
- **`prompt_addendum(context_vars)`** — appends a block to every node's system prompt, mirroring how recording instructions are placed in `compose_system_prompt_for_node`.

Both fields are optional and the hook is opt-in. A package that doesn't implement it is untouched, and with no packages implementing it the composed prompt is byte-identical to today. A factory that raises is reported through `log_failure`/`classify_exception` and skipped rather than failing call setup — matching the convention `run_completion_handlers` already uses.

Nothing here names a vendor; it works for any CRM or memory provider.

## Tests

Cover collection, opt-out, a raising factory, prompt placement and ordering, and that a slow or broken contribution can't abort a call. Full suite green locally (1915 passed). Also verified end-to-end on a live call with a package implementing the hook: the caller was recognised before the first turn, the addendum reached the system prompt, and the call connected and transferred normally.

A second PR follows with a ConvoMem package built on this hook, so the framework change can be reviewed on its own.

## One unrelated commit

`chore(sdk): regenerate trigger node + OpenAPI` — 871ad4cc added `from_phone_number_id` to `TriggerCallRequest` without rerunning `scripts/generate_sdk.sh`, so `test_sdk_sync` currently fails on a clean `main` (verified in a separate worktree). Regenerated here so this PR's CI is green — happy to split it out if you'd rather take it separately.







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds optional integration-provided context and prompt content for calls. The exercised paths show that malformed, synchronous, failing, non-dictionary, and delayed pre-call hooks do not prevent a valid opening response or context merge.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The reviewed integration hook failure paths degrade gracefully: invalid hooks are skipped, failures do not stop the call, valid context is retained, and delayed work is cancelled after the configured wait.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the historical escaping TypeError by directly invoking a malformed run\_pre\_call before harness capture.
- Wrote and integrated the isolated validation harness for malformed hooks and included its command-output captures.
- After capture, the harness parsed and executed \_sanitize\_hooks from the current registry and ran the exact loop slice from run\_pipeline.py; malformed and synchronous-hook cases completed without aborting setup.
- Validated startup behavior by showing the startup error was caught, problematic hooks were ignored, the fetch context was merged, and the delayed hook was canceled; the harness asserts cancellation, merged context, and initial-response calls, then exits 0.
- Encountered an environment blocker where focused pytest collection could not occur due to pipecat-ai==1.8.1 lacking pipecat.utils.run\_context, which is not a failure of the changed behavior.

<a href="https://app.greptile.com/trex/runs/21771842/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(integrations): degrade per hook, and..."](https://github.com/dograh-hq/dograh/commit/fe0c11661066dec9c40e43335e5972765fdb2402) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53726546)</sub>

<!-- /greptile_comment -->