### PR TITLE
fix: transfer disposition and vicidial lead sync

### DIFF
--- a/api/services/pipecat/event_handlers.py
+++ b/api/services/pipecat/event_handlers.py
@@ -187,9 +187,20 @@ def register_event_handlers(
         # Stop recordings
         await audio_buffer.stop_recording()
 
-        await engine.end_call_with_reason(
-            EndTaskReason.USER_HANGUP.value, abort_immediately=True
+        # A disconnect right after a handoff is the external PBX taking the
+        # customer leg, not the caller hanging up. The reason stays distinct
+        # from EndTaskReason.TRANSFER_CALL on purpose: that value drives the
+        # serializer's ARI bridge-transfer strategy, whereas an external-PBX
+        # transfer still wants the ordinary hangup strategy to tear down our
+        # own legs.
+        gathered_context = await engine.get_gathered_context()
+        reason = (
+            EndTaskReason.CALL_TRANSFERRED.value
+            if gathered_context.get("external_pbx_transferred")
+            else EndTaskReason.USER_HANGUP.value
         )
+
+        await engine.end_call_with_reason(reason, abort_immediately=True)
 
     @task.event_handler("on_pipeline_started")
     async def on_pipeline_started(_task: PipelineWorker, _frame: Frame):

--- a/api/services/telephony/providers/ari/external_pbx/vicidial.py
+++ b/api/services/telephony/providers/ari/external_pbx/vicidial.py
@@ -12,10 +12,15 @@ from loguru import logger
 from .base import ExternalPBXAdapter, ExternalPBXResult, HeaderReader
 
 _LEAD_FIELD_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
-_RESERVED_LEAD_FIELDS = frozenset({"source", "user", "pass", "function", "lead_id"})
+# Every control parameter update_lead sends. A mapped field sharing one of
+# these names would override it, since mapped fields are appended last.
+_RESERVED_LEAD_FIELDS = frozenset(
+    {"source", "user", "pass", "function", "lead_id", "format", "custom_fields"}
+)
 
 _HEADER_PREFIX = "X-VICIDIAL-"
 _IDENTITY_HEADER_FIELDS = ("callerid", "user", "lead_id", "campaign_id", "ingroup_id")
+_CUSTOM_FIELDS_UPDATED = "CUSTOM FIELDS VALUES UPDATED"
 
 
 def _response_code(response_text: str) -> str:
@@ -26,6 +31,46 @@ def _response_code(response_text: str) -> str:
     if prefix in {"success", "error", "notice", "warning"}:
         return prefix
     return "unexpected"
+
+
+def _update_applied(response_text: str) -> bool:
+    """Whether VICIdial reports that ``update_lead`` changed anything.
+
+    Standard columns and custom list fields are written by separate code paths
+    in non_agent_api.php, and each announces itself on its own line:
+
+        SUCCESS: update_lead LEAD HAS BEEN UPDATED - ...          (standard)
+        NOTICE: update_lead CUSTOM FIELDS VALUES UPDATED - ...    (custom)
+
+    A write touching only custom fields therefore never emits a SUCCESS line, so
+    matching on that alone reports a working sync as a rejection.
+    """
+    return any(
+        line.startswith("SUCCESS") or _CUSTOM_FIELDS_UPDATED in line
+        for line in (raw.strip() for raw in response_text.splitlines())
+    )
+
+
+def _response_summary(response_text: str) -> str:
+    """Return VICIdial's failure reason without the parameters it echoes back.
+
+    ``response_code`` alone cannot separate a rejected field name from a missing
+    lead or a revoked permission, so the reason itself is worth logging. What is
+    not worth logging is the block VICIdial appends after it, which repeats the
+    API user and the search values it was given:
+
+        ERROR: update_lead NO MATCHES FOUND IN THE SYSTEM: |DOGRAHAPI|1||
+        ERROR: update_lead NO VALID SEARCH METHOD - DOGRAHAPI|LEAD_ID|||
+
+    Either ``|`` or `` - `` can introduce that block, so cut at whichever comes
+    first and keep only the reason ahead of it.
+    """
+    if not response_text:
+        return "<empty body>"
+    reason = response_text
+    for delimiter in ("|", " - "):
+        reason = reason.partition(delimiter)[0]
+    return reason.strip().rstrip(":-").strip()[:200]
 
 
 class VicidialAdapter(ExternalPBXAdapter):
@@ -55,19 +100,50 @@ class VicidialAdapter(ExternalPBXAdapter):
         # workflow configured. Enumerating X-VICIDIAL-* instead would cost an
         # extra request up front and one more per header VICIdial happens to
         # attach — all on the latency-sensitive inbound setup path.
-        names = list(_IDENTITY_HEADER_FIELDS) + [
+        configured = [
             field
             for field in dict.fromkeys(
                 value.strip() for value in lead_fields if isinstance(value, str)
             )
             if field
-            and field not in _IDENTITY_HEADER_FIELDS
-            and _LEAD_FIELD_RE.match(field)
         ]
+        requested = [
+            field
+            for field in configured
+            if field not in _IDENTITY_HEADER_FIELDS and _LEAD_FIELD_RE.match(field)
+        ]
+        names = list(_IDENTITY_HEADER_FIELDS) + requested
         values = await asyncio.gather(
             *(read_header(_HEADER_PREFIX + field) for field in names)
         )
         headers = {field: value.strip() for field, value in zip(names, values)}
+
+        # A configured field the PBX sent empty and one that was never asked for
+        # both just go missing from `lead`, and those need opposite fixes: the
+        # first is a PBX/lead-data problem, the second a workflow setting one.
+        # Header values are customer PII, so report names and emptiness only.
+        if configured:
+            already_captured = [
+                field for field in configured if field in _IDENTITY_HEADER_FIELDS
+            ]
+            logger.info(
+                "[VICIdial] Lead header read: "
+                f"requested={requested} "
+                f"populated={[field for field in requested if headers.get(field)]} "
+                f"empty={[field for field in requested if not headers.get(field)]}"
+                + (f" already_captured={already_captured}" if already_captured else "")
+            )
+            invalid = [
+                field
+                for field in configured
+                if field not in _IDENTITY_HEADER_FIELDS
+                and not _LEAD_FIELD_RE.match(field)
+            ]
+            if invalid:
+                logger.warning(
+                    "[VICIdial] Ignoring invalid names in the workflow's Lead "
+                    f"Fields To Capture setting: {invalid}"
+                )
         callerid = headers.get("callerid", "")
         if not callerid:
             return None
@@ -147,16 +223,30 @@ class VicidialAdapter(ExternalPBXAdapter):
     async def update_fields(
         self, identity: Mapping[str, Any], fields: Mapping[str, str]
     ) -> ExternalPBXResult:
+        # Each early return below ends the write silently otherwise, which reads
+        # in the log exactly like no transfer having happened at all.
         if not fields:
+            logger.info(
+                "[VICIdial] update_lead skipped: no field mappings resolved to a "
+                "non-empty value"
+            )
             return ExternalPBXResult(True, "update_lead", "No lead fields configured")
         if not all(
             [self._non_agent_url, self._non_agent_user, self._non_agent_password]
         ):
+            logger.warning(
+                "[VICIdial] update_lead skipped: non-agent API is not configured "
+                f"fields={sorted(fields)}"
+            )
             return ExternalPBXResult(
                 False, "update_lead", "Non-agent API is not configured"
             )
         lead_id = str(identity.get("lead_id", "")).strip()
         if not lead_id:
+            logger.warning(
+                "[VICIdial] update_lead skipped: no lead_id was captured from the "
+                f"INVITE fields={sorted(fields)}"
+            )
             return ExternalPBXResult(
                 False, "update_lead", "No VICIdial lead ID captured"
             )
@@ -174,12 +264,20 @@ class VicidialAdapter(ExternalPBXAdapter):
                 continue
             safe_fields[normalized] = str(value)
         if not safe_fields:
+            logger.warning(
+                "[VICIdial] update_lead skipped: no configured destination field "
+                f"survived validation fields={sorted(fields)}"
+            )
             return ExternalPBXResult(
                 False, "update_lead", "No valid lead fields resolved"
             )
 
+        # Field order is load-bearing: VICIdial's custom-field parser ignores
+        # whatever occupies the first query-string slot, so a mapped field
+        # placed there is dropped without any error. Control parameters lead
+        # and the mapped fields follow; _RESERVED_LEAD_FIELDS is what stops a
+        # mapped field from overriding a control parameter from that position.
         params = {
-            **safe_fields,
             "source": self._non_agent_source,
             "user": self._non_agent_user,
             "pass": self._non_agent_password,
@@ -190,18 +288,34 @@ class VicidialAdapter(ExternalPBXAdapter):
             # reads here as a rejection. The agent API echoes unconditionally,
             # which is why only this call needs it.
             "format": "text",
+            # Without this, VICIdial silently ignores every parameter that names
+            # a custom list field — no update, no error, just an empty body. We
+            # cannot know which destination fields a deployment defined as
+            # custom, so it is always sent; a request carrying only standard
+            # columns is unaffected by it.
+            "custom_fields": "Y",
+            **safe_fields,
         }
         try:
             async with aiohttp.ClientSession(timeout=self._timeout) as session:
                 async with session.get(self._non_agent_url, params=params) as response:
                     response_text = (await response.text()).strip()
-                    ok = response.status == 200 and response_text.startswith("SUCCESS")
+                    ok = response.status == 200 and _update_applied(response_text)
             logger.info(
                 "[VICIdial] update_lead completed "
                 f"status={response.status} ok={ok} "
-                f"field_count={len(safe_fields)} "
+                f"fields={sorted(safe_fields)} "
                 f"response_code={_response_code(response_text)}"
             )
+            if not ok:
+                # The field names are workflow configuration, not lead data, so
+                # naming them here is what separates "VICIdial does not know this
+                # field" from a permission or lead-lookup failure.
+                logger.warning(
+                    "[VICIdial] update_lead rejected "
+                    f"fields={sorted(safe_fields)} "
+                    f"response={_response_summary(response_text)!r}"
+                )
             return ExternalPBXResult(
                 ok,
                 "update_lead",
@@ -209,7 +323,8 @@ class VicidialAdapter(ExternalPBXAdapter):
             )
         except Exception as exc:
             logger.error(
-                f"[VICIdial] update_lead failed error_type={type(exc).__name__}"
+                "[VICIdial] update_lead failed "
+                f"fields={sorted(safe_fields)} error_type={type(exc).__name__}"
             )
             return ExternalPBXResult(
                 False, "update_lead", "VICIdial API request failed"

--- a/api/services/workflow/pipecat_engine.py
+++ b/api/services/workflow/pipecat_engine.py
@@ -804,6 +804,24 @@ class PipecatEngine:
         # Setup LLM context with prompts and functions.
         await self._setup_llm_context(node)
 
+    def record_call_disposition(self, disposition: str) -> None:
+        """Fix the call's disposition ahead of teardown.
+
+        ``end_call_with_reason`` falls back to its own ``reason`` only when no
+        disposition has been recorded, so an outcome already known to be final
+        before the pipeline winds down has to be stamped here.
+
+        An external-PBX transfer is the case that needs it. The PBX pulls the
+        customer off our media leg within ~100ms of its transfer API returning,
+        so ``on_client_disconnected`` fires while the transfer handler is still
+        waiting out its post-handoff settle delay. Whichever path reaches
+        ``end_call_with_reason`` first wins the disposition and the other is a
+        no-op, so without this the completed transfer is recorded as a user
+        hangup.
+        """
+        self._gathered_context["call_disposition"] = disposition
+        self._gathered_context["mapped_call_disposition"] = disposition
+
     async def end_call_with_reason(
         self,
         reason: str,

--- a/api/services/workflow/pipecat_engine_custom_tools.py
+++ b/api/services/workflow/pipecat_engine_custom_tools.py
@@ -737,9 +737,22 @@ class CustomToolManager:
                             self._engine._gathered_context[
                                 "external_pbx_transferred"
                             ] = True
+                            # The PBX drops our media leg within ~100ms of the
+                            # transfer API returning, so on_client_disconnected
+                            # reaches end_call_with_reason long before the settle
+                            # delay below is over. Stamp the disposition now, or
+                            # that handler records this completed transfer as a
+                            # user hangup.
+                            self._engine.record_call_disposition(
+                                EndTaskReason.CALL_TRANSFERRED.value
+                            )
                             await db_client.update_workflow_run(
                                 run_id=self._engine._workflow_run_id,
-                                gathered_context={"external_pbx_transferred": True},
+                                gathered_context={
+                                    "external_pbx_transferred": True,
+                                    "call_disposition": EndTaskReason.CALL_TRANSFERRED.value,
+                                    "mapped_call_disposition": EndTaskReason.CALL_TRANSFERRED.value,
+                                },
                             )
                             await function_call_params.result_callback(
                                 external_result, properties=properties

--- a/api/services/workflow/tools/transfer_resolver.py
+++ b/api/services/workflow/tools/transfer_resolver.py
@@ -62,15 +62,6 @@ def _base_timeout(config: dict[str, Any]) -> int:
     return min(max(timeout_int, 5), 120)
 
 
-def _mask_destination(destination: Any) -> str:
-    value = "" if destination is None else str(destination).strip()
-    if not value:
-        return ""
-    if len(value) <= 4:
-        return "***"
-    return f"***{value[-4:]}"
-
-
 _SENSITIVE_LOG_KEY_PARTS = (
     "authorization",
     "auth",
@@ -430,7 +421,7 @@ async def resolve_transfer_config(
             f"rule_index={resolved.metadata.get('rule_index')} "
             f"fallback={bool(resolved.metadata.get('fallback'))} "
             f"source={resolved.source} "
-            f"destination={_mask_destination(resolved.destination)}"
+            f"destination={resolved.destination}"
         )
         return resolved
 
@@ -443,7 +434,7 @@ async def resolve_transfer_config(
         )
         logger.info(
             "Transfer destination resolved "
-            f"source={resolved.source} destination={_mask_destination(resolved.destination)} "
+            f"source={resolved.source} destination={resolved.destination} "
             f"timeout={resolved.timeout_seconds}"
         )
         return resolved
@@ -477,7 +468,7 @@ async def resolve_transfer_config(
     logger.info(
         "Transfer destination resolved "
         f"resolution_id={resolution_id} source={resolved.source} "
-        f"destination={_mask_destination(resolved.destination)} "
+        f"destination={resolved.destination} "
         f"timeout={resolved.timeout_seconds} "
         f"custom_message_present={bool(resolved.message)}"
     )

--- a/api/tests/telephony/providers/ari/test_external_pbx.py
+++ b/api/tests/telephony/providers/ari/test_external_pbx.py
@@ -145,6 +145,44 @@ async def test_vicidial_adapter_ignores_duplicate_and_invalid_lead_fields():
 
 
 @pytest.mark.asyncio
+async def test_vicidial_lead_header_log_separates_empty_from_never_requested():
+    """A blank header and an unconfigured one both vanish from ``lead``.
+
+    They need opposite fixes — one is PBX/lead data, the other a workflow
+    setting — so the log has to tell them apart.
+    """
+    adapter = create_adapter(_vicidial_config())
+    headers = {
+        "X-VICIDIAL-callerid": "M123",
+        "X-VICIDIAL-first_name": "Ada",
+        # state is configured but the PBX sends it blank
+        "X-VICIDIAL-state": "",
+    }
+    read_header, _ = _header_access(headers)
+
+    with (
+        patch(
+            "api.services.telephony.providers.ari.external_pbx.vicidial.logger.info"
+        ) as log_info,
+        patch(
+            "api.services.telephony.providers.ari.external_pbx.vicidial.logger.warning"
+        ) as log_warning,
+    ):
+        await adapter.capture_call_identity(
+            read_header, ["first_name", "state", "bad name)"]
+        )
+
+    messages = " ".join(call.args[0] for call in log_info.call_args_list)
+    assert "requested=['first_name', 'state']" in messages
+    assert "populated=['first_name']" in messages
+    assert "empty=['state']" in messages
+    # Header values are customer PII; only names belong in the log.
+    assert "Ada" not in messages and "M123" not in messages
+    # An unusable configured name is a misconfiguration, not a PBX problem.
+    assert "bad name)" in " ".join(call.args[0] for call in log_warning.call_args_list)
+
+
+@pytest.mark.asyncio
 async def test_vicidial_adapter_returns_none_without_callerid():
     adapter = create_adapter(_vicidial_config())
     read_header, _ = _header_access({"X-VICIDIAL-first_name": "Ada"})
@@ -261,6 +299,219 @@ async def test_vicidial_update_lead_log_redacts_rejection_body():
         "private note",
     ):
         assert sensitive_value not in messages
+
+
+@pytest.mark.asyncio
+async def test_vicidial_update_lead_asks_for_custom_fields():
+    """Without custom_fields=Y, VICIdial ignores every custom-field parameter.
+
+    No update, no error — just an empty body. Which destination fields a
+    deployment defined as custom is not knowable here, so the flag always goes.
+    """
+    adapter = create_adapter(_vicidial_config())
+    session = _StubSession(
+        _StubResponse(200, "SUCCESS: update_lead LEAD HAS BEEN UPDATED - u|42|1|||")
+    )
+
+    with patch(
+        "api.services.telephony.providers.ari.external_pbx.vicidial.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        await adapter.update_fields({"lead_id": "42"}, {"Medicaid": "yes"})
+
+    _, kwargs = session.requests[0]
+    assert kwargs["params"]["custom_fields"] == "Y"
+
+
+@pytest.mark.asyncio
+async def test_vicidial_update_lead_never_puts_a_mapped_field_first():
+    """VICIdial's custom-field parser ignores the first query-string parameter.
+
+    A mapped field placed there is dropped silently — no error, no update — so
+    the control parameters must lead and the mapped fields follow.
+    """
+    adapter = create_adapter(_vicidial_config())
+    session = _StubSession(
+        _StubResponse(200, "SUCCESS: update_lead LEAD HAS BEEN UPDATED - u|42|1|||")
+    )
+
+    with patch(
+        "api.services.telephony.providers.ari.external_pbx.vicidial.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        await adapter.update_fields(
+            {"lead_id": "42"}, {"Medicaid": "yes", "MedSupp": "no"}
+        )
+
+    keys = list(session.requests[0][1]["params"])
+    assert keys[0] not in ("Medicaid", "MedSupp")
+    # Every mapped field must sit after every control parameter.
+    assert min(keys.index("Medicaid"), keys.index("MedSupp")) > keys.index(
+        "custom_fields"
+    )
+
+
+@pytest.mark.asyncio
+async def test_vicidial_update_lead_rejects_fields_shadowing_control_params():
+    """Mapped fields are appended last, so a collision would hijack the call."""
+    adapter = create_adapter(_vicidial_config())
+    session = _StubSession(
+        _StubResponse(200, "SUCCESS: update_lead LEAD HAS BEEN UPDATED - u|42|1|||")
+    )
+
+    with patch(
+        "api.services.telephony.providers.ari.external_pbx.vicidial.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        await adapter.update_fields(
+            {"lead_id": "42"},
+            {"format": "json", "custom_fields": "N", "function": "add_lead"},
+        )
+
+    assert not session.requests, "a request with only reserved names must not be sent"
+
+
+@pytest.mark.asyncio
+async def test_vicidial_update_lead_accepts_a_custom_fields_only_notice():
+    """A custom-fields-only write never emits a SUCCESS line, only a NOTICE."""
+    adapter = create_adapter(_vicidial_config())
+    session = _StubSession(
+        _StubResponse(
+            200, "NOTICE: update_lead CUSTOM FIELDS VALUES UPDATED - |42|499|499|499|1"
+        )
+    )
+
+    with patch(
+        "api.services.telephony.providers.ari.external_pbx.vicidial.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await adapter.update_fields({"lead_id": "42"}, {"Medicaid": "yes"})
+
+    assert result.ok
+    assert result.message == "VICIdial lead updated"
+
+
+@pytest.mark.asyncio
+async def test_vicidial_update_lead_accepts_mixed_standard_and_custom_response():
+    """Standard and custom writes each announce themselves on their own line."""
+    adapter = create_adapter(_vicidial_config())
+    session = _StubSession(
+        _StubResponse(
+            200,
+            "SUCCESS: update_lead LEAD HAS BEEN UPDATED - u|42|1|||\n"
+            "NOTICE: update_lead CUSTOM FIELDS VALUES UPDATED - |42|499|499|499|1",
+        )
+    )
+
+    with patch(
+        "api.services.telephony.providers.ari.external_pbx.vicidial.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await adapter.update_fields(
+            {"lead_id": "42"}, {"comments": "note", "Medicaid": "yes"}
+        )
+
+    assert result.ok
+
+
+@pytest.mark.asyncio
+async def test_vicidial_update_lead_still_rejects_an_unrelated_notice():
+    """Only the custom-field notice counts — not NOTICE lines in general."""
+    adapter = create_adapter(_vicidial_config())
+    session = _StubSession(
+        _StubResponse(200, "NOTICE: update_lead NOTHING TO UPDATE - |42|")
+    )
+
+    with patch(
+        "api.services.telephony.providers.ari.external_pbx.vicidial.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        result = await adapter.update_fields({"lead_id": "42"}, {"Medicaid": "yes"})
+
+    assert not result.ok
+
+
+@pytest.mark.asyncio
+async def test_vicidial_update_lead_rejection_names_fields_and_reason():
+    """A rejection has to say which fields were sent and why VICIdial refused.
+
+    ``response_code=empty`` alone cannot separate "VICIdial does not know this
+    field" from a missing lead or a revoked permission.
+    """
+    adapter = create_adapter(_vicidial_config())
+    session = _StubSession(_StubResponse(200, ""))
+
+    with (
+        patch(
+            "api.services.telephony.providers.ari.external_pbx.vicidial.aiohttp.ClientSession",
+            return_value=session,
+        ),
+        patch(
+            "api.services.telephony.providers.ari.external_pbx.vicidial.logger.warning"
+        ) as log_warning,
+    ):
+        result = await adapter.update_fields(
+            {"lead_id": "42"}, {"Medicaid": "yes", "MedSupp": "no"}
+        )
+
+    assert not result.ok
+    messages = " ".join(call.args[0] for call in log_warning.call_args_list)
+    assert "Medicaid" in messages and "MedSupp" in messages
+    assert "<empty body>" in messages
+    # Destination field names are workflow config; their values are lead data.
+    assert "yes" not in messages and "no" not in messages
+
+
+@pytest.mark.asyncio
+async def test_vicidial_update_lead_rejection_reason_drops_echoed_parameters():
+    adapter = create_adapter(_vicidial_config())
+    # VICIdial appends the API user and search values after "|" or " - ".
+    session = _StubSession(
+        _StubResponse(
+            200,
+            "ERROR: update_lead NO MATCHES FOUND IN THE SYSTEM: |lead-api-user|42||",
+        )
+    )
+
+    with (
+        patch(
+            "api.services.telephony.providers.ari.external_pbx.vicidial.aiohttp.ClientSession",
+            return_value=session,
+        ),
+        patch(
+            "api.services.telephony.providers.ari.external_pbx.vicidial.logger.warning"
+        ) as log_warning,
+    ):
+        await adapter.update_fields({"lead_id": "42"}, {"comments": "private note"})
+
+    messages = " ".join(call.args[0] for call in log_warning.call_args_list)
+    assert "NO MATCHES FOUND IN THE SYSTEM" in messages
+    for echoed in ("lead-api-user", "private note"):
+        assert echoed not in messages
+
+
+@pytest.mark.asyncio
+async def test_vicidial_update_lead_skips_are_not_silent():
+    """Every early return ends the write; none may leave the log blank."""
+    adapter = create_adapter(_vicidial_config())
+
+    with patch(
+        "api.services.telephony.providers.ari.external_pbx.vicidial.logger.info"
+    ) as log_info:
+        result = await adapter.update_fields({"lead_id": "42"}, {})
+    assert result.ok
+    assert "no field mappings resolved" in " ".join(
+        call.args[0] for call in log_info.call_args_list
+    )
+
+    with patch(
+        "api.services.telephony.providers.ari.external_pbx.vicidial.logger.warning"
+    ) as log_warning:
+        result = await adapter.update_fields({}, {"comments": "hello"})
+    assert not result.ok
+    assert "no lead_id was captured" in " ".join(
+        call.args[0] for call in log_warning.call_args_list
+    )
 
 
 def _ari_connection(monkeypatch, variables: dict[str, str]):

--- a/api/tests/test_transfer_message_playback.py
+++ b/api/tests/test_transfer_message_playback.py
@@ -18,6 +18,7 @@ from pipecat.frames.frames import (
     BotStoppedSpeakingFrame,
     TTSSpeakFrame,
 )
+from pipecat.utils.enums import EndTaskReason
 
 from api.enums import ToolCategory, WorkflowRunMode
 from api.services.workflow.pipecat_engine import PipecatEngine
@@ -120,6 +121,9 @@ class RecordingEngine:
 
     async def flush_variable_extraction(self):
         return None
+
+    def record_call_disposition(self, disposition):
+        self.events.append(("disposition", disposition))
 
     async def end_call_with_reason(self, reason, abort_immediately=False):
         self.events.append(("end_call", reason))
@@ -278,3 +282,134 @@ async def test_external_pbx_transfer_without_message_does_not_wait():
 
     assert "wait_for_playback" not in engine.events
     assert "pbx_transfer" in engine.events
+
+
+class TestTransferDispositionRace:
+    """The PBX drops our media leg ~100ms after its transfer API returns.
+
+    ``on_client_disconnected`` therefore fires while the transfer handler is
+    still waiting out ``_TRANSFER_POST_HANDOFF_DELAY_SECS``, and whichever path
+    reaches ``end_call_with_reason`` first wins the disposition -- the other is
+    a no-op. Every transferred call was being recorded as ``user_hangup``
+    because of it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_recorded_disposition_survives_a_later_hangup(self):
+        """A disconnect after the stamp must not relabel the call."""
+        engine = make_engine()
+        engine.task = SimpleNamespace(queue_frame=AsyncMock())
+
+        engine.record_call_disposition(EndTaskReason.CALL_TRANSFERRED.value)
+
+        with (
+            patch.object(
+                PipecatEngine, "perform_final_variable_extraction", AsyncMock()
+            ),
+            patch(
+                "api.services.workflow.pipecat_engine.db_client.update_workflow_run",
+                AsyncMock(),
+            ),
+        ):
+            await engine.end_call_with_reason(
+                EndTaskReason.USER_HANGUP.value, abort_immediately=True
+            )
+
+        context = await engine.get_gathered_context()
+        assert context["call_disposition"] == EndTaskReason.CALL_TRANSFERRED.value
+        assert context["mapped_call_disposition"] == (
+            EndTaskReason.CALL_TRANSFERRED.value
+        )
+        assert EndTaskReason.USER_HANGUP.value not in context["call_tags"]
+
+    @pytest.mark.asyncio
+    async def test_an_untransferred_disconnect_is_still_a_user_hangup(self):
+        """The fallback must stay intact for calls the caller really drops."""
+        engine = make_engine()
+        engine.task = SimpleNamespace(queue_frame=AsyncMock())
+
+        with (
+            patch.object(
+                PipecatEngine, "perform_final_variable_extraction", AsyncMock()
+            ),
+            patch(
+                "api.services.workflow.pipecat_engine.db_client.update_workflow_run",
+                AsyncMock(),
+            ),
+        ):
+            await engine.end_call_with_reason(
+                EndTaskReason.USER_HANGUP.value, abort_immediately=True
+            )
+
+        context = await engine.get_gathered_context()
+        assert context["call_disposition"] == EndTaskReason.USER_HANGUP.value
+
+    @pytest.mark.asyncio
+    async def test_transfer_stamps_disposition_before_the_settle_delay(self):
+        """Stamping after the delay loses the race with the disconnect."""
+        engine = RecordingEngine()
+        manager = CustomToolManager(engine)
+        tool = TransferToolModel()
+        handler = manager._create_transfer_call_handler(tool, "transfer_call")
+
+        workflow_run = SimpleNamespace(
+            mode=WorkflowRunMode.ARI.value,
+            initial_context={"external_pbx_call": {"type": "vicidial", "lead_id": "42"}},
+            gathered_context={"call_id": "1786379595.10"},
+        )
+
+        async def fake_transfer_external_pbx_call(**_kwargs):
+            engine.events.append("pbx_transfer")
+            return {"status": "success", "action": "external_pbx_transfer"}
+
+        provider = SimpleNamespace(
+            transfer_external_pbx_call=fake_transfer_external_pbx_call,
+            supports_transfers=lambda: True,
+            validate_config=lambda: True,
+        )
+        params = SimpleNamespace(arguments={}, result_callback=AsyncMock())
+
+        async def recording_sleep(_seconds):
+            engine.events.append("settle_delay")
+
+        with (
+            patch(
+                "api.services.workflow.pipecat_engine_custom_tools.db_client.get_workflow_run_by_id",
+                AsyncMock(return_value=workflow_run),
+            ),
+            patch(
+                "api.services.workflow.pipecat_engine_custom_tools.db_client.get_workflow_run_configurations",
+                AsyncMock(return_value={"external_pbx_field_mappings": []}),
+            ),
+            patch(
+                "api.services.workflow.pipecat_engine_custom_tools.db_client.update_workflow_run",
+                AsyncMock(),
+            ) as update_run,
+            patch(
+                "api.services.workflow.pipecat_engine_custom_tools.get_telephony_provider_for_run",
+                AsyncMock(return_value=provider),
+            ),
+            patch(
+                "api.services.workflow.pipecat_engine_custom_tools.resolve_transfer_config",
+                AsyncMock(
+                    return_value=ResolvedTransferConfig(
+                        destination="Florida",
+                        timeout_seconds=30,
+                        source="context_mapping",
+                    )
+                ),
+            ),
+            patch(
+                "api.services.workflow.pipecat_engine_custom_tools.asyncio.sleep",
+                recording_sleep,
+            ),
+        ):
+            await handler(params)
+
+        assert engine.events.index(("disposition", "call_transferred")) < (
+            engine.events.index("settle_delay")
+        ), f"disposition must be stamped before the delay: {engine.events}"
+        # It also has to reach the DB, since integrations read the run row.
+        persisted = update_run.await_args.kwargs["gathered_context"]
+        assert persisted["call_disposition"] == "call_transferred"
+        assert persisted["mapped_call_disposition"] == "call_transferred"


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes external-PBX transfers being dispositioned as user_hangup and makes VICIdial lead updates actually apply (and explain failures) instead of silently doing nothing.

- Old: external PBX transfers often ended as user_hangup due to a race; VICIdial update_lead reported success while writing nothing and logs hid why. New: transfers are recorded as call_transferred immediately and disconnects honor it; VICIdial requests are formed so updates apply, and logs clearly state what was sent and why VICIdial accepted or rejected it.

**VICIdial lead sync**
- Always send custom_fields=Y and place control params first; expand reserved set to include format and custom_fields to prevent mapped-field collisions.
- Treat NOTICE: ... CUSTOM FIELDS VALUES UPDATED as success; accept mixed SUCCESS + NOTICE responses.
- Log every skip or rejection with field names and a concise VICIdial reason; redact values and any echoed credentials.
- During lead header capture, log requested vs populated vs empty fields and warn on invalid names; do not log PII.

**Transfer disposition and logging**
- Stamp disposition via engine.record_call_disposition(EndTaskReason.CALL_TRANSFERRED) on PBX confirmation and persist it; on_client_disconnected uses CALL_TRANSFERRED when external_pbx_transferred is set.
- Keep ARI teardown on the ordinary hangup path for external-PBX transfers; do not trigger the bridge-transfer strategy.
- Log transfer destinations unmasked so routing is auditable across all resolution paths.

<sup>Written for commit 8a8a27823d40e05eab137cfe804db6dff704bf3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change improves external-PBX transfer disposition handling and VICIdial synchronization. Before merging, redact resolved transfer destinations in `transfer_resolver.py`: runtime execution showed that PSTN numbers, SIP endpoints, and private routes are written verbatim to INFO logs across context-mapping, static, and HTTP-resolver flows.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until transfer-resolution logging no longer exposes complete destination values.

A focused runtime harness exercised the affected production resolver paths and captured the sensitive destination values verbatim in emitted INFO logs.

**Files Needing Attention:** `api/services/workflow/tools/transfer_resolver.py` at the context-mapping/PBX, static, and HTTP-resolver destination log statements.

<details open><summary><h3>Security Review</h3></summary>

Resolved transfer destinations are sensitive routing data. The resolver currently exposes full PSTN numbers, SIP endpoints, and private tenant routes to application-log readers in all three supported resolution paths. Apply a consistent masking or redaction helper before emitting these log messages.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding, documenting the validation steps and evidence reviewed.
- T-Rex ran the focused transfer destination log exposure validation harness against the production resolver; the run completed with exit code 0.
- T-Rex noted the exact code areas implicated in the log exposure and described the recommended masking remediation.

<a href="https://app.greptile.com/trex/runs/19332267/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Resolved transfer destinations are logged in full**

   - **Bug**
     - `resolve_transfer_config` logs raw `resolved.destination` values for context-mapping, static, and HTTP resolver branches. A focused runtime execution captured a PSTN number, private route, and SIP endpoint verbatim in INFO logs.
   - **Cause**
     - The resolver interpolates `resolved.destination` directly into log messages instead of using the module's sensitive-value handling or the masked-destination convention used by the provider-call logs.
   - **Fix**
     - Introduce/use a destination masking helper and replace direct `resolved.destination` interpolation at lines 424, 437, and 471. Preserve only an intentionally limited suffix or a redacted marker consistently across all branches.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(transfer): record completed external..."](https://github.com/dograh-hq/dograh/commit/8a8a27823d40e05eab137cfe804db6dff704bf3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54223261)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->