### PR TITLE
feat(telephony): expose provider call ID in workflow initial context

### DIFF
--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -386,6 +386,7 @@ async def _run_pipeline_telephony_impl(
             workflow_run=workflow_run,
             resolved_user_config=user_config,
             organization_id=organization_id,
+            provider_call_id=call_id,
         )
     except Exception as e:
         # Closest layer to the failure and the only one with the traceback, so
@@ -557,6 +558,7 @@ async def _run_pipeline_impl(
     workflow_run=None,
     resolved_user_config=None,
     organization_id: int | None = None,
+    provider_call_id: str | None = None,
 ) -> None:
     """
     Run the pipeline with the given transport and configuration
@@ -599,6 +601,12 @@ async def _run_pipeline_impl(
         merged_call_context_vars = merge_external_initial_context(
             merged_call_context_vars, call_context_vars
         )
+
+    # Only telephony passes an authenticated provider call identifier. Make it
+    # available to workflow prompts and tools, overriding any stale or
+    # externally supplied value persisted on the workflow run.
+    if provider_call_id is not None:
+        merged_call_context_vars["call_id"] = provider_call_id
 
     # Get workflow for metadata (name, organization_id, call_disposition_codes)
     workflow = await db_client.get_workflow(workflow_id, **workflow_scope)

--- a/api/services/workflow/initial_context.py
+++ b/api/services/workflow/initial_context.py
@@ -8,7 +8,12 @@ from api.services.managed_model_services import MPS_CORRELATION_ID_CONTEXT_KEY
 # These values describe or authorize the run itself. External context may add
 # prompt variables, but it must never supply or replace run-owned metadata.
 RESERVED_INITIAL_CONTEXT_KEYS = frozenset(
-    {"provider", "runtime_configuration", MPS_CORRELATION_ID_CONTEXT_KEY}
+    {
+        "call_id",
+        "provider",
+        "runtime_configuration",
+        MPS_CORRELATION_ID_CONTEXT_KEY,
+    }
 )
 
 GREETING_OVERRIDE_CONTEXT_KEY = "greeting_override"

--- a/api/tests/test_initial_context.py
+++ b/api/tests/test_initial_context.py
@@ -3,6 +3,7 @@ from api.services.workflow.initial_context import merge_external_initial_context
 
 def test_external_context_cannot_replace_reserved_run_metadata():
     initial_context = {
+        "call_id": "run-call-id",
         "provider": "twilio",
         "runtime_configuration": {"llm_model": "gpt-4.1"},
         "mps_correlation_id": "run-correlation-id",
@@ -12,6 +13,7 @@ def test_external_context_cannot_replace_reserved_run_metadata():
     merged = merge_external_initial_context(
         initial_context,
         {
+            "call_id": "external-call-id",
             "provider": "external-provider",
             "runtime_configuration": {"llm_model": "external-model"},
             "mps_correlation_id": "external-correlation-id",
@@ -20,6 +22,7 @@ def test_external_context_cannot_replace_reserved_run_metadata():
     )
 
     assert merged == {
+        "call_id": "run-call-id",
         "provider": "twilio",
         "runtime_configuration": {"llm_model": "gpt-4.1"},
         "mps_correlation_id": "run-correlation-id",
@@ -31,6 +34,7 @@ def test_external_context_cannot_introduce_reserved_run_metadata():
     assert merge_external_initial_context(
         {},
         {
+            "call_id": "external-call-id",
             "provider": "external-provider",
             "runtime_configuration": {"llm_model": "external-model"},
             "mps_correlation_id": "external-correlation-id",


### PR DESCRIPTION
## Checklist

- [x] I have read and followed the [contributing guidelines](https://github.com/dograh-hq/dograh/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes the provider call ID as call_id in the workflow initial context for telephony runs and protects it as run-owned metadata. Previously call_id could be absent or set by external context; now telephony supplies it and the pipeline overrides any existing value, blocking spoofing and stale data.

- Telephony passes an authenticated provider_call_id into `_run_pipeline_impl`, which sets merged initial context call_id and overrides any prior value.
- Adds call_id to reserved initial context keys; external initial context cannot add or replace it.
- Migration: Stop setting call_id in external initial context; rely on the system-provided value for telephony runs. Non-telephony runs remain unchanged.

<sup>Written for commit 6a07fedf6cfd49ee5b3257ed19fb9ff59a749a50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change exposes the authenticated telephony provider call ID as the reserved `call_id` workflow-context value, ensuring stale stored values and caller-provided context cannot replace it. Focused execution confirmed that the provider ID is forwarded into the shared implementation, wins over conflicting values, and is persisted with the workflow run. The committed tests cover only reserved-key filtering, so a future regression in the telephony handoff or persistence path would not be detected.

<h3>Confidence Score: 4/5</h3>

The runtime behavior was exercised successfully, but the change should gain focused regression coverage before merge so the telephony call-ID contract remains protected.

A focused before-and-after harness exercised the affected forwarding, conflict-precedence, and persistence behavior. It confirmed one test-coverage issue and no additional defect in the examined path.

**Files Needing Attention:** `api/tests/test_initial_context.py` needs a focused test covering the telephony wrapper, the resolved `call_id` value, and the workflow-run persistence update; the exercised runtime code is in `api/services/pipecat/run_pipeline.py`.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Published a finding-comment-proof for a posted P2 finding, including the focused telephony call-ID handoff harness to exercise the runtime path.
- Captured an initial run showing the parent commit failed the telephony call-ID handoff assertion as seen in the corresponding log.
- Verified that the candidate passes telephony call-ID forwarding and persistence after the harness run, as indicated by the second log.
- Validated the contract with a focused runtime test for the handoff at api/services/pipecat/run\_pipeline.py:379-390, precedence at :597-609, and persistence at :743-749, and noted that existing PR test coverage is limited to merge\_external\_initial\_context in api/tests/test\_initial\_context.py:4-43.

<a href="https://app.greptile.com/trex/runs/20310566/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `api/tests/test_initial_context.py`, line 4-43 ([link](https://github.com/dograh-hq/dograh/blob/6a07fedf6cfd49ee5b3257ed19fb9ff59a749a50/api/tests/test_initial_context.py#L4-L43)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Telephony call-ID behavior lacks runtime coverage**

   The added tests only cover filtering `call_id` from external initial-context data. They do not exercise the telephony wrapper forwarding the authenticated provider call ID, its precedence over stale or external `call_id` values, or persistence of the resulting context. Add a focused runtime test covering the wrapper-to-core handoff and asserting the value passed to `update_workflow_run` remains the provider call ID when conflicting values are present.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Focused telephony call-ID handoff harness](https://app.greptile.com/trex/artifacts/61f7deea-6cb6-4c6f-8361-8931be5635d7)**

   - The executed harness loads and invokes the changed telephony and core pipeline functions, asserting forwarding, conflict precedence, and the persisted context; it demonstrates the missing test scope.

   **[Parent commit fails the telephony call-ID handoff assertion](https://app.greptile.com/trex/artifacts/1a269343-f06d-44d6-86db-d01c6bd90eb5)**

   - Running the focused harness against parent commit c03e995 fails because the wrapper did not pass provider\_call\_id to the core pipeline; this proves the behavioral delta.

   **[Candidate passes telephony call-ID forwarding and persistence](https://app.greptile.com/trex/artifacts/601fb58e-758b-49ee-853b-2e18f91242eb)**

   - Running the same harness against candidate commit 6a07fed exits successfully after verifying provider-ID forwarding and persistence over stale/external values; the changed behavior works but lacks repository coverage.

   <a href="https://app.greptile.com/trex/runs/20310566/artifacts?artifact=61f7deea-6cb6-4c6f-8361-8931be5635d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Telephony call-ID forwarding, precedence, and persistence are untested**

   - **Bug**
     - The PR's only changed tests validate reserved-key filtering in `merge_external_initial_context`. They do not execute the telephony wrapper that forwards the provider call ID, the core pipeline logic that overrides stale/external `call_id` values, or the workflow-run persistence update.
   - **Cause**
     - Tests were added at the helper layer only, while the feature spans `_run_pipeline_telephony_impl` and `_run_pipeline_impl`.
   - **Fix**
     - Add an async focused test that invokes `_run_pipeline_telephony_impl` with mocked transport/config dependencies, asserts `_run_pipeline_impl(... provider_call_id=call_id)`, then invokes or observes `_run_pipeline_impl` with conflicting stored/external IDs and asserts `db_client.update_workflow_run(... initial_context=...)` contains the provider call ID.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(telephony): expose provider call ID..."](https://github.com/dograh-hq/dograh/commit/6a07fedf6cfd49ee5b3257ed19fb9ff59a749a50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56134975)</sub>

<!-- /greptile_comment -->