### PR TITLE
Update README with new Product Hunt badges - Product of the week

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@
   <a href="https://www.producthunt.com/products/dograh?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-dograh-3" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1217382&theme=light&period=daily&t=1786607298379" alt="Dograh - The open source VAPI alternative | Product Hunt" width="250" height="54"></a>
   &nbsp;
   <a href="https://trendshift.io/repositories/31007" target="_blank"><img src="https://trendshift.io/api/badge/repositories/31007" alt="dograh-hq%2Fdograh | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+  <br />
+  <a href="https://www.producthunt.com/products/dograh?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-dograh-3" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1217382&theme=light&period=weekly&t=1786966826740" alt="Dograh - The open source VAPI alternative | Product Hunt" width="250" height="54"></a>
+  &nbsp;
+  <a href="https://www.producthunt.com/products/dograh?embed=true&utm_source=badge-top-post-topic-badge&utm_medium=badge&utm_campaign=badge-dograh-3" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-topic-badge.svg?post_id=1217382&theme=neutral&period=weekly&topic_id=267&t=1786969133488" alt="Dograh - The open source VAPI alternative | Product Hunt" width="250" height="54"></a>
 </p>
 
 ## 🎥 Featured


### PR DESCRIPTION
Added additional Product Hunt badges for weekly and topic recognition.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two new Product Hunt badges to the README to highlight weekly recognition. Previously we showed only the daily Top Post badge; now we also show the weekly Top Post badge and a weekly Top Post by Topic badge, separated by a line break.

**Review notes**
- Verify both badges render on GitHub and link to the correct Product Hunt pages.
- Confirm query params: `period=weekly` on the Top Post badge and `period=weekly&topic_id=267` on the Topic badge.
- Expect a small layout change due to the `<br />` creating a second row of badges.

<sup>Written for commit b00e871cbe257d1e98d1d24347a6a6e180b1e064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two Product Hunt recognition badges to the README: a weekly top-post badge and a weekly Developer Tools topic badge.

The added markup was checked against the prior README. Both badge images returned live SVG responses with the expected weekly labels, and the README diff passed whitespace validation. Product Hunt returned HTTP 403 to direct automated requests for the destination pages, but the embedded badge markup and image URLs are valid.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the README badges are structurally valid and their hosted images render as the intended Product Hunt awards.

No defects were found. Validation compared the README before and after the change, parsed the new markup, and verified the live badge images and their labels.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Baseline state prior to the change showed no weekly badges in the README.
- After the change, the README includes two weekly badge pairs with valid image URLs and labels such as '#1 Product of the Week' and 'Developer Tools'.
- The validation script parsed README markup, validated the required Product Hunt parameters, fetched the badge image URLs and destination URLs, and inspected the SVG labels.
- Git diff --check passed, indicating no syntax or lint issues were detected in the changes.
- Direct Product Hunt destination-page requests returned HTTP 403, while the badge image URLs served 200-level SVGs with the intended labels.

<a href="https://app.greptile.com/trex/runs/19206454/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Update README with new Product Hunt badg..."](https://github.com/dograh-hq/dograh/commit/b00e871cbe257d1e98d1d24347a6a6e180b1e064) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53975579)</sub>

<!-- /greptile_comment -->