### PR TITLE
fix(telephony): hang up Twilio calls when the media stream closes

### DIFF
--- a/api/services/telephony/providers/twilio/provider.py
+++ b/api/services/telephony/providers/twilio/provider.py
@@ -176,12 +176,17 @@ class TwilioProvider(TelephonyProvider):
             wss_backend_endpoint, workflow_id, organization_id, workflow_run_id
         )
 
+        # <Connect> hands the call to the media stream and blocks until it
+        # closes. Twilio then continues with the next verb, so the document must
+        # end in <Hangup/> - otherwise the caller stays on a silent open line
+        # after the agent ends the call. Transfers are unaffected: they replace
+        # this document via a REST TwiML redirect before the stream closes.
         twiml_content = f"""<?xml version="1.0" encoding="UTF-8"?>
 <Response>
     <Connect>
         <Stream url="{ws_url}"></Stream>
     </Connect>
-    <Pause length="40"/>
+    <Hangup/>
 </Response>"""
         # Redacted: the stream URL carries a bearer capability token, and this
         # log line is the one place it would otherwise reach a log sink.
@@ -582,12 +587,17 @@ class TwilioProvider(TelephonyProvider):
             status_callback_url = f"{backend_endpoint}/api/v1/telephony/twilio/status-callback/{workflow_run_id}"
             status_callback_attr = f' statusCallback="{status_callback_url}"'
 
+        # <Connect> hands the call to the media stream and blocks until it
+        # closes. Twilio then continues with the next verb, so the document must
+        # end in <Hangup/> - otherwise the caller stays on a silent open line
+        # after the agent ends the call. Transfers are unaffected: they replace
+        # this document via a REST TwiML redirect before the stream closes.
         twiml_content = f"""<?xml version="1.0" encoding="UTF-8"?>
 <Response>
     <Connect>
         <Stream url="{websocket_url}"{status_callback_attr}></Stream>
     </Connect>
-    <Pause length="40"/>
+    <Hangup/>
 </Response>"""
 
         return Response(content=twiml_content, media_type="application/xml")

--- a/api/tests/telephony/twilio/test_twiml_hangup.py
+++ b/api/tests/telephony/twilio/test_twiml_hangup.py
@@ -1,0 +1,62 @@
+"""The connect-stream TwiML must end the call once the media stream closes.
+
+``<Connect>`` blocks until the stream closes and then continues with the next
+verb. When that verb was ``<Pause length="40"/>`` the caller was left on a
+silent, still-connected line for 40 seconds after the agent hung up (#627).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.services.telephony.providers.twilio.provider import TwilioProvider
+
+WS_URL = "wss://example.test/api/v1/telephony/twilio/ws/7/11/123/tok"
+
+
+def _provider() -> TwilioProvider:
+    return TwilioProvider(
+        {
+            "account_sid": "AC123",
+            "auth_token": "twilio-auth-token",
+            "from_numbers": ["+15551230002"],
+        }
+    )
+
+
+def _assert_hangs_up(twiml: str) -> None:
+    assert "<Connect>" in twiml
+    assert "<Pause" not in twiml
+    assert twiml.rstrip().endswith("<Hangup/>\n</Response>")
+
+
+@pytest.mark.asyncio
+async def test_outbound_twiml_hangs_up_when_stream_closes():
+    with (
+        patch(
+            "api.services.telephony.providers.twilio.provider.get_backend_endpoints",
+            new_callable=AsyncMock,
+            return_value=("https://example.test", "wss://example.test"),
+        ),
+        patch(
+            "api.services.telephony.ws_auth.build_media_ws_url",
+            return_value=WS_URL,
+        ),
+    ):
+        twiml = await _provider().get_webhook_response(
+            workflow_id=7, organization_id=11, workflow_run_id=123
+        )
+
+    _assert_hangs_up(twiml)
+
+
+@pytest.mark.asyncio
+async def test_inbound_twiml_hangs_up_when_stream_closes():
+    response = await _provider().start_inbound_stream(
+        websocket_url=WS_URL,
+        workflow_run_id=123,
+        normalized_data=None,
+        backend_endpoint="https://example.test",
+    )
+
+    _assert_hangs_up(response.body.decode())


### PR DESCRIPTION
Fixes #627.

## The problem

Both Twilio TwiML documents — outbound (`get_webhook_response`) and inbound (`start_inbound_stream`) — ended like this:

```xml
<Response>
    <Connect>
        <Stream url="…"></Stream>
    </Connect>
    <Pause length="40"/>
</Response>
```

`<Connect>` is a **blocking** verb: it hands the call over to the connected resource and, when that stream closes for any reason (including a normal application-side hangup from Dograh), Twilio continues executing the document at the next verb — here `<Pause length="40"/>`.

So when the agent ended the call, the caller heard the closing line and was then left on a **silent but still-connected line for 40 seconds**, until Twilio exhausted the document and hung up on its own. Web test calls disconnect correctly, which is why this only reproduces over real Twilio calls.

The `<Pause>` looks like it was carried over from the `<Start><Stream>` pattern, where it genuinely is needed — `<Start>` is non-blocking, so the document needs something to keep the call alive. With `<Connect>` it is vestigial.

## The change

Replace the trailing `<Pause length="40"/>` with `<Hangup/>` in both documents, so the call is torn down as soon as the media stream closes. A short comment at each site records why the document has to end in a terminating verb.

## Why transfers are not affected

Transfers were the obvious risk, since they are the one flow that expects the call to outlive the media stream. They don't go through this document: `TwilioConferenceStrategy.execute_transfer` transfers by `POST`ing a fresh `<Dial><Conference>` document to `Accounts/{sid}/Calls/{sid}.json`, and a REST TwiML redirect **replaces** the in-progress document before the stream closes. The trailing verb never executes on that path.

## Tests

New regression test at `api/tests/telephony/twilio/test_twiml_hangup.py` covering both the outbound and inbound documents: each must contain `<Connect>`, must not contain `<Pause`, and must end in `<Hangup/>`.

Verified the test actually catches the bug — with the fix reverted both cases fail on the `<Pause>` assertion; with it in place both pass.

- `api/tests/telephony/twilio/` — 12 passed
- `api/tests/telephony/` — 270 passed (the remaining errors in my environment are `asyncpg` connection failures in DB-fixture tests, with no Postgres running; unrelated to a change that only touches TwiML string generation)

## Out of scope, but worth flagging

- **Cloudonix has the identical pattern** (`api/services/telephony/providers/cloudonix/provider.py`, both the outbound `cxml` and `start_inbound_stream`): same `<Connect><Stream>` followed by `<Pause length="40"/>`. Very likely the same bug, but it's a different provider whose CXML semantics I can't verify, so I've left it alone rather than widen this PR. Happy to follow up if you'd like it fixed the same way.
- The issue's **secondary lead** — that `TwilioHangupStrategy.execute_hangup` was never observed firing, possibly because `FastAPIWebsocketOutputTransport._write_frame()` skips the `EndFrame` when the client is already closing — is untouched here. It lives in the pipecat submodule and this fix does not depend on it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #627 so Twilio calls hang up when the media stream closes, instead of leaving the caller on a silent but still-connected line for 40 seconds.

- Replaces the trailing `<Pause length="40"/>` with `<Hangup/>` in both the outbound (`get_webhook_response`) and inbound (`start_inbound_stream`) TwiML documents.
- Transfers are unaffected: `TwilioConferenceStrategy.execute_transfer` replaces the in-progress document via a REST TwiML redirect to `Calls/{sid}.json` before the stream closes, so the trailing verb never runs on that path.
- Adds a regression test at `api/tests/telephony/twilio/test_twiml_hangup.py` covering both documents.
- Cloudonix uses the same `<Connect><Stream>` plus `<Pause>` pattern and likely has the same bug, but its CXML semantics couldn't be verified, so it's left untouched.

<sup>Written for commit a2b5e9f56dbac4a553c29e3dac98396516c338de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change replaces the post-stream 40-second pause with `<Hangup/>` in Twilio inbound and outbound media-stream responses, so callers are disconnected when the stream closes.

Runtime checks exercised both TwiML-generation paths before and after the change. The updated documents end with `<Hangup/>`, preserve the outbound stream URL, and preserve the inbound stream URL and status callback. The focused Twilio test suite passed with 2 tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on focused runtime validation of the changed inbound and outbound TwiML paths.

No defects were found. The generated XML was checked before and after the change, including terminal call behavior and preservation of required stream attributes, and the focused regression tests passed.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the authored runtime XML-validation script against both the parent commit and the updated code for outbound get\_webhook\_response and inbound start\_inbound\_stream.
- Observed that, before the change, both responses ended with \<Pause length="40"/\>, and after the change they ended with \<Hangup/\>.
- Confirmed that the outbound stream retained the url attribute and the inbound stream retained both the url and statusCallback attributes after the change.
- Ran the focused pytest suite for api/tests/telephony/twilio/test\_twiml\_hangup.py and observed that 2 tests passed.
- Logged the exact execution commands, working directories, and exit codes in the run artifacts to document the validation context.

<a href="https://app.greptile.com/trex/runs/21339312/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(telephony): hang up Twilio calls whe..."](https://github.com/dograh-hq/dograh/commit/a2b5e9f56dbac4a553c29e3dac98396516c338de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58104148)</sub>

<!-- /greptile_comment -->