### PR TITLE
feat: add Google Tag Manager

### DIFF
--- a/ui/.env.example
+++ b/ui/.env.example
@@ -10,3 +10,5 @@ NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
 NEXT_PUBLIC_NODE_ENV=development
 # form submissions backend
 # NEXT_PUBLIC_ONBOARDING_API_URL=http://localhost:8001
+# Google Tag Manager container ID (e.g. GTM-XXXXXXX); GTM is not loaded when blank
+NEXT_PUBLIC_GTM_ID=

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "ui",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "1.44.0",
+      "version": "1.45.0",
       "dependencies": {
         "@calcom/embed-react": "^1.5.3",
         "@dagrejs/dagre": "^1.1.4",
         "@floating-ui/react-dom": "^2.1.9",
+        "@next/third-parties": "^16.3.1",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2656,6 +2657,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.3.1.tgz",
+      "integrity": "sha512-OyIUIohaQ8AkD/8Ew0yPTaxcoOwobIgBjvNnhajgJ2IWPuSjFHfKYAFmFjYmL5Jwrf2qJDWubadhPqPbFhrDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -18708,6 +18722,12 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/thread-stream": {
       "version": "3.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,6 +17,7 @@
     "@calcom/embed-react": "^1.5.3",
     "@dagrejs/dagre": "^1.1.4",
     "@floating-ui/react-dom": "^2.1.9",
+    "@next/third-parties": "^16.3.1",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./globals.css";
 
+import { GoogleTagManager } from "@next/third-parties/google";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Suspense } from "react";
@@ -38,6 +39,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  const gtmId = process.env.NEXT_PUBLIC_GTM_ID?.trim();
 
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
@@ -63,6 +65,7 @@ export default function RootLayout({
           }}
         />
       </head>
+      {gtmId ? <GoogleTagManager gtmId={gtmId} /> : null}
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false} disableTransitionOnChange>

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -65,9 +65,9 @@ export default function RootLayout({
           }}
         />
       </head>
-      {gtmId ? <GoogleTagManager gtmId={gtmId} /> : null}
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        {gtmId ? <GoogleTagManager gtmId={gtmId} /> : null}
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false} disableTransitionOnChange>
           <SentryErrorBoundary>
             <AuthProvider>


### PR DESCRIPTION
Adds Google Tag Manager (GTM-T7GV2FCQ) via @next/third-parties, for Google Ads conversion tracking. ID comes from NEXT_PUBLIC_GTM_ID and is guarded, blank value means GTM doesn't load. Same pattern as the landing page PR.

Before merging: set NEXT_PUBLIC_GTM_ID = GTM-T7GV2FCQ in Vercel (Production). Do not mark it Sensitive

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google Tag Manager via `@next/third-parties` for Google Ads conversion tracking. Previously no GTM loaded; now GTM loads only when `NEXT_PUBLIC_GTM_ID` is a non-blank string and is injected inside the document body to ensure a single load.

- Renders `<GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID.trim()} />` inside `app/layout.tsx` body.
- Trims the ID; blank or whitespace-only values skip GTM.
- Adds `NEXT_PUBLIC_GTM_ID` to `.env.example`.

**Rollout**
- Set `NEXT_PUBLIC_GTM_ID=GTM-T7GV2FCQ` in Vercel Production (do not mark Sensitive).
- Verify a single `gtm.js` request and Google Ads conversion events in Production.

<sup>Written for commit c69947721f2c8ece007cee489c74d1ca75a3ae35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional Google Tag Manager support in the root layout. Browser rendering confirms that a whitespace-padded container ID is trimmed and produces one GTM loader inside `<body>`, while an empty ID produces no GTM loader.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The previously reported GTM placement and duplicate-loader behavior was disproved by browser rendering: the configured loader appears once under the document body, and the disabled configuration emits no loader.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a Chromium GTM root-placement browser check on the UI with an empty GTM ID and with a whitespace-padded GTM ID.
- Observed that the empty-ID page contained no GTM scripts or loader resources, while the padded-ID page included one trimmed GTM script under the BODY and one matching browser resource entry.
- Noted that the request listener observed two events for the same URL, but the rendered DOM and browser resource timing each recorded one loader, so the rendered result does not show duplicate GTM injection.
- Cross-validated with Playwright that the request hook saw two identical URL events but the final DOM had one GTM script node and one loader resource, aligning with the non-duplication conclusion.
- Prepared artifacts from the browser checks, including the authored test source, the observed outputs, and the before/after visuals, for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/19379960/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: move GTM inside body per review"](https://github.com/dograh-hq/dograh/commit/c69947721f2c8ece007cee489c74d1ca75a3ae35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53994580)</sub>

<!-- /greptile_comment -->