### PR TITLE
fix(helm): add readiness probe and minReadySeconds to arq-worker

### DIFF
--- a/deploy/helm/dograh/templates/arq-worker-deployment.yaml
+++ b/deploy/helm/dograh/templates/arq-worker-deployment.yaml
@@ -18,6 +18,7 @@ spec:
     matchLabels:
       {{- include "dograh.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: arq-worker
+  minReadySeconds: {{ .Values.workers.minReadySeconds }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -52,6 +53,8 @@ spec:
             {{- include "dograh.dbEnv" . | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.workers.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.workers.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.workers.resources | nindent 12 }}
       {{- with .Values.workers.nodeSelector }}

--- a/deploy/helm/dograh/values.yaml
+++ b/deploy/helm/dograh/values.yaml
@@ -284,6 +284,33 @@ workers:
     timeoutSeconds: 5
     failureThreshold: 3
 
+  # Gates rolling updates. Without it a container is Ready as soon as it is
+  # Running, so a crashlooping pod still counts as Available and the Deployment
+  # scales down healthy pods despite maxUnavailable: 0.
+  #
+  # Both checks are per-pod. `arq --check` is not used: its health key is
+  # per-queue, so a healthy sibling would mask a broken pod. Importing
+  # api.tasks.arq is not used either - it pulls in pipecat and re-initialises
+  # S3 storage, ~13s per probe.
+  readinessProbe:
+    exec:
+      command:
+        - sh
+        - -c
+        - |
+          grep -qa api.tasks.arq.WorkerSettings /proc/1/cmdline || exit 1
+          python -c "import os, socket
+          from urllib.parse import urlparse
+          u = urlparse(os.environ['REDIS_URL'])
+          socket.create_connection((u.hostname, u.port or 6379), timeout=3).close()"
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+  # Must hold Ready this long before counting as Available.
+  minReadySeconds: 15
+
   podAnnotations: {}
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
Without a readiness probe a container is Ready as soon as it is Running, so a crashlooping pod counts as Available and a rolling update scales down healthy pods despite maxUnavailable: 0. The probe checks the worker is PID 1 and that this pod can reach Redis.


Claude-Session: https://claude.ai/code/session_01KEXLYraD9GaD2JeAjWSNPo

## Checklist

- [x] I have read and followed the [contributing guidelines](https://github.com/dograh-hq/dograh/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a readiness probe and `minReadySeconds` to the arq-worker Deployment so a crashlooping pod no longer counts as Available and rolling updates stop scaling down healthy pods despite `maxUnavailable: 0`.

- The probe checks the worker is PID 1 and that this pod can reach Redis.
- It avoids `arq --check` (per-queue key masks a broken pod) and importing `api.tasks.arq` (pulls in pipecat, ~13s per probe).
- Both values ship with defaults in `values.yaml`, so no migration is required.

<sup>Written for commit 8c5813616e13c09917292101f9e0dd229f563620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds worker readiness checks and a 15-second minimum-ready period to make rolling updates safer. Verification reproduced a gap in the Redis check: it accepts a TCP connection even when the worker cannot complete the TLS handshake or authenticate to Redis. That can let an unusable replacement worker be counted as available and allow a healthy worker to be removed during rollout.

<h3>Confidence Score: 4/5</h3>

Do not merge until readiness verifies a usable authenticated Redis session rather than only network reachability.

A focused execution reproduced the mismatch between the readiness command and ARQ's required Redis connection behavior using both TLS-invalid and authentication-rejecting endpoints.

**Files Needing Attention:** deploy/helm/dograh/values.yaml needs a Redis protocol-level readiness check that honors the REDIS_URL TLS and credential settings.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the corresponding review comment.
- T-Rex conducted contract-validation work showing how the probe behaved before and after the worker validation against invalid Redis endpoints.

<a href="https://app.greptile.com/trex/runs/21651921/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Worker readiness reports Ready when Redis accepts TCP but rejects required TLS or authentication**

   - **Bug**
     - `deploy/helm/dograh/values.yaml:302-305` only calls `socket.create_connection(...).close()`. The executed reproduction shows this exits 0 for endpoints that accept TCP yet cannot satisfy worker Redis requirements. In contrast, the ARQ worker uses `ssl=parsed_url.scheme == "rediss"`, supplies `password=parsed_url.password`, and fails during `create_pool` under both conditions. Consequently a worker can be Ready while unable to process its Redis-backed queue.
   - **Cause**
     - The readiness probe validates layer-4 reachability only; it neither performs a TLS handshake for `rediss://` nor authenticates and executes a Redis protocol command.
   - **Fix**
     - Replace the raw socket connection with a lightweight Redis client check constructed from `REDIS_URL` that honors TLS and credentials and executes `PING` (or an equivalent authenticated Redis command), with a bounded timeout. Keep the existing per-pod/PID-1 check if desired.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(helm): add readiness probe and minRe..."](https://github.com/dograh-hq/dograh/commit/8c5813616e13c09917292101f9e0dd229f563620) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58729649)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->