### PR TITLE
fix: keep Langfuse traces private by default

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -57,6 +57,9 @@ MINIO_SECURE=false
 # LANGFUSE_PUBLIC_KEY="pk-lf-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 # LANGFUSE_HOST="https://cloud.langfuse.com"
 # LANGFUSE_PROJECT_ID="cmxxxxxxxxxxxxxxxxxxxxxxx"
+# Traces are private by default. Set to true to make them readable by anyone
+# holding the trace URL, with no Langfuse login.
+# LANGFUSE_TRACES_PUBLIC=false
 
 # TURN Server Configuration (for WebRTC NAT traversal)
 # Required for reliable WebRTC connections behind firewalls/NAT

--- a/api/services/workflow/tools/knowledge_base.py
+++ b/api/services/workflow/tools/knowledge_base.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from loguru import logger
 from opentelemetry import trace
+from pipecat.utils.tracing.langfuse_helpers import mark_trace_public
 
 from api.db import db_client
 from api.services.gen_ai import build_embedding_service
@@ -84,8 +85,7 @@ async def retrieve_from_knowledge_base(
                 "knowledge_base_retrieval", context=parent_context
             ) as span:
                 try:
-                    # Mark trace as public for Langfuse
-                    span.set_attribute("langfuse.trace.public", True)
+                    mark_trace_public(span)
 
                     # Add operation metadata
                     span.set_attribute(

--- a/deploy/helm/dograh/templates/configmap.yaml
+++ b/deploy/helm/dograh/templates/configmap.yaml
@@ -42,3 +42,6 @@ data:
   {{- if .Values.secrets.langfuseProjectId }}
   LANGFUSE_PROJECT_ID: {{ .Values.secrets.langfuseProjectId | quote }}
   {{- end }}
+  {{- if .Values.secrets.langfuseTracesPublic }}
+  LANGFUSE_TRACES_PUBLIC: {{ .Values.secrets.langfuseTracesPublic | quote }}
+  {{- end }}

--- a/deploy/helm/dograh/values.yaml
+++ b/deploy/helm/dograh/values.yaml
@@ -161,6 +161,9 @@ secrets:
   langfusePublicKey: ""
   langfuseHost: ""
   langfuseProjectId: ""
+  # Traces are private by default. "true" makes them readable by anyone holding
+  # the trace URL, with no Langfuse login.
+  langfuseTracesPublic: ""
 
   # Signs the telephony media WebSocket URL the carrier dials back, so the ids
   # in that URL are no longer enough on their own to open the socket. Empty

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -235,7 +235,7 @@ services:
       # LANGFUSE_PROJECT_ID: ""
       # Traces are private by default. Set to "true" to make them readable by
       # anyone holding the trace URL, with no Langfuse login.
-      # LANGFUSE_TRACES_PUBLIC: "false"
+      LANGFUSE_TRACES_PUBLIC: "${LANGFUSE_TRACES_PUBLIC:-false}"
 
       # TURN server configuration (for WebRTC NAT traversal in remote server)
       # Uses time-limited credentials via TURN REST API (HMAC-SHA1).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -233,6 +233,9 @@ services:
       # LANGFUSE_PUBLIC_KEY: ""
       # LANGFUSE_HOST: ""
       # LANGFUSE_PROJECT_ID: ""
+      # Traces are private by default. Set to "true" to make them readable by
+      # anyone holding the trace URL, with no Langfuse login.
+      # LANGFUSE_TRACES_PUBLIC: "false"
 
       # TURN server configuration (for WebRTC NAT traversal in remote server)
       # Uses time-limited credentials via TURN REST API (HMAC-SHA1).

--- a/docs/configurations/tracing.mdx
+++ b/docs/configurations/tracing.mdx
@@ -120,6 +120,10 @@ We provide seamless integration with Langfuse for tracing if you want to use you
 
 Once enabled, traces will be available for every completed call in Dograh.
 
+<Warning>
+Traces are private by default — opening a trace link requires access to your Langfuse project. Setting `LANGFUSE_TRACES_PUBLIC=true` makes every trace readable by anyone holding its URL, with no login, which exposes full call transcripts, prompts, and tool payloads. Only enable it if you intend to share trace links outside your Langfuse project.
+</Warning>
+
 <Note>
 For self-hosted deployments, you can also configure Langfuse via [environment variables](/developer/environment-variables#tracing-langfuse) (`LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_HOST`) as a default for all organizations. Tracing activates automatically once credentials are available — no separate enable flag is required. Per-organization credentials set in the UI take precedence over environment variables.
 </Note>

--- a/docs/configurations/tracing.mdx
+++ b/docs/configurations/tracing.mdx
@@ -125,7 +125,7 @@ Traces are private by default — opening a trace link requires access to your L
 </Warning>
 
 <Note>
-For self-hosted deployments, you can also configure Langfuse via [environment variables](/developer/environment-variables#tracing-langfuse) (`LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_HOST`) as a default for all organizations. Tracing activates automatically once credentials are available — no separate enable flag is required. Per-organization credentials set in the UI take precedence over environment variables.
+For self-hosted deployments, you can also configure Langfuse via [environment variables](/developer/environment-variables#tracing-langfuse) (`LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_HOST`, `LANGFUSE_PROJECT_ID`) as a default for all organizations. Tracing activates automatically once credentials are available — no separate enable flag is required. Per-organization credentials set in the UI take precedence over environment variables.
 </Note>
 
 ## Quick Reference

--- a/docs/developer/environment-variables.mdx
+++ b/docs/developer/environment-variables.mdx
@@ -148,6 +148,7 @@ Presigned URLs point at `S3_ENDPOINT_URL`, so that host must be reachable from t
 | `LANGFUSE_HOST` | `null` | Langfuse server URL |
 | `LANGFUSE_PUBLIC_KEY` | `null` | Langfuse public key |
 | `LANGFUSE_SECRET_KEY` | `null` | Langfuse secret key |
+| `LANGFUSE_TRACES_PUBLIC` | `false` | When `true`, traces are marked public in Langfuse — anyone holding a trace URL can read it without logging in. Leave unset to keep traces visible only to your Langfuse project members. |
 
 Tracing activates automatically as soon as credentials are available — either via these environment variables (applied to all organizations) or per-organization in the UI under **Platform Settings**. If neither is set, spans are dropped silently. See the [Tracing guide](/configurations/tracing) for setup instructions.
 

--- a/docs/developer/environment-variables.mdx
+++ b/docs/developer/environment-variables.mdx
@@ -148,9 +148,10 @@ Presigned URLs point at `S3_ENDPOINT_URL`, so that host must be reachable from t
 | `LANGFUSE_HOST` | `null` | Langfuse server URL |
 | `LANGFUSE_PUBLIC_KEY` | `null` | Langfuse public key |
 | `LANGFUSE_SECRET_KEY` | `null` | Langfuse secret key |
+| `LANGFUSE_PROJECT_ID` | `null` | Langfuse project ID, required with environment credentials to generate trace URLs |
 | `LANGFUSE_TRACES_PUBLIC` | `false` | When `true`, traces are marked public in Langfuse — anyone holding a trace URL can read it without logging in. Leave unset to keep traces visible only to your Langfuse project members. |
 
-Tracing activates automatically as soon as credentials are available — either via these environment variables (applied to all organizations) or per-organization in the UI under **Platform Settings**. If neither is set, spans are dropped silently. See the [Tracing guide](/configurations/tracing) for setup instructions.
+Tracing activates automatically as soon as credentials are available — either via these environment variables (applied to all organizations) or per-organization in the UI under **Platform Settings**. Environment credentials require `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_PROJECT_ID`. If neither is set, spans are dropped silently. See the [Tracing guide](/configurations/tracing) for setup instructions.
 
 ---
 


### PR DESCRIPTION
## Problem

Langfuse traces are marked public unconditionally. A public trace is readable by [anyone holding its URL](https://langfuse.com/docs/observability/features/url) — no login, no project membership — and Dograh persists that URL per run (`gathered_context.trace_url`) and renders it as a link on the run page, so the URL does travel. Full call transcripts, prompts and tool payloads are exposed to whoever it reaches.

The attribute is set in seven places: six inside the pipecat fork, and one here.

## Changes

**`api/services/workflow/tools/knowledge_base.py`** — the knowledge base retrieval span set `langfuse.trace.public` inline instead of calling pipecat's `mark_trace_public()`, bypassing the gate added in dograh-hq/pipecat#58. That span is a child of the live conversation trace, so a single KB retrieval could mark the whole call trace public. Now routed through the helper, so it honours `LANGFUSE_TRACES_PUBLIC` like every other span.

**Config and docs** — `LANGFUSE_TRACES_PUBLIC` documented alongside the existing Langfuse settings:

- `api/.env.example`, `docker-compose.yaml` — commented entry in the existing Langfuse block
- `deploy/helm/dograh/values.yaml` + `templates/configmap.yaml` — `langfuseTracesPublic`, same conditional pattern as `langfuseProjectId`
- `docs/developer/environment-variables.mdx` — table row
- `docs/configurations/tracing.mdx` — a warning spelling out what "public" actually means before someone enables it

## Behaviour change

Traces become private by default. Deployments that share trace links with people who have no Langfuse account need `LANGFUSE_TRACES_PUBLIC=true`.

## Depends on

dograh-hq/pipecat#58 adds the `LANGFUSE_TRACES_PUBLIC` gate inside `mark_trace_public()`, covering all six call sites in the fork with one guard.

This PR depends on [dograh-hq/pipecat#58](https://github.com/dograh-hq/pipecat/pull/58).

The current Dograh submodule already points to Pipecat `main` at `ca89ca3c2`, but that commit does not contain the `LANGFUSE_TRACES_PUBLIC` gate yet. The gate will be added when #58 merges.

After #58 merges, this PR will be updated with a **submodule pointer bump to the merged Pipecat commit**. That bump is required for Dograh to actually use the new gate.

Therefore, this PR should **not be merged until #58 has landed and the submodule pointer has been updated**.

## Testing

The gate itself is covered by 3 unit tests in dograh-hq/pipecat#58 (flag unset → private, `false` → private, `1`/`true`/`TRUE`/`yes` → public). This PR's change is a one-line delegation to that tested helper, so no new test here.

Verified locally: `py_compile` on the touched module, both YAML files parse, Helm conditional matches the existing pattern.

Refs #658


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Langfuse traces private by default and prevents a knowledge-base retrieval span from making its parent call trace public. Previously we set `langfuse.trace.public=true` inline; now we call `mark_trace_public()`, which respects `LANGFUSE_TRACES_PUBLIC` via the updated `pipecat` submodule.

- Code: replace the inline attribute with `mark_trace_public(span)` in `api/services/workflow/tools/knowledge_base.py`.
- Config: add `LANGFUSE_TRACES_PUBLIC` to `.env.example`; pass it via `docker-compose.yaml` (`"${LANGFUSE_TRACES_PUBLIC:-false}"`); add `langfuseTracesPublic` to Helm `values.yaml` and wire it in `templates/configmap.yaml`.
- Docs: add a warning in tracing docs; update the env table with `LANGFUSE_TRACES_PUBLIC` and `LANGFUSE_PROJECT_ID`.
- Behavior: traces are private by default; set `LANGFUSE_TRACES_PUBLIC=true` to share links with non-project users.
- Rollout: effective on merge (submodule bumped); deployments relying on public traces must set `LANGFUSE_TRACES_PUBLIC=true`.

<sup>Written for commit 63a6e37b0bd7e9d938e473e92716086688d968d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds deployment configuration and documentation for Langfuse trace visibility and updates the Pipecat dependency revision.

## T-Rex validation blocked

The Pipecat package and source for revision `496607395f0df106cf5c352a3d219ff459940157` are unavailable: Git could not retrieve the pinned object and Python could not import Pipecat. As a result, the private-by-default behavior of `mark_trace_public` could not be exercised.

<h3>Confidence Score: 3/5</h3>

The trace-privacy behavior remains unresolved because the helper implementation at the pinned dependency revision could not be run.

A security-sensitive trace visibility failure remains actionable until the helper is verified to leave traces private when public sharing is disabled.

**Files Needing Attention:** api/services/workflow/tools/knowledge_base.py

<details open><summary><h3>Security Review</h3></summary>

Knowledge-base retrieval traces can include prompts, transcripts, document references, and tool payloads. The code continues to call `mark_trace_public(span)`, but the pinned helper could not be executed to confirm that an unset or false `LANGFUSE_TRACES_PUBLIC` value prevents public trace URLs.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I attempted to run the authored integration harness against Pipecat's mark\_trace\_public with LANGFUSE\_TRACES\_PUBLIC unset and false, but both runs failed before the helper could execute because the Pipecat package could not be imported and the pinned Pipecat revision could not be retrieved.
- The pinned Pipecat revision availability check failed to retrieve the pinned revision from the git remote, preventing the harness from running against the intended code.
- The unset and false trace privacy test output was captured, but it does not yet reveal whether the trace would be private because setup issues blocked helper execution.
- A git-object capture shows that the working tree Pipecat checkout is at a different commit while the requested gitlink object is unavailable, explaining why the pinned revision could not be used.

<a href="https://app.greptile.com/trex/runs/20397103/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["chore: bump pipecat submodule"](https://github.com/dograh-hq/dograh/commit/63a6e37b0bd7e9d938e473e92716086688d968d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54068870)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->