### PR TITLE
added meta pixel

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -57,6 +57,9 @@ MINIO_SECURE=false
 # LANGFUSE_PUBLIC_KEY="pk-lf-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 # LANGFUSE_HOST="https://cloud.langfuse.com"
 # LANGFUSE_PROJECT_ID="cmxxxxxxxxxxxxxxxxxxxxxxx"
+# Traces are private by default. Set to true to make them readable by anyone
+# holding the trace URL, with no Langfuse login.
+# LANGFUSE_TRACES_PUBLIC=false
 
 # TURN Server Configuration (for WebRTC NAT traversal)
 # Required for reliable WebRTC connections behind firewalls/NAT

--- a/api/services/workflow/tools/knowledge_base.py
+++ b/api/services/workflow/tools/knowledge_base.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from loguru import logger
 from opentelemetry import trace
+from pipecat.utils.tracing.langfuse_helpers import mark_trace_public
 
 from api.db import db_client
 from api.services.gen_ai import build_embedding_service
@@ -84,8 +85,7 @@ async def retrieve_from_knowledge_base(
                 "knowledge_base_retrieval", context=parent_context
             ) as span:
                 try:
-                    # Mark trace as public for Langfuse
-                    span.set_attribute("langfuse.trace.public", True)
+                    mark_trace_public(span)
 
                     # Add operation metadata
                     span.set_attribute(

--- a/deploy/helm/dograh/templates/configmap.yaml
+++ b/deploy/helm/dograh/templates/configmap.yaml
@@ -42,3 +42,6 @@ data:
   {{- if .Values.secrets.langfuseProjectId }}
   LANGFUSE_PROJECT_ID: {{ .Values.secrets.langfuseProjectId | quote }}
   {{- end }}
+  {{- if .Values.secrets.langfuseTracesPublic }}
+  LANGFUSE_TRACES_PUBLIC: {{ .Values.secrets.langfuseTracesPublic | quote }}
+  {{- end }}

--- a/deploy/helm/dograh/values.yaml
+++ b/deploy/helm/dograh/values.yaml
@@ -161,6 +161,9 @@ secrets:
   langfusePublicKey: ""
   langfuseHost: ""
   langfuseProjectId: ""
+  # Traces are private by default. "true" makes them readable by anyone holding
+  # the trace URL, with no Langfuse login.
+  langfuseTracesPublic: ""
 
   # Signs the telephony media WebSocket URL the carrier dials back, so the ids
   # in that URL are no longer enough on their own to open the socket. Empty

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -233,6 +233,9 @@ services:
       # LANGFUSE_PUBLIC_KEY: ""
       # LANGFUSE_HOST: ""
       # LANGFUSE_PROJECT_ID: ""
+      # Traces are private by default. Set to "true" to make them readable by
+      # anyone holding the trace URL, with no Langfuse login.
+      LANGFUSE_TRACES_PUBLIC: "${LANGFUSE_TRACES_PUBLIC:-false}"
 
       # TURN server configuration (for WebRTC NAT traversal in remote server)
       # Uses time-limited credentials via TURN REST API (HMAC-SHA1).

--- a/docs/configurations/tracing.mdx
+++ b/docs/configurations/tracing.mdx
@@ -120,8 +120,12 @@ We provide seamless integration with Langfuse for tracing if you want to use you
 
 Once enabled, traces will be available for every completed call in Dograh.
 
+<Warning>
+Traces are private by default — opening a trace link requires access to your Langfuse project. Setting `LANGFUSE_TRACES_PUBLIC=true` makes every trace readable by anyone holding its URL, with no login, which exposes full call transcripts, prompts, and tool payloads. Only enable it if you intend to share trace links outside your Langfuse project.
+</Warning>
+
 <Note>
-For self-hosted deployments, you can also configure Langfuse via [environment variables](/developer/environment-variables#tracing-langfuse) (`LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_HOST`) as a default for all organizations. Tracing activates automatically once credentials are available — no separate enable flag is required. Per-organization credentials set in the UI take precedence over environment variables.
+For self-hosted deployments, you can also configure Langfuse via [environment variables](/developer/environment-variables#tracing-langfuse) (`LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_HOST`, `LANGFUSE_PROJECT_ID`) as a default for all organizations. Tracing activates automatically once credentials are available — no separate enable flag is required. Per-organization credentials set in the UI take precedence over environment variables.
 </Note>
 
 ## Quick Reference

--- a/docs/developer/environment-variables.mdx
+++ b/docs/developer/environment-variables.mdx
@@ -148,8 +148,10 @@ Presigned URLs point at `S3_ENDPOINT_URL`, so that host must be reachable from t
 | `LANGFUSE_HOST` | `null` | Langfuse server URL |
 | `LANGFUSE_PUBLIC_KEY` | `null` | Langfuse public key |
 | `LANGFUSE_SECRET_KEY` | `null` | Langfuse secret key |
+| `LANGFUSE_PROJECT_ID` | `null` | Langfuse project ID, required with environment credentials to generate trace URLs |
+| `LANGFUSE_TRACES_PUBLIC` | `false` | When `true`, traces are marked public in Langfuse — anyone holding a trace URL can read it without logging in. Leave unset to keep traces visible only to your Langfuse project members. |
 
-Tracing activates automatically as soon as credentials are available — either via these environment variables (applied to all organizations) or per-organization in the UI under **Platform Settings**. If neither is set, spans are dropped silently. See the [Tracing guide](/configurations/tracing) for setup instructions.
+Tracing activates automatically as soon as credentials are available — either via these environment variables (applied to all organizations) or per-organization in the UI under **Platform Settings**. Environment credentials require `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_PROJECT_ID`. If neither is set, spans are dropped silently. See the [Tracing guide](/configurations/tracing) for setup instructions.
 
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keep Langfuse traces private by default and gate public visibility behind configuration. Previously, knowledge base retrieval set `langfuse.trace.public=true` inline, which could expose an entire call trace; now visibility flows through `pipecat`’s `mark_trace_public(...)` and respects `LANGFUSE_TRACES_PUBLIC`.

- Replace direct span attribute with `pipecat.utils.tracing.langfuse_helpers.mark_trace_public`; bump `pipecat` submodule to include the helper.
- Add `LANGFUSE_TRACES_PUBLIC` across `.env.example`, `docker-compose.yaml`, and Helm (`secrets.langfuseTracesPublic` → `LANGFUSE_TRACES_PUBLIC` in the ConfigMap).
- Update docs: warn about public traces; add `LANGFUSE_PROJECT_ID` as required when using environment credentials; clarify default-private behavior.
- Migration: If you need shareable trace links, set `LANGFUSE_TRACES_PUBLIC=true` (Helm: set `secrets.langfuseTracesPublic: "true"`). Otherwise, no action is required and traces stay private.

<sup>Written for commit 4cb69216fb6196225227852888c736d2cab9c06d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes Langfuse traces private by default, adds an explicit opt-in for public trace links, and documents the related deployment settings.

One P2 configuration issue remains: the Helm value controlling public trace links is rendered as a non-sensitive ConfigMap value but is placed in the chart’s `secrets` namespace. Operators following the chart’s configuration split may set `config.langfuseTracesPublic`, which the template does not consume.

### T-Rex validation blocked

The Helm rendering comparison could not run because the `helm` tool is not installed. The attempted checks and their captured output are attached below.

<h3>Confidence Score: 4/5</h3>

Safe to merge after correcting the Helm values namespace; the remaining issue is configuration discoverability rather than a runtime failure.

There is one independent P2, non-security finding. Under the scoring table, P2-only findings result in a score of 4.

**Files Needing Attention:** deploy/helm/dograh/values.yaml and deploy/helm/dograh/templates/configmap.yaml should use config.langfuseTracesPublic consistently.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The comparison script was run to render Helm templates for both config.langfuseTracesPublic=true and secrets.langfuseTracesPublic=true.
- Both render attempts reported that the helm executable is unavailable, so no rendered manifests were produced.
- Artifacts capturing the Helm render command and the two render-attempt logs were collected for review.

<a href="https://app.greptile.com/trex/runs/20451902/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep Langfuse traces private by def..."](https://github.com/dograh-hq/dograh/commit/4cb69216fb6196225227852888c736d2cab9c06d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56402882)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->