### PR TITLE
feat: configurable ElevenLabs voice settings, custom message variants, optional greeting mute

### DIFF
--- a/api/services/configuration/registry.py
+++ b/api/services/configuration/registry.py
@@ -989,6 +989,25 @@ class ElevenlabsTTSConfiguration(BaseServiceConfiguration):
             "regional compliance."
         ),
     )
+    stability: float = Field(
+        default=0.8,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Voice stability. Higher values (0.6-0.9) give consistent, steady "
+            "delivery; lower values (0.3-0.5) give more expressive, dynamic "
+            "delivery with wider emotional range."
+        ),
+    )
+    similarity_boost: float = Field(
+        default=0.75,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "How closely the output adheres to the original voice. Higher "
+            "boosts clarity and consistency; very high values may distort."
+        ),
+    )
 
 
 @register_tts

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from typing import Optional
 
 from fastapi import HTTPException
@@ -882,8 +883,18 @@ async def _run_pipeline_impl(
         correct_aggregation_callback=engine.create_aggregation_correction_callback(),
     )
 
+    # The initial-greeting mute keeps noisy channels from interrupting the very
+    # first bot utterance, but it also makes the greeting impossible to barge
+    # into. Deployments that want a fully interruptible greeting can disable it.
+    _greeting_mute_disabled = (
+        os.getenv("DISABLE_INITIAL_GREETING_MUTE", "false").lower() == "true"
+    )
     user_mute_strategies = [
-        MuteUntilFirstBotCompleteUserMuteStrategy(),
+        *(
+            []
+            if _greeting_mute_disabled
+            else [MuteUntilFirstBotCompleteUserMuteStrategy()]
+        ),
         FunctionCallUserMuteStrategy(),
         CallbackUserMuteStrategy(should_mute_callback=engine.should_mute_user),
     ]

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -630,9 +630,9 @@ def create_tts_service(
             settings=ElevenLabsTTSSettings(
                 voice=voice_id,
                 model=user_config.tts.model,
-                stability=0.8,
+                stability=getattr(user_config.tts, "stability", 0.8),
                 speed=user_config.tts.speed,
-                similarity_boost=0.75,
+                similarity_boost=getattr(user_config.tts, "similarity_boost", 0.75),
             ),
             text_filters=[xml_function_tag_filter],
             skip_aggregator_types=["recording_router", "recording"],

--- a/api/services/workflow/pipecat_engine_custom_tools.py
+++ b/api/services/workflow/pipecat_engine_custom_tools.py
@@ -7,6 +7,7 @@ during workflow execution.
 from __future__ import annotations
 
 import asyncio
+import random
 import time
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -104,6 +105,20 @@ class CustomToolManager:
     def __init__(self, engine: "PipecatEngine") -> None:
         self._engine = engine
 
+    @staticmethod
+    def _pick_message_variant(message: str) -> str:
+        """Support multiple '|'-separated message variants; pick one at random.
+
+        A plain message without '|' is returned unchanged, preserving existing
+        behaviour. Empty variants (e.g. trailing '|') are ignored.
+        """
+        if "|" not in message:
+            return message
+        variants = [part.strip() for part in message.split("|") if part.strip()]
+        if not variants:
+            return message
+        return random.choice(variants)
+
     async def _play_config_message(
         self, config: dict, *, append_to_context: bool = False
     ) -> bool:
@@ -137,6 +152,7 @@ class CustomToolManager:
         if message_type == "custom":
             custom_message = config.get("customMessage", "")
             if custom_message:
+                custom_message = self._pick_message_variant(custom_message)
                 await self._engine.task.queue_frame(
                     TTSSpeakFrame(
                         custom_message,
@@ -437,6 +453,7 @@ class CustomToolManager:
                                 persist_to_logs=True,
                             )
                 elif custom_message:
+                    custom_message = self._pick_message_variant(custom_message)
                     logger.info(
                         f"Playing custom message before HTTP tool: {custom_message}"
                     )


### PR DESCRIPTION
Three small, non-breaking quality-of-life features for voice deployments:

1. **ElevenLabs `stability` / `similarity_boost` as config fields** — `service_factory.py` currently hardcodes `stability=0.8` / `similarity_boost=0.75`. High stability is great for consistency but deliberately flattens emotional range; expressive sales/hospitality agents want ~0.4–0.5 (per ElevenLabs' own guidance). Defaults preserve current behaviour exactly. Same shape as #278 (base_url).

2. **`customMessage` variants** — a pre-tool custom message may now contain `|`-separated variants; one is picked at random per play. A caller who triggers the same tool twice in a call no longer hears the identical sentence verbatim (a strong 'bot tell'). Messages without `|` behave exactly as before.

3. **`DISABLE_INITIAL_GREETING_MUTE` env flag** — `MuteUntilFirstBotCompleteUserMuteStrategy` is currently unconditional, so the opening greeting can never be barged into and anything the caller says during it is discarded. Default keeps the mute; deployments that want an interruptible greeting can opt out.

Happy to split into separate PRs if preferred.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable ElevenLabs voice parameters, randomized `customMessage` variants, and an opt-out for the initial-greeting mute. This reduces repetitive bot phrasing and enables barge-in when desired while keeping current defaults.

- ElevenLabs config: new `stability` and `similarity_boost` fields on `ElevenlabsTTSConfiguration`; `service_factory` reads them with defaults `0.8`/`0.75`. Action: set `tts.stability` and `tts.similarity_boost` to tune expressiveness.
- `customMessage` variants: support `|`-separated alternatives in pre-tool and HTTP/transfer messages; one is chosen at random per play. Messages without `|` are unchanged. Action: add variants where you want variation.
- Initial-greeting mute: set `DISABLE_INITIAL_GREETING_MUTE=true` to allow barge-in on the first bot utterance; leaving it unset keeps the existing mute. No migrations required.

<sup>Written for commit 61492953991c4a6672d30ceaa1085a4d592b517d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds configurable ElevenLabs voice tuning, pipe-delimited custom-message variants, and an option to avoid muting callers during the initial greeting.

A verified regression prevents safe use of literal pipe characters in existing free-form custom messages. Messages such as `Hours: 9|5` are now split and only one fragment is played and logged. Merge is not safe until existing literal-pipe messages are preserved or the variant representation is made explicit and migrated safely.

<h3>Confidence Score: 4/5</h3>

Not safe to merge because existing saved caller messages containing literal pipes can be truncated during playback.

There is one verified, non-security P1 finding. The required scoring table assigns a score of 4 for exactly one non-security P1 finding.

**Files Needing Attention:** api/services/workflow/pipecat_engine_custom_tools.py: the custom-message variant parser must preserve existing free-form text containing literal pipe characters.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the literal-pipe runtime reproduction script to exercise the custom-message path and reproduce the posted P1 finding.
- T-Rex captured and reviewed the literal-pipe behavior before PR #680 to establish a baseline for comparison.
- T-Rex captured and reviewed the literal-pipe behavior after PR #680 to verify the impact of the change described in the finding.

<a href="https://app.greptile.com/trex/runs/19598320/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: configurable ElevenLabs stability/..."](https://github.com/dograh-hq/dograh/commit/61492953991c4a6672d30ceaa1085a4d592b517d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54749483)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->