### PR TITLE
added meta pixel

### DIFF
--- a/ui/.env.example
+++ b/ui/.env.example
@@ -12,3 +12,5 @@ NEXT_PUBLIC_NODE_ENV=development
 # NEXT_PUBLIC_ONBOARDING_API_URL=http://localhost:8001
 # Google Tag Manager container ID (e.g. GTM-XXXXXXX); GTM is not loaded when blank
 NEXT_PUBLIC_GTM_ID=
+# Meta (Facebook) Pixel ID; the Pixel is not loaded when blank (OSS/dev)
+NEXT_PUBLIC_META_PIXEL_ID=

--- a/ui/src/app/billing/page.tsx
+++ b/ui/src/app/billing/page.tsx
@@ -33,6 +33,7 @@ import { useAppConfig } from "@/context/AppConfigContext";
 import { useOrganizationTimezone } from "@/hooks/useOrganizationTimezone";
 import { useAuth } from "@/lib/auth";
 import { formatDateTime } from "@/lib/dateTime";
+import { trackMetaInitiateCheckout } from "@/lib/metaPixel";
 
 const LEDGER_PAGE_SIZE = 50;
 
@@ -207,6 +208,9 @@ export default function BillingPage() {
             return;
         }
 
+        // Fire on checkout intent (the click). The purchase-URL round-trip below
+        // gives the pixel beacon time to flush before the full-page redirect.
+        trackMetaInitiateCheckout();
         setPurchasing(true);
         try {
             const response = await createMpsCreditPurchaseUrlApiV1OrganizationsUsageMpsCreditsPurchaseUrlPost();

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { Suspense } from "react";
 
 import ChatwootWidget from "@/components/ChatwootWidget";
 import AppLayout from "@/components/layout/AppLayout";
+import MetaPixel from "@/components/MetaPixel";
 import PostHogIdentify from "@/components/PostHogIdentify";
 import { SentryErrorBoundary } from "@/components/SentryErrorBoundary";
 import SpinLoader from "@/components/SpinLoader";
@@ -40,6 +41,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   const gtmId = process.env.NEXT_PUBLIC_GTM_ID?.trim();
+  const metaPixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID?.trim();
 
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
@@ -68,6 +70,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         {gtmId ? <GoogleTagManager gtmId={gtmId} /> : null}
+        {metaPixelId ? <MetaPixel pixelId={metaPixelId} /> : null}
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false} disableTransitionOnChange>
           <SentryErrorBoundary>
             <AuthProvider>

--- a/ui/src/components/MetaPixel.tsx
+++ b/ui/src/components/MetaPixel.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Script from "next/script";
+import { useEffect, useRef } from "react";
+
+import { trackMetaPageView } from "@/lib/metaPixel";
+
+/**
+ * MetaPixel
+ * ---------
+ * Loads the Meta (Facebook) Pixel base code and tracks client-side route changes.
+ *
+ * Rendered in the root layout (`app/layout.tsx`) ONLY when NEXT_PUBLIC_META_PIXEL_ID
+ * is set, so it never loads for OSS/self-hosted deployments (which leave the var
+ * blank) — mirroring how Google Tag Manager is gated.
+ *
+ * The base snippet fires the initial PageView. Next.js App Router navigations are
+ * client-side, so subsequent PageViews are fired manually on pathname change.
+ */
+export default function MetaPixel({ pixelId }: { pixelId: string }) {
+    const pathname = usePathname();
+    // Track the last path we emitted a PageView for. The base snippet already
+    // fires PageView for the initial path, so we only fire on subsequent
+    // *changes* — this also stays correct under React StrictMode's double-invoke.
+    const lastPathRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (lastPathRef.current === null) {
+            lastPathRef.current = pathname; // initial PageView handled by the base snippet
+            return;
+        }
+        if (pathname !== lastPathRef.current) {
+            lastPathRef.current = pathname;
+            trackMetaPageView();
+        }
+    }, [pathname]);
+
+    return (
+        <>
+            <Script id="meta-pixel" strategy="afterInteractive">
+                {`!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+fbq('init', '${pixelId}');
+fbq('track', 'PageView');`}
+            </Script>
+            <noscript>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                    height="1"
+                    width="1"
+                    style={{ display: "none" }}
+                    alt=""
+                    src={`https://www.facebook.com/tr?id=${pixelId}&ev=PageView&noscript=1`}
+                />
+            </noscript>
+        </>
+    );
+}

--- a/ui/src/components/lead-forms/submitLead.ts
+++ b/ui/src/components/lead-forms/submitLead.ts
@@ -6,6 +6,7 @@
 import posthog from "posthog-js";
 
 import { PostHogEvent } from "@/constants/posthog-events";
+import { trackMetaLead } from "@/lib/metaPixel";
 
 import { detectCountry, detectTimezone } from "./detectCountry";
 import type { LeadKind, LeadOrigin, LeadSource } from "./leadFieldOptions";
@@ -32,6 +33,7 @@ export async function submitLead({ kind, source, origin, payload }: SubmitLeadAr
   const body = { source, origin, country: detectCountry(), timezone: detectTimezone(), ...payload };
   // PostHog capture — the durable record, always fired.
   posthog.capture(SUBMIT_EVENT[kind], body);
+  trackMetaLead({ content_name: kind, source });
   // Persist to the separate user_onboarding service (best-effort, public); return its verdict.
   return postLeadToService(kind, body);
 }

--- a/ui/src/components/lead-forms/submitOnboarding.ts
+++ b/ui/src/components/lead-forms/submitOnboarding.ts
@@ -11,6 +11,7 @@
 import posthog from "posthog-js";
 
 import { PostHogEvent } from "@/constants/posthog-events";
+import { trackMetaLead } from "@/lib/metaPixel";
 
 import { detectCountry } from "./detectCountry";
 import type { LeadOrigin } from "./leadFieldOptions";
@@ -38,6 +39,7 @@ export async function submitOnboarding(
   email?: string,
 ): Promise<void> {
   posthog.capture(PostHogEvent.ONBOARDING_SUBMITTED, { ...answers, origin });
+  trackMetaLead({ content_name: "onboarding", origin });
   await postOnboardingToService({
     source: "onboarding",
     origin,

--- a/ui/src/context/LeadFormsContext.tsx
+++ b/ui/src/context/LeadFormsContext.tsx
@@ -11,6 +11,7 @@ import { OnboardingModal } from "@/components/lead-forms/OnboardingModal";
 import { PostHogEvent } from "@/constants/posthog-events";
 import { useOnboarding } from "@/context/OnboardingContext";
 import { useAuth } from "@/lib/auth";
+import { trackMetaCompleteRegistration } from "@/lib/metaPixel";
 
 interface LeadFormsContextValue {
   openHireExpert: (source: LeadSource) => void;
@@ -71,6 +72,9 @@ export function LeadFormsProvider({ children }: { children: ReactNode }) {
         if (res.data?.total === 0 && !onboardingDoneRef.current) {
           setOnboardingOpen(true);
           posthog.capture(PostHogEvent.ONBOARDING_SHOWN);
+          // Brand-new user detected (0 workflows, onboarding not yet done) — the
+          // app's canonical "just registered" signal. Meta standard event.
+          trackMetaCompleteRegistration();
         }
       } catch {
         // If the count can't be fetched, do NOT show the modal — fail closed so

--- a/ui/src/lib/metaPixel.ts
+++ b/ui/src/lib/metaPixel.ts
@@ -1,0 +1,46 @@
+/**
+ * Meta (Facebook) Pixel — thin, guarded tracking seam.
+ *
+ * This repo calls PostHog directly (see constants/posthog-events.ts); there is no
+ * central analytics wrapper. We mirror that convention: call these helpers at the
+ * same sites we already `posthog.capture(...)`.
+ *
+ * Every helper is a no-op unless the Pixel is actually loaded (i.e. `window.fbq`
+ * exists). The Pixel only loads on Cloud, where NEXT_PUBLIC_META_PIXEL_ID is set
+ * at build time (see components/MetaPixel.tsx + app/layout.tsx). OSS self-hosters
+ * and local dev leave the var blank, so `fbq` never loads and nothing is sent.
+ */
+
+declare global {
+  interface Window {
+    fbq?: (...args: unknown[]) => void;
+  }
+}
+
+type MetaEventParams = Record<string, unknown>;
+
+/** Fire a Meta standard event, guarded on the Pixel being loaded. */
+function metaTrack(event: string, params?: MetaEventParams): void {
+  if (typeof window === "undefined" || typeof window.fbq !== "function") return;
+  if (params) {
+    window.fbq("track", event, params);
+  } else {
+    window.fbq("track", event);
+  }
+}
+
+export function trackMetaPageView(): void {
+  metaTrack("PageView");
+}
+
+export function trackMetaCompleteRegistration(params?: MetaEventParams): void {
+  metaTrack("CompleteRegistration", params);
+}
+
+export function trackMetaLead(params?: MetaEventParams): void {
+  metaTrack("Lead", params);
+}
+
+export function trackMetaInitiateCheckout(params?: MetaEventParams): void {
+  metaTrack("InitiateCheckout", params);
+}


### PR DESCRIPTION
## Checklist

- [x] I have read and followed the [contributing guidelines](https://github.com/dograh-hq/dograh/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Meta (Facebook) Pixel gated by `NEXT_PUBLIC_META_PIXEL_ID` and tracks PageView, Lead, CompleteRegistration, and InitiateCheckout. Previously no Meta events were sent; now these fire only when the env var is set, with all calls no-op in OSS/dev.

- Loads `MetaPixel` from the root layout when `NEXT_PUBLIC_META_PIXEL_ID` is present; initializes `fbq`, fires the initial PageView, tracks App Router navigations, and includes a noscript beacon.
- Adds guarded helpers in `ui/src/lib/metaPixel.ts` and wires them to: lead submit (`Lead`), onboarding submit (`Lead`), onboarding shown for first-time users (`CompleteRegistration`), and billing purchase click (`InitiateCheckout`, fired before redirect to allow the beacon to flush).
- Guards all tracking on `window.fbq` and dedupes the initial PageView to avoid React Strict Mode double-invocation.
- Rollout: set `NEXT_PUBLIC_META_PIXEL_ID` in the Cloud environment; no changes required for self-hosted. `.env.example` documents the new variable.

<sup>Written for commit 5b476c2c6ee9e1d1b49732fb1f3cfc913f865253. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds environment-gated Meta Pixel loading and conversion tracking for page views, lead actions, onboarding, and checkout intent. A focused runtime reproduction confirmed that returning users who remain eligible for onboarding can generate duplicate `CompleteRegistration` conversions when the lead-forms provider remounts. This should be corrected before merge to preserve advertising conversion accuracy.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until registration conversion tracking is deduplicated across provider remounts.

There is one verified, non-security P1 finding. Under the required scoring table, one non-security P1 results in a score of 4.

**Files Needing Attention:** ui/src/context/LeadFormsContext.tsx needs an event-specific, durable deduplication mechanism or the conversion emission must move to the actual registration-completion flow.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the review comment.
- T-Rex prepared a focused provider-remount reproduction source to support verification of the P1 finding.
- T-Rex ran the single-provider mount test and captured its output for review.
- T-Rex ran the provider remount duplicate-event test and captured its output for review.
- T-Rex performed validation steps to map the test results to the posted P1 finding in the review comment.

<a href="https://app.greptile.com/trex/runs/20452552/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["added meta pixel"](https://github.com/dograh-hq/dograh/commit/5b476c2c6ee9e1d1b49732fb1f3cfc913f865253) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56404088)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->