### PR TITLE
fix: [Bug]: Grok Realtime — logged transcript is doubled/tripled ("ballooni...

### DIFF
--- a/api/services/pipecat/realtime/grok_realtime.py
+++ b/api/services/pipecat/realtime/grok_realtime.py
@@ -19,6 +19,7 @@ Adds:
 """
 
 import json
+from collections import OrderedDict
 from typing import Any
 
 from loguru import logger
@@ -42,6 +43,8 @@ from pipecat.services.xai.realtime import events
 from pipecat.services.xai.realtime.llm import GrokRealtimeLLMService
 from pipecat.utils.time import time_now_iso8601
 
+MAX_TRACKED_CONVERSATION_ITEM_IDS = 512
+
 
 class DograhGrokRealtimeLLMService(GrokRealtimeLLMService):
     """Grok Realtime with Dograh engine integration quirks."""
@@ -53,6 +56,7 @@ class DograhGrokRealtimeLLMService(GrokRealtimeLLMService):
         self._bot_is_speaking: bool = False
         self._deferred_node_transition_function_calls: list[FunctionCallFromLLM] = []
         self._pending_initial_greeting_text: str | None = None
+        self._handled_conversation_item_ids: OrderedDict[str, None] = OrderedDict()
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         if isinstance(frame, UserMuteStartedFrame):
@@ -302,6 +306,22 @@ class DograhGrokRealtimeLLMService(GrokRealtimeLLMService):
 
         except Exception as e:
             logger.error(f"Failed to process function call arguments: {e}")
+
+    async def _handle_evt_conversation_item_added(self, evt):
+        item_id = getattr(evt.item, "id", None)
+        if item_id is not None:
+            if item_id in self._handled_conversation_item_ids:
+                logger.debug(
+                    f"{self}: ignoring repeat conversation item event for {item_id}"
+                )
+                return
+            self._handled_conversation_item_ids[item_id] = None
+            while (
+                len(self._handled_conversation_item_ids)
+                > MAX_TRACKED_CONVERSATION_ITEM_IDS
+            ):
+                self._handled_conversation_item_ids.popitem(last=False)
+        await super()._handle_evt_conversation_item_added(evt)
 
     async def _handle_evt_input_audio_transcription_completed(self, evt):
         await self._call_event_handler(

--- a/api/services/pipecat/realtime/grok_realtime.py
+++ b/api/services/pipecat/realtime/grok_realtime.py
@@ -321,7 +321,12 @@ class DograhGrokRealtimeLLMService(GrokRealtimeLLMService):
                 > MAX_TRACKED_CONVERSATION_ITEM_IDS
             ):
                 self._handled_conversation_item_ids.popitem(last=False)
-        await super()._handle_evt_conversation_item_added(evt)
+        try:
+            await super()._handle_evt_conversation_item_added(evt)
+        except Exception:
+            if item_id is not None:
+                self._handled_conversation_item_ids.pop(item_id, None)
+            raise
 
     async def _handle_evt_input_audio_transcription_completed(self, evt):
         await self._call_event_handler(

--- a/api/services/pipecat/realtime/grok_realtime.py
+++ b/api/services/pipecat/realtime/grok_realtime.py
@@ -19,7 +19,6 @@ Adds:
 """
 
 import json
-from collections import OrderedDict
 from typing import Any
 
 from loguru import logger
@@ -43,8 +42,6 @@ from pipecat.services.xai.realtime import events
 from pipecat.services.xai.realtime.llm import GrokRealtimeLLMService
 from pipecat.utils.time import time_now_iso8601
 
-MAX_TRACKED_CONVERSATION_ITEM_IDS = 512
-
 
 class DograhGrokRealtimeLLMService(GrokRealtimeLLMService):
     """Grok Realtime with Dograh engine integration quirks."""
@@ -56,7 +53,7 @@ class DograhGrokRealtimeLLMService(GrokRealtimeLLMService):
         self._bot_is_speaking: bool = False
         self._deferred_node_transition_function_calls: list[FunctionCallFromLLM] = []
         self._pending_initial_greeting_text: str | None = None
-        self._handled_conversation_item_ids: OrderedDict[str, None] = OrderedDict()
+        self._handled_conversation_item_ids: set[str] = set()
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         if isinstance(frame, UserMuteStartedFrame):
@@ -315,17 +312,12 @@ class DograhGrokRealtimeLLMService(GrokRealtimeLLMService):
                     f"{self}: ignoring repeat conversation item event for {item_id}"
                 )
                 return
-            self._handled_conversation_item_ids[item_id] = None
-            while (
-                len(self._handled_conversation_item_ids)
-                > MAX_TRACKED_CONVERSATION_ITEM_IDS
-            ):
-                self._handled_conversation_item_ids.popitem(last=False)
+            self._handled_conversation_item_ids.add(item_id)
         try:
             await super()._handle_evt_conversation_item_added(evt)
         except Exception:
             if item_id is not None:
-                self._handled_conversation_item_ids.pop(item_id, None)
+                self._handled_conversation_item_ids.discard(item_id)
             raise
 
     async def _handle_evt_input_audio_transcription_completed(self, evt):

--- a/api/services/pipecat/realtime/grok_realtime.py
+++ b/api/services/pipecat/realtime/grok_realtime.py
@@ -316,7 +316,8 @@ class DograhGrokRealtimeLLMService(GrokRealtimeLLMService):
         try:
             await super()._handle_evt_conversation_item_added(evt)
         except Exception:
-            if item_id is not None:
+            assistant_turn_started = self._current_assistant_response is evt.item
+            if item_id is not None and not assistant_turn_started:
                 self._handled_conversation_item_ids.discard(item_id)
             raise
 

--- a/api/services/pipecat/realtime/grok_realtime.py
+++ b/api/services/pipecat/realtime/grok_realtime.py
@@ -306,20 +306,14 @@ class DograhGrokRealtimeLLMService(GrokRealtimeLLMService):
 
     async def _handle_evt_conversation_item_added(self, evt):
         item_id = getattr(evt.item, "id", None)
+        if item_id is not None and item_id in self._handled_conversation_item_ids:
+            logger.debug(
+                f"{self}: ignoring repeat conversation item event for {item_id}"
+            )
+            return
+        await super()._handle_evt_conversation_item_added(evt)
         if item_id is not None:
-            if item_id in self._handled_conversation_item_ids:
-                logger.debug(
-                    f"{self}: ignoring repeat conversation item event for {item_id}"
-                )
-                return
             self._handled_conversation_item_ids.add(item_id)
-        try:
-            await super()._handle_evt_conversation_item_added(evt)
-        except Exception:
-            assistant_turn_started = self._current_assistant_response is evt.item
-            if item_id is not None and not assistant_turn_started:
-                self._handled_conversation_item_ids.discard(item_id)
-            raise
 
     async def _handle_evt_input_audio_transcription_completed(self, evt):
         await self._call_event_handler(

--- a/api/tests/test_grok_realtime_wrapper.py
+++ b/api/tests/test_grok_realtime_wrapper.py
@@ -244,6 +244,25 @@ async def test_failed_conversation_item_event_is_reprocessed_on_redelivery():
     assert "item-1" in service._handled_conversation_item_ids
 
 
+@pytest.mark.asyncio
+async def test_failure_after_assistant_turn_started_keeps_item_deduplicated():
+    service = _make_service()
+    service._call_event_handler = AsyncMock()
+    service.push_frame = AsyncMock(side_effect=RuntimeError("boom"))
+
+    item = events.ConversationItem(id="item-1", type="message", role="assistant")
+
+    with pytest.raises(RuntimeError):
+        await service._handle_evt_conversation_item_added(SimpleNamespace(item=item))
+
+    assert "item-1" in service._handled_conversation_item_ids
+
+    service.push_frame = AsyncMock()
+    await service._handle_evt_conversation_item_added(SimpleNamespace(item=item))
+
+    service.push_frame.assert_not_awaited()
+
+
 def test_factory_creates_dograh_grok_realtime_service():
     effective_config = EffectiveAIModelConfiguration(
         is_realtime=True,

--- a/api/tests/test_grok_realtime_wrapper.py
+++ b/api/tests/test_grok_realtime_wrapper.py
@@ -225,6 +225,25 @@ async def test_repeat_conversation_item_event_does_not_restart_assistant_turn():
     )
 
 
+@pytest.mark.asyncio
+async def test_failed_conversation_item_event_is_reprocessed_on_redelivery():
+    service = _make_service()
+    service._call_event_handler = AsyncMock(side_effect=[RuntimeError("boom"), None])
+    service.push_frame = AsyncMock()
+
+    item = events.ConversationItem(id="item-1", type="message", role="assistant")
+
+    with pytest.raises(RuntimeError):
+        await service._handle_evt_conversation_item_added(SimpleNamespace(item=item))
+
+    assert "item-1" not in service._handled_conversation_item_ids
+
+    await service._handle_evt_conversation_item_added(SimpleNamespace(item=item))
+
+    assert service._current_assistant_response is item
+    assert "item-1" in service._handled_conversation_item_ids
+
+
 def test_factory_creates_dograh_grok_realtime_service():
     effective_config = EffectiveAIModelConfiguration(
         is_realtime=True,

--- a/api/tests/test_grok_realtime_wrapper.py
+++ b/api/tests/test_grok_realtime_wrapper.py
@@ -2,7 +2,11 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from pipecat.frames.frames import LLMMessagesAppendFrame, TTSSpeakFrame
+from pipecat.frames.frames import (
+    LLMFullResponseStartFrame,
+    LLMMessagesAppendFrame,
+    TTSSpeakFrame,
+)
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.xai.realtime import events
@@ -196,6 +200,29 @@ async def test_completed_input_transcription_is_broadcast_as_finalized():
     assert service.broadcast_frame.await_args.args[0].__name__ == "TranscriptionFrame"
     assert service.broadcast_frame.await_args.kwargs["text"] == "Hello there"
     assert service.broadcast_frame.await_args.kwargs["finalized"] is True
+
+
+@pytest.mark.asyncio
+async def test_repeat_conversation_item_event_does_not_restart_assistant_turn():
+    service = _make_service()
+    service._call_event_handler = AsyncMock()
+    service.push_frame = AsyncMock()
+
+    item = events.ConversationItem(id="item-1", type="message", role="assistant")
+
+    await service._handle_evt_conversation_item_added(SimpleNamespace(item=item))
+    await service._handle_evt_conversation_item_added(SimpleNamespace(item=item))
+
+    response_start_frames = [
+        call.args[0]
+        for call in service.push_frame.await_args_list
+        if isinstance(call.args[0], LLMFullResponseStartFrame)
+    ]
+    assert len(response_start_frames) == 1
+    assert service._current_assistant_response is item
+    service._call_event_handler.assert_awaited_once_with(
+        "on_conversation_item_created", "item-1", item
+    )
 
 
 def test_factory_creates_dograh_grok_realtime_service():

--- a/api/tests/test_grok_realtime_wrapper.py
+++ b/api/tests/test_grok_realtime_wrapper.py
@@ -245,7 +245,7 @@ async def test_failed_conversation_item_event_is_reprocessed_on_redelivery():
 
 
 @pytest.mark.asyncio
-async def test_failure_after_assistant_turn_started_keeps_item_deduplicated():
+async def test_failed_start_frame_is_retried_on_redelivery():
     service = _make_service()
     service._call_event_handler = AsyncMock()
     service.push_frame = AsyncMock(side_effect=RuntimeError("boom"))
@@ -255,12 +255,18 @@ async def test_failure_after_assistant_turn_started_keeps_item_deduplicated():
     with pytest.raises(RuntimeError):
         await service._handle_evt_conversation_item_added(SimpleNamespace(item=item))
 
-    assert "item-1" in service._handled_conversation_item_ids
+    assert "item-1" not in service._handled_conversation_item_ids
 
     service.push_frame = AsyncMock()
     await service._handle_evt_conversation_item_added(SimpleNamespace(item=item))
 
-    service.push_frame.assert_not_awaited()
+    response_start_frames = [
+        call.args[0]
+        for call in service.push_frame.await_args_list
+        if isinstance(call.args[0], LLMFullResponseStartFrame)
+    ]
+    assert len(response_start_frames) == 1
+    assert "item-1" in service._handled_conversation_item_ids
 
 
 def test_factory_creates_dograh_grok_realtime_service():


### PR DESCRIPTION
Fixes #682

## Root cause

Grok Realtime opens an assistant turn twice per conversation item

## Changes

- DograhGrokRealtimeLLMService now handles each conversation item exactly once, so the duplicate xAI item events no longer push a second LLMFullResponseStartFrame (and a second on_conversation_item_created) per assistant item.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Grok Realtime from starting an assistant turn multiple times when xAI delivers duplicate conversation-item-added events. Before: duplicates opened a second turn and emitted extra LLMFullResponseStartFrame and on_conversation_item_created; now each item is handled once, duplicates are ignored, and retry is allowed only if the first attempt failed before the assistant turn started.

- Tracks handled item IDs per service and skips repeats with a debug log.
- On errors before a turn starts, clears the ID so redelivery is retried; after a turn starts, keeps the ID to avoid duplicate output.
- Adds tests for single LLMFullResponseStartFrame/on_conversation_item_created on duplicates, retry after early failure, and suppression after late failure.
- No public API or configuration changes.

<sup>Written for commit 05001e41f0fc45caeefdc888c421e63ccb0901aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The change suppresses repeat Grok conversation-item events after a handler completes and keeps retries available when processing fails before response output. One reliability failure remains: if the inherited handler emits an assistant response-start frame and then fails later, redelivering the same item emits a second response-start frame and can create a duplicate assistant turn.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until retries after partial assistant output cannot start a second assistant turn.

The reproduced failure is limited to a post-output exception path in `api/services/pipecat/realtime/grok_realtime.py`. Roshan931 stated that the item ID remains tracked once inherited handling has claimed the assistant turn, but current code adds the ID only after `await super()._handle_evt_conversation_item_added(evt)` returns. The executed retry test observed one response-start frame on the first delivery and a second response-start frame when the same item was redelivered after a later failure.

**Files Needing Attention:** api/services/pipecat/realtime/grok_realtime.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding, as noted in the first review comment.
- T-Rex produced a second proof for a posted P1 finding, as noted in the second review comment.
- T-Rex completed a general-contract-validation pass that documents the focused retry/idempotency test source, the observed output showing starts=1 and starts=2, and the existing Grok wrapper test results (12 passing tests), confirming the focused repro runs alongside wrapper coverage.

<a href="https://app.greptile.com/trex/runs/20614466/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Failed assistant start frame is permanently suppressed on redelivery**

   - **Bug**
     - When the superclass sets `_current_assistant_response` to the assistant item and then `push_frame(LLMFullResponseStartFrame())` raises, the candidate handler keeps that item's ID in `_handled_conversation_item_ids`. A redelivery returns at lines 310-314, so it cannot retry the start frame; the executed after run observed zero `push_frame` calls on redelivery.
   - **Cause**
     - The cleanup decision at lines 319-320 treats identity assignment as proof that the assistant turn started, even though the only start-frame emission at upstream line 795 failed.
   - **Fix**
     - Discard `item_id` on any exception from the superclass handler, as in the prior implementation, or track successful start-frame delivery separately and retain the ID only after that delivery succeeds.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Redelivery after a post-start failure emits a duplicate assistant response start**

   - **Bug**
     - The focused runtime test invoked the real Pipecat superclass handler, which calls the conversation-created callback, sets the assistant response, and pushes `LLMFullResponseStartFrame`; it then simulated a later exception. For the exact same item, first delivery reported `starts=1 handled=False`, while redelivery reported `starts=2 handled=False`. Thus each retry produces another externally emitted response-start frame.
   - **Cause**
     - The wrapper records `item_id` only after `await super()._handle_evt_conversation_item_added(evt)` completes successfully. An exception after the superclass has successfully delivered a start frame bypasses the set insertion, leaving the event eligible for retry even though partial output was already emitted. The superclass's start emission is at `pipecat/src/pipecat/services/xai/realtime/llm.py:793-795`; the late dedupe commit is at `api/services/pipecat/realtime/grok_realtime.py:314-316`.
   - **Fix**
     - Track a distinct committed/partially-emitted state once the assistant start frame is successfully delivered, while retaining retryability when the callback fails before output or when start-frame delivery itself fails. This needs an explicit boundary around the superclass's side effects rather than treating complete superclass return as the commit point.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["fix: address review feedback"](https://github.com/dograh-hq/dograh/commit/3a748cca32554eae8c3ed675e6cb42765a128306) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55660257)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->