### PR TITLE
feat: click to copy telephony phone ID

### DIFF
--- a/ui/src/app/telephony-configurations/[configId]/page.tsx
+++ b/ui/src/app/telephony-configurations/[configId]/page.tsx
@@ -442,6 +442,7 @@ export default function TelephonyConfigurationDetailPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>Address</TableHead>
+                  <TableHead>Phone number ID</TableHead>
                   <TableHead>Type</TableHead>
                   <TableHead>Label</TableHead>
                   <TableHead>Status</TableHead>
@@ -456,6 +457,22 @@ export default function TelephonyConfigurationDetailPage() {
                 {phoneNumbers.map((n) => (
                   <TableRow key={n.id}>
                     <TableCell className="font-mono">{n.address}</TableCell>
+                    <TableCell>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          copyTextToClipboard(String(n.id))
+                            .then(() => toast.success("Phone number ID copied"))
+                            .catch(() => toast.error("Failed to copy ID"));
+                        }}
+                        title="Click to copy phone number ID"
+                        aria-label={`Copy phone number ID ${n.id}`}
+                        className="group inline-flex items-center gap-1 rounded font-mono text-xs text-muted-foreground hover:text-foreground"
+                      >
+                        <span>{n.id}</span>
+                        <Copy className="h-3 w-3 shrink-0" />
+                      </button>
+                    </TableCell>
                     <TableCell>
                       <Badge variant="outline">{n.address_type}</Badge>
                     </TableCell>


### PR DESCRIPTION
## Checklist

- [x] I have read and followed the [contributing guidelines](https://github.com/dograh-hq/dograh/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a copyable Phone number ID column to the telephony configuration page so users can grab the ID without manual selection.

- Clicking the ID copies it to the clipboard and shows a success or failure toast.

<sup>Written for commit bc42aca023417df9f3025959520a5358b4395dd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Phone number ID column to the telephony configuration detail page, with an accessible per-row control for copying the identifier. Rendered-page testing verified that each row displays correctly, a selected numeric ID is copied exactly as text with a success notification, and clipboard errors produce the expected failure notification.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge based on focused runtime coverage of the rendered phone-number table and both clipboard outcomes.

The focused test rendered two phone-number rows, verified exact copying of the selected numeric identifier, and exercised both resolved and rejected clipboard operations successfully.

**Files Needing Attention:** No files need additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Vitest test for phone-number ID copy in the UI was run in the UI repository and exited with code 0.
- The rendered-page harness supplied two numeric phone-number IDs, the copy action was triggered, and the test confirmed that the copied ID was captured as a string and that a success notification appeared, while a rejected clipboard operation produced a failure notification.
- The uploaded harness and the test log were used to validate that the exact authored source was executed and that the command output was captured for review.

<a href="https://app.greptile.com/trex/runs/20983484/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: click to copy telephony phone ID"](https://github.com/dograh-hq/dograh/commit/bc42aca023417df9f3025959520a5358b4395dd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57422099)</sub>

<!-- /greptile_comment -->