### PR TITLE
feat(tools): expose workflow_run_id to in-call tools

### DIFF
--- a/api/schemas/tool.py
+++ b/api/schemas/tool.py
@@ -146,7 +146,8 @@ class HttpApiConfig(BaseModel):
         json_schema_extra=_llm_hint(
             "Use {{parameter_name}} placeholders to position LLM and preset "
             "parameters anywhere in the body, including nested objects and arrays; "
-            "also {{initial_context.*}}. A value that is exactly one placeholder "
+            "also {{initial_context.*}}, {{gathered_context.*}} and "
+            "{{workflow_run_id}}. A value that is exactly one placeholder "
             "keeps the value's original JSON type. Omit this field to send all "
             "parameters as a flat top-level JSON object. Ignored for GET and DELETE."
         ),

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -73,7 +73,10 @@ from api.services.pipecat.worker_runner import run_pipeline_worker
 from api.services.pipecat.ws_sender_registry import get_ws_sender
 from api.services.telephony import registry as telephony_registry
 from api.services.workflow.dto import ReactFlowDTO
-from api.services.workflow.initial_context import merge_external_initial_context
+from api.services.workflow.initial_context import (
+    WORKFLOW_RUN_ID_CONTEXT_KEY,
+    merge_external_initial_context,
+)
 from api.services.workflow.pipecat_engine import PipecatEngine
 from api.services.workflow.workflow_graph import WorkflowGraph
 from pipecat.audio.turn.smart_turn.base_smart_turn import SmartTurnParams
@@ -599,6 +602,12 @@ async def _run_pipeline_impl(
         merged_call_context_vars = merge_external_initial_context(
             merged_call_context_vars, call_context_vars
         )
+
+    # Run-owned, so it is assigned rather than merged: it must win over any
+    # stale value persisted on the run. In-call tools render their URL, body
+    # and preset parameters from this context, so this is what lets a record
+    # written mid-call be correlated back to the run it came from.
+    merged_call_context_vars[WORKFLOW_RUN_ID_CONTEXT_KEY] = workflow_run_id
 
     # Get workflow for metadata (name, organization_id, call_disposition_codes)
     workflow = await db_client.get_workflow(workflow_id, **workflow_scope)

--- a/api/services/workflow/initial_context.py
+++ b/api/services/workflow/initial_context.py
@@ -24,6 +24,26 @@ RESERVED_INITIAL_CONTEXT_KEYS = frozenset(
 
 GREETING_OVERRIDE_CONTEXT_KEY = "greeting_override"
 
+# Run-owned names that tool templates may address at the top level, without the
+# ``initial_context.`` prefix. Only reserved keys belong here: external context
+# cannot supply them, so they cannot shadow a caller-supplied prompt variable.
+RUN_OWNED_TEMPLATE_KEYS = (WORKFLOW_RUN_ID_CONTEXT_KEY,)
+
+
+def run_owned_template_vars(
+    call_context_vars: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Return the run-owned subset of the call context for top-level rendering.
+
+    The URL and preset-parameter contexts spread the whole call context at the
+    top level, but the body context reserves the top level for LLM and preset
+    arguments. Layering these keys underneath the arguments keeps the unprefixed
+    spelling (``{{workflow_run_id}}``) working in a body template too, so the
+    same template text means the same thing on every surface.
+    """
+    context = call_context_vars or {}
+    return {key: context[key] for key in RUN_OWNED_TEMPLATE_KEYS if key in context}
+
 
 def merge_external_initial_context(
     initial_context: Mapping[str, Any] | None,

--- a/api/services/workflow/initial_context.py
+++ b/api/services/workflow/initial_context.py
@@ -5,10 +5,21 @@ from typing import Any
 
 from api.services.managed_model_services import MPS_CORRELATION_ID_CONTEXT_KEY
 
+# The Dograh workflow run id, exposed to prompts and in-call tools so records
+# written mid-call can be correlated back to the run. Named to match the
+# top-level key post-run webhook nodes already render (see
+# api/tasks/run_integrations.py::_build_render_context).
+WORKFLOW_RUN_ID_CONTEXT_KEY = "workflow_run_id"
+
 # These values describe or authorize the run itself. External context may add
 # prompt variables, but it must never supply or replace run-owned metadata.
 RESERVED_INITIAL_CONTEXT_KEYS = frozenset(
-    {"provider", "runtime_configuration", MPS_CORRELATION_ID_CONTEXT_KEY}
+    {
+        "provider",
+        "runtime_configuration",
+        MPS_CORRELATION_ID_CONTEXT_KEY,
+        WORKFLOW_RUN_ID_CONTEXT_KEY,
+    }
 )
 
 GREETING_OVERRIDE_CONTEXT_KEY = "greeting_override"

--- a/api/services/workflow/text_chat_runner.py
+++ b/api/services/workflow/text_chat_runner.py
@@ -49,7 +49,10 @@ from api.services.pipecat.worker_runner import (
     wait_for_pipeline_worker_started,
 )
 from api.services.workflow.dto import ReactFlowDTO
-from api.services.workflow.initial_context import merge_external_initial_context
+from api.services.workflow.initial_context import (
+    WORKFLOW_RUN_ID_CONTEXT_KEY,
+    merge_external_initial_context,
+)
 from api.services.workflow.pipecat_engine import PipecatEngine
 from api.services.workflow.workflow_graph import WorkflowGraph
 
@@ -504,6 +507,9 @@ async def execute_text_chat_pending_turn(
     initial_context = {
         **base_initial_context,
         "runtime_configuration": runtime_configuration,
+        # Text sessions share the tool handlers with the voice pipeline, so the
+        # run id has to be injected here too for tools to render it.
+        WORKFLOW_RUN_ID_CONTEXT_KEY: workflow_run_id,
     }
     if mps_correlation_id:
         initial_context[MPS_CORRELATION_ID_CONTEXT_KEY] = mps_correlation_id

--- a/api/services/workflow/tools/custom_tool.py
+++ b/api/services/workflow/tools/custom_tool.py
@@ -18,6 +18,7 @@ from api.errors.failure import (
     redact_failure_message,
 )
 from api.services.configuration.masking import mask_key
+from api.services.workflow.initial_context import run_owned_template_vars
 from api.utils.credential_auth import build_auth_header
 from api.utils.template_renderer import (
     get_nested_value,
@@ -441,9 +442,13 @@ async def execute_http_tool(
         if body_template is None:
             body = resolved_arguments
         else:
+            # Run-owned keys sit underneath the arguments, so a tool that
+            # declares a parameter of the same name still wins - the top level
+            # stays the argument namespace.
             body = render_body_template(
                 body_template,
                 {
+                    **run_owned_template_vars(initial_context),
                     **resolved_arguments,
                     "initial_context": initial_context,
                     "gathered_context": gathered_context,

--- a/api/tests/test_workflow_run_id_in_tool_context.py
+++ b/api/tests/test_workflow_run_id_in_tool_context.py
@@ -5,10 +5,11 @@ do-not-call list) writes a record that an external backend later has to
 correlate back to the run. Post-run webhook nodes already render
 ``workflow_run_id``; in-call tools did not (#690), so it resolved to nothing.
 
-Note the two spellings are not interchangeable, and that is by design:
-``initial_context`` is spread at the top level of the URL and preset-parameter
-contexts, but the body context reserves the top level for LLM/preset arguments.
-So a body template has to say ``{{initial_context.workflow_run_id}}``.
+The run id is addressable by the same unprefixed spelling on every surface -
+URL, preset parameter and body template. The body context otherwise reserves
+its top level for LLM/preset arguments, so the run id is layered underneath
+them: a tool that declares its own ``workflow_run_id`` parameter still wins, and
+the namespaced spelling stays the way to reach the run's own value.
 """
 
 from dataclasses import dataclass
@@ -19,6 +20,7 @@ import pytest
 
 from api.services.workflow.initial_context import (
     RESERVED_INITIAL_CONTEXT_KEYS,
+    RUN_OWNED_TEMPLATE_KEYS,
     WORKFLOW_RUN_ID_CONTEXT_KEY,
     merge_external_initial_context,
 )
@@ -81,14 +83,19 @@ async def test_run_id_renders_in_the_url_template(http_client):
     )
 
 
+@pytest.mark.parametrize(
+    "placeholder",
+    ["{{workflow_run_id}}", "{{initial_context.workflow_run_id}}"],
+)
 @pytest.mark.asyncio
-async def test_run_id_renders_in_the_body_template(http_client):
+async def test_run_id_renders_in_the_body_template(http_client, placeholder):
+    """Both spellings work, so the URL/preset spelling can't silently post ""."""
     tool = _tool(
         {
             "method": "POST",
             "url": "https://api.example.com/bookings",
             "timeout_ms": 5000,
-            "body_template": {"run_id": "{{initial_context.workflow_run_id}}"},
+            "body_template": {"run_id": placeholder},
         }
     )
 
@@ -98,6 +105,39 @@ async def test_run_id_renders_in_the_body_template(http_client):
 
     assert result["status"] == "success"
     assert http_client.request.call_args.kwargs["json"] == {"run_id": RUN_ID}
+
+
+@pytest.mark.asyncio
+async def test_body_run_id_does_not_shadow_a_declared_parameter(http_client):
+    """The top level stays the argument namespace; the run id only fills gaps."""
+    tool = _tool(
+        {
+            "method": "POST",
+            "url": "https://api.example.com/bookings",
+            "timeout_ms": 5000,
+            "body_template": {
+                "run_id": "{{workflow_run_id}}",
+                "true_run_id": "{{initial_context.workflow_run_id}}",
+            },
+        }
+    )
+
+    result = await execute_http_tool(
+        tool,
+        {WORKFLOW_RUN_ID_CONTEXT_KEY: 7},
+        call_context_vars={WORKFLOW_RUN_ID_CONTEXT_KEY: RUN_ID},
+    )
+
+    assert result["status"] == "success"
+    assert http_client.request.call_args.kwargs["json"] == {
+        "run_id": 7,
+        "true_run_id": RUN_ID,
+    }
+
+
+def test_only_reserved_keys_are_exposed_unprefixed_in_bodies():
+    """Non-reserved context is caller-supplied and must not shadow arguments."""
+    assert set(RUN_OWNED_TEMPLATE_KEYS) <= RESERVED_INITIAL_CONTEXT_KEYS
 
 
 @pytest.mark.asyncio
@@ -144,13 +184,17 @@ async def test_without_the_run_id_the_tool_cannot_reference_the_run(http_client)
 
 @pytest.mark.asyncio
 async def test_body_only_tool_silently_loses_the_run_id_without_it(http_client):
-    """Without a URL template there is no loud failure - just an empty value."""
+    """Without a URL template there is no loud failure - just an empty value.
+
+    This is the #690 symptom: the request looks fine but can't be correlated.
+    Injecting the run id into the call context is what stops it happening.
+    """
     tool = _tool(
         {
             "method": "POST",
             "url": "https://api.example.com/bookings",
             "timeout_ms": 5000,
-            "body_template": {"run_id": "{{initial_context.workflow_run_id}}"},
+            "body_template": {"run_id": "{{workflow_run_id}}"},
         }
     )
 

--- a/api/tests/test_workflow_run_id_in_tool_context.py
+++ b/api/tests/test_workflow_run_id_in_tool_context.py
@@ -1,0 +1,176 @@
+"""The workflow run id must reach in-call tools.
+
+An HTTP tool that fires mid-call (booking an appointment, adding a number to a
+do-not-call list) writes a record that an external backend later has to
+correlate back to the run. Post-run webhook nodes already render
+``workflow_run_id``; in-call tools did not (#690), so it resolved to nothing.
+
+Note the two spellings are not interchangeable, and that is by design:
+``initial_context`` is spread at the top level of the URL and preset-parameter
+contexts, but the body context reserves the top level for LLM/preset arguments.
+So a body template has to say ``{{initial_context.workflow_run_id}}``.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from api.services.workflow.initial_context import (
+    RESERVED_INITIAL_CONTEXT_KEYS,
+    WORKFLOW_RUN_ID_CONTEXT_KEY,
+    merge_external_initial_context,
+)
+from api.services.workflow.tools.custom_tool import execute_http_tool
+
+RUN_ID = 4242
+
+
+@dataclass
+class _ToolModel:
+    tool_uuid: str
+    name: str
+    description: str
+    definition: Dict[str, Any]
+    category: str = "http_api"
+
+
+def _tool(config: Dict[str, Any]) -> _ToolModel:
+    return _ToolModel(
+        tool_uuid="tool-uuid-run-id",
+        name="Create Booking",
+        description="Create a booking",
+        definition={"schema_version": 1, "type": "http_api", "config": config},
+    )
+
+
+@pytest.fixture
+def http_client():
+    """Patch httpx so the tool records its request instead of sending one."""
+    with patch(
+        "api.services.workflow.tools.custom_tool.httpx.AsyncClient"
+    ) as client_class:
+        client = AsyncMock()
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"ok": True}
+        client.request.return_value = response
+        client_class.return_value.__aenter__.return_value = client
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_run_id_renders_in_the_url_template(http_client):
+    tool = _tool(
+        {
+            "method": "POST",
+            "url": "https://api.example.com/runs/{{workflow_run_id}}/bookings",
+            "timeout_ms": 5000,
+        }
+    )
+
+    result = await execute_http_tool(
+        tool, {}, call_context_vars={WORKFLOW_RUN_ID_CONTEXT_KEY: RUN_ID}
+    )
+
+    assert result["status"] == "success"
+    assert (
+        http_client.request.call_args.kwargs["url"]
+        == "https://api.example.com/runs/4242/bookings"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_id_renders_in_the_body_template(http_client):
+    tool = _tool(
+        {
+            "method": "POST",
+            "url": "https://api.example.com/bookings",
+            "timeout_ms": 5000,
+            "body_template": {"run_id": "{{initial_context.workflow_run_id}}"},
+        }
+    )
+
+    result = await execute_http_tool(
+        tool, {}, call_context_vars={WORKFLOW_RUN_ID_CONTEXT_KEY: RUN_ID}
+    )
+
+    assert result["status"] == "success"
+    assert http_client.request.call_args.kwargs["json"] == {"run_id": RUN_ID}
+
+
+@pytest.mark.asyncio
+async def test_run_id_renders_in_preset_parameters(http_client):
+    tool = _tool(
+        {
+            "method": "POST",
+            "url": "https://api.example.com/bookings",
+            "timeout_ms": 5000,
+            "preset_parameters": [
+                {"name": "run_id", "value_template": "{{workflow_run_id}}"}
+            ],
+        }
+    )
+
+    result = await execute_http_tool(
+        tool, {}, call_context_vars={WORKFLOW_RUN_ID_CONTEXT_KEY: RUN_ID}
+    )
+
+    assert result["status"] == "success"
+    assert http_client.request.call_args.kwargs["json"] == {"run_id": "4242"}
+
+
+@pytest.mark.asyncio
+async def test_without_the_run_id_the_tool_cannot_reference_the_run(http_client):
+    """The #690 behavior: the templates collapse and no run can be identified."""
+    tool = _tool(
+        {
+            "method": "POST",
+            "url": "https://api.example.com/runs/{{workflow_run_id}}/bookings",
+            "timeout_ms": 5000,
+            "body_template": {"run_id": "{{initial_context.workflow_run_id}}"},
+        }
+    )
+
+    result = await execute_http_tool(tool, {}, call_context_vars={})
+
+    # A URL template variable with no value fails loudly rather than posting to
+    # a mangled path, so the request is never sent at all.
+    assert result["status"] == "error"
+    assert "URL template rendering failed" in result["error"]
+    http_client.request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_body_only_tool_silently_loses_the_run_id_without_it(http_client):
+    """Without a URL template there is no loud failure - just an empty value."""
+    tool = _tool(
+        {
+            "method": "POST",
+            "url": "https://api.example.com/bookings",
+            "timeout_ms": 5000,
+            "body_template": {"run_id": "{{initial_context.workflow_run_id}}"},
+        }
+    )
+
+    await execute_http_tool(tool, {}, call_context_vars={})
+
+    assert http_client.request.call_args.kwargs["json"] == {"run_id": ""}
+
+
+def test_run_id_is_reserved_against_external_context():
+    assert WORKFLOW_RUN_ID_CONTEXT_KEY in RESERVED_INITIAL_CONTEXT_KEYS
+
+    merged = merge_external_initial_context(
+        {WORKFLOW_RUN_ID_CONTEXT_KEY: RUN_ID, "customer_name": "Before"},
+        {WORKFLOW_RUN_ID_CONTEXT_KEY: 9999, "customer_name": "After"},
+    )
+
+    assert merged == {WORKFLOW_RUN_ID_CONTEXT_KEY: RUN_ID, "customer_name": "After"}
+
+
+def test_run_id_cannot_be_introduced_by_external_context():
+    assert merge_external_initial_context(
+        {}, {WORKFLOW_RUN_ID_CONTEXT_KEY: 9999, "customer_name": "Ada"}
+    ) == {"customer_name": "Ada"}


### PR DESCRIPTION
Closes #690.

## The problem

An HTTP tool that fires **during** a call can't reference the run it belongs to. The render context for a tool's URL, `body_template` and preset parameters is built from `call_context_vars`, and the engine keeps `_workflow_run_id` as a separate field that is never merged in — so `{{workflow_run_id}}` resolves to nothing.

That means a record written mid-call (a booking, a scheduled callback, a do-not-call entry) can't be correlated back to the run it came from, which is what transcript lookup, idempotency, and dedup against post-call recovery jobs all key on. Post-run **webhook nodes** already get `workflow_run_id` via `_build_render_context`; in-call tools — where these writes naturally happen, since the model can react to the tool response mid-conversation — did not.

## The change

Option A from the issue: inject the run id into the call context rather than threading it through the tool layer.

- `run_pipeline.py` — assign `workflow_run_id` into `merged_call_context_vars` right after the external-context merge, next to the existing `mps_correlation_id` injection. The single `PipecatEngine` construction here serves both the voice pipeline and realtime.
- `text_chat_runner.py` — the twin injection, so text sessions (which share the tool handlers) behave identically.
- `initial_context.py` — a `WORKFLOW_RUN_ID_CONTEXT_KEY` constant, added to `RESERVED_INITIAL_CONTEXT_KEYS`; plus `RUN_OWNED_TEMPLATE_KEYS` / `run_owned_template_vars()`, the run-owned subset tool templates may address without a prefix.
- `custom_tool.py` — layer those run-owned keys under the arguments in the body render context, so `{{workflow_run_id}}` works in a `body_template` too (see below).

It's assigned rather than merged so it always wins over a stale value persisted on the run.

The key name deliberately matches the top-level `workflow_run_id` that `api/tasks/run_integrations.py::_build_render_context` already renders for webhook nodes, and it carries the same raw `int`.

**On reserving the key:** beyond blocking caller-supplied context, this also covers `event_handlers.py`, which merges the **pre-call fetch response** into the live call context mid-call — without the reservation, a fetch endpoint could overwrite the run id with an arbitrary value. It also means the embed widget can't supply a variable of that name (`embed_context.py` drops reserved names), which is the intended behavior.

This follows the same shape as #692, which injects `call_id` and reserves it. The two are complementary, not duplicates — `call_id` is the telephony provider's SID, `workflow_run_id` is the Dograh run. Expect a small conflict with that PR in these two files whichever lands first; happy to rebase.

## Both spellings work

`{{workflow_run_id}}` renders in a URL template, a preset parameter and a `body_template`, and `{{initial_context.workflow_run_id}}` does too.

The body render context reserves its top level for LLM and preset arguments (`{**resolved_arguments, "initial_context": ...}`), so the unprefixed spelling originally resolved to nothing there — a body-only tool silently posted `{"run_id": ""}`, which is the same uncorrelatable write #690 is about, just without the loud failure a URL template gives you. cubic flagged it; fixed in the follow-up commit.

Run-owned keys are now layered *underneath* the arguments in the body context, so:

- the same template text means the same thing on every surface;
- a tool that declares its own `workflow_run_id` parameter still wins — the top level stays the argument namespace, and `{{initial_context.workflow_run_id}}` remains the way to reach the run's own value;
- only **reserved** keys are exposed this way (`RUN_OWNED_TEMPLATE_KEYS`, asserted to be a subset of `RESERVED_INITIAL_CONTEXT_KEYS`), so nothing caller-supplied can shadow an argument name. Non-reserved context still needs its prefix, which is the collision-safety the body context was protecting.

## Tests

New `api/tests/test_workflow_run_id_in_tool_context.py` — covering: the run id rendering in a URL, in both body spellings and in preset parameters; that a declared parameter still shadows it inside a body; that only reserved keys are exposed unprefixed; both reserved-key paths (can't be replaced, can't be introduced); and the #690 behavior itself.

That last one turned out to have two distinct shapes worth pinning:
- a tool with the run id in its **URL** fails loudly (`URL template variable 'workflow_run_id' has no value`) and never sends the request;
- a **body-only** tool has no such guard — it silently posts `{"run_id": ""}`, which is exactly the "looks fine, can't be correlated" failure described in the issue.

Results: 7 passed. Related suites — `test_initial_context.py`, `test_custom_tools.py`, `test_custom_tools_context_integration.py`, `test_embed_context_variables.py`, and the text-chat/pipeline suites — 47 + 115 passed.

Two non-failures in my environment, both confirmed pre-existing on a clean `main`: `TestUrlPathParameters::test_current_time_timezone_in_url` fails without `tzdata` installed (IANA zones on Windows), and the DB-fixture tests error out with `asyncpg` connection failures since I have no local Postgres.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes the workflow run id to in-call HTTP tools so records written mid-call can be correlated back to the run. The run id was previously kept separate from the tool render context, so `{{workflow_run_id}}` resolved to nothing; it's now injected into call context for both the voice pipeline and text chat, matching the key post-run webhook nodes already render.

- The run id is reserved against external context, so callers (including the pre-call fetch response and embed widget) can't spoof or overwrite it.
- The two spellings are not interchangeable: `{{workflow_run_id}}` works in URL and preset parameter templates, but `body_template` must use `{{initial_context.workflow_run_id}}`—this precedence is pre-existing and intentionally left unchanged.

<sup>Written for commit 7c43562d2511fdf2239fd960d013eb75b1c0d433. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes the authoritative workflow run identifier available to HTTP tools during voice, realtime, and text conversations. It also prevents externally supplied context from replacing that identifier and preserves declared tool-argument precedence.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the affected HTTP-tool rendering and context-protection paths passed focused execution coverage.

No blocking failure remains. Focused execution confirmed run-ID rendering in URL, preset-parameter, and body templates; protection from external-context replacement; and correct precedence for declared tool arguments.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused workflow run-ID pytest suite with the supplied Python 3.13 environment.
- Rendered the endpoint https://api.example.com/runs/4242/bookings, sent run\_id 4242, and produced body ID 4242.
- Verified that external ID 9999 cannot replace the run-owned ID and that the declared tool argument workflow\_run\_id 7 takes precedence over the unprefixed body placeholder while initial\_context.workflow\_run\_id remains 4242.
- Confirmed all 10 focused tests passed, validating the rendering, context isolation, and precedence behavior.

<a href="https://app.greptile.com/trex/runs/21565027/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tools): let body templates address w..."](https://github.com/dograh-hq/dograh/commit/f38e5a1e13bf550ed150d57bfb82807ddd936cf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58113767)</sub>

<!-- /greptile_comment -->