### PR TITLE
fix: [Bug]: Webhook node has no way to sign/authenticate outbound requests wi...

### DIFF
--- a/docs/developer/webhooks.mdx
+++ b/docs/developer/webhooks.mdx
@@ -69,7 +69,7 @@ The credential picker supports these types:
 | Type | Header Dograh sends |
 |---|---|
 | `bearer_token` | `Authorization: Bearer <token>` |
-| `api_key` | The header name you choose, defaulting to `X-API-Key` |
+| `api_key` | The header name you set, conventionally `X-API-Key` |
 | `basic_auth` | `Authorization: Basic <base64(username:password)>` |
 | `custom_header` | The header name and value you choose |
 
@@ -82,6 +82,7 @@ Don't put secrets in **Custom Headers**. Header names that look like credentials
 </Warning>
 
 ---
+
 ## Receiving webhooks
 
 Your endpoint should:

--- a/docs/developer/webhooks.mdx
+++ b/docs/developer/webhooks.mdx
@@ -62,18 +62,26 @@ Dograh always includes a top-level `call_disposition` field in the delivered pay
 
 ## Authentication
 
-Webhook requests support the following authentication methods, configured via a stored credential:
+Never type a shared secret into the workflow. Attach a stored credential instead: open the webhook node, and in the **Authentication** field pick an existing credential or click **+** to create one. Credentials belong to your organization and are reusable across webhook nodes, HTTP API tools, MCP tools, call transfer resolvers, and pre-call data fetch.
 
-| Type | Description |
+The credential picker supports these types:
+
+| Type | Header Dograh sends |
 |---|---|
-| `NONE` | No authentication |
-| `API_KEY` | Sends the key in a custom header (e.g. `X-API-Key`) |
-| `BEARER_TOKEN` | Sends `Authorization: Bearer <token>` |
-| `BASIC_AUTH` | HTTP Basic authentication (username + password) |
-| `CUSTOM_HEADER` | Any custom header key-value pair |
+| `bearer_token` | `Authorization: Bearer <token>` |
+| `api_key` | The header name you choose, defaulting to `X-API-Key` |
+| `basic_auth` | `Authorization: Basic <base64(username:password)>` |
+| `custom_header` | The header name and value you choose |
+
+Leave **Authentication** empty to send no authentication header.
+
+The workflow definition stores only the credential's `credential_uuid`, and so does the delivery record. The secret is re-resolved from the credential store on every send attempt, so rotating a credential applies to later deliveries without editing the workflow, and the secret is never exported with the workflow. The credentials API never returns stored secret values.
+
+<Warning>
+Don't put secrets in **Custom Headers**. Header names that look like credentials — `Authorization`, `X-API-Key`, and anything containing `auth`, `token`, `secret`, `password`, `passwd`, `cookie`, `credential`, `api-key`, `apikey`, `api_key`, or `access-key` — are dropped and never stored or sent. Use a credential instead.
+</Warning>
 
 ---
-
 ## Receiving webhooks
 
 Your endpoint should:

--- a/docs/getting-started/send-call-data-with-webhooks.mdx
+++ b/docs/getting-started/send-call-data-with-webhooks.mdx
@@ -23,10 +23,9 @@ Click **Add node**, scroll down, and you'll find the **Webhook** node. Add it an
 
 First thing you'll see is the endpoint URL. Paste your backend's webhook URL here. Still testing? Use a free URL from [webhook.site](https://webhook.site), copy your unique URL there and paste it into Dograh.
 
-Set the method to **POST**. If your backend needs auth, add a bearer token or API key right here too.
+Set the method to **POST**. If your backend needs auth, use the **Authentication** field on the same node: pick a saved credential, or click **+** to store a bearer token, API key, basic auth, or custom header. Keep secrets out of **Custom Headers** — the workflow only records which credential to use, so the secret itself is never saved in or exported with the workflow.
 
 ## Step 3: Build the payload template
-
 This is the important part, it decides exactly what JSON Dograh sends. Include both kinds of context: `initial_context` fields like debtor name, client name, and debt amount, and `gathered_context` fields like amount to pay, payment method, and sentiment. You can also include the final call outcome with `{{gathered_context.call_disposition}}` — how the call ended, e.g. `user_hangup` or `voicemail_detected`.
 
 ```json

--- a/docs/getting-started/send-call-data-with-webhooks.mdx
+++ b/docs/getting-started/send-call-data-with-webhooks.mdx
@@ -26,6 +26,7 @@ First thing you'll see is the endpoint URL. Paste your backend's webhook URL her
 Set the method to **POST**. If your backend needs auth, use the **Authentication** field on the same node: pick a saved credential, or click **+** to store a bearer token, API key, basic auth, or custom header. Keep secrets out of **Custom Headers** — the workflow only records which credential to use, so the secret itself is never saved in or exported with the workflow.
 
 ## Step 3: Build the payload template
+
 This is the important part, it decides exactly what JSON Dograh sends. Include both kinds of context: `initial_context` fields like debtor name, client name, and debt amount, and `gathered_context` fields like amount to pay, payment method, and sentiment. You can also include the final call outcome with `{{gathered_context.call_disposition}}` — how the call ended, e.g. `user_hangup` or `voicemail_detected`.
 
 ```json

--- a/docs/voice-agent/webhook.mdx
+++ b/docs/voice-agent/webhook.mdx
@@ -36,5 +36,4 @@ An example of the payload is given below
   "duration": "{{cost_info.call_duration_seconds}}",
   "recording_url": "{{recording_url}}",
   "transcript_url": "{{transcript_url}}"
-}
-```
+}```

--- a/docs/voice-agent/webhook.mdx
+++ b/docs/voice-agent/webhook.mdx
@@ -36,4 +36,5 @@ An example of the payload is given below
   "duration": "{{cost_info.call_duration_seconds}}",
   "recording_url": "{{recording_url}}",
   "transcript_url": "{{transcript_url}}"
-}```
+}
+```


### PR DESCRIPTION
Fixes #633

## Root cause

Webhook credential auth exists but is undiscoverable in docs

## Changes

- Documented the existing credential-backed webhook authentication path: the webhook node's Authentication field with its inline credential-create dialog, the header each credential type sends, that only credential_uuid is persisted in the workflow and delivery row, and that secret-looking Custom Headers are dropped and never sent. No code change: the requested capability (opaque secret referenced by credential_uuid, types bearer_token/api_key/basic_auth/custom_header) is already implemented end to end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents webhook node authentication so users can sign outbound requests without embedding secrets. Previously the docs omitted this and implied a default API-key header; now they point to the Authentication field, list supported credential types, and clarify header and secret handling.

- Show how to attach a saved credential in the webhook node (picker and inline create), with types `bearer_token` (Authorization: Bearer), `api_key` (you set the header name; conventionally `X-API-Key`), `basic_auth` (Authorization: Basic), and `custom_header`. Leaving Authentication empty sends no auth header.
- Clarify persistence: workflows and deliveries store only `credential_uuid`; secrets are re-resolved on send, never exported, and never returned by the credentials API.
- Warn that secret-like Custom Headers are dropped and never sent; store secrets as credentials instead.
- Update `docs/developer/webhooks.mdx` and `docs/getting-started/send-call-data-with-webhooks.mdx` to steer users to credentials; docs-only change, no runtime behavior change.

<sup>Written for commit 390cfeaf06ca3ebd6323027ff04d4621249fe500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary

The webhook documentation now directs users to stored credentials for authentication and accurately describes credential reuse, secret handling, credential rotation, and custom-header restrictions. The getting-started guide now points users to the Authentication field instead of placing secrets in workflow headers.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The focused checks confirmed that the updated documentation matches the exercised credential and webhook delivery behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused webhook authentication contract validation harness against credential validation, webhook delivery enqueueing and send-time resolution, credential response serialization, and custom-header filtering; the run completed its contract assertions successfully.
- Validated that api\_key with header\_name: "" is accepted and emitted as {"": "key"}, and confirmed that the docs wording no longer promises a default header name behavior (blank input remains under separate validation).

<a href="https://app.greptile.com/trex/runs/20347712/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address review feedback"](https://github.com/dograh-hq/dograh/commit/390cfeaf06ca3ebd6323027ff04d4621249fe500) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55659676)</sub>

<!-- /greptile_comment -->