### PR TITLE
fix(api): read ambient noise, context compaction and voicemail config from the run's pinned definition

### DIFF
--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -327,12 +327,6 @@ async def _run_pipeline_telephony_impl(
         raise HTTPException(status_code=404, detail="Workflow not found")
     set_current_org_id(workflow.organization_id)
 
-    ambient_noise_config = None
-    if workflow.workflow_configurations:
-        ambient_noise_config = workflow.workflow_configurations.get(
-            "ambient_noise_configuration"
-        )
-
     # The telephony config id is stamped on the workflow run when it's created
     # (test call, campaign dispatch, inbound). Transports use it to load creds
     # from the right config row. Falls back to None for legacy runs (transports
@@ -358,7 +352,11 @@ async def _run_pipeline_telephony_impl(
         get_effective_ai_model_configuration_for_workflow,
     )
 
+    # Read every setting from the run's pinned definition. The workflow row's
+    # workflow_configurations column tracks the latest *draft*, so reading it
+    # here would let unpublished edits change live call behaviour.
     run_configs = workflow_run.definition.workflow_configurations or {}
+    ambient_noise_config = run_configs.get("ambient_noise_configuration")
     user_config = await get_effective_ai_model_configuration_for_workflow(
         organization_id=workflow.organization_id,
         workflow_configurations=run_configs,
@@ -460,13 +458,6 @@ async def _run_pipeline_smallwebrtc_impl(
     if workflow:
         set_current_org_id(workflow.organization_id)
 
-    ambient_noise_config = None
-    if workflow and workflow.workflow_configurations:
-        if "ambient_noise_configuration" in workflow.workflow_configurations:
-            ambient_noise_config = workflow.workflow_configurations[
-                "ambient_noise_configuration"
-            ]
-
     # Create audio configuration for WebRTC
     audio_config = create_audio_config(WorkflowRunMode.SMALLWEBRTC.value)
 
@@ -486,9 +477,11 @@ async def _run_pipeline_smallwebrtc_impl(
             detail="workflow_run_workflow_mismatch",
         )
 
+    # Pinned definition, not the workflow row (which mirrors the draft).
     run_configs = (
         (workflow_run.definition.workflow_configurations or {}) if workflow_run else {}
     )
+    ambient_noise_config = run_configs.get("ambient_noise_configuration")
     user_config = await get_effective_ai_model_configuration_for_workflow(
         organization_id=workflow.organization_id if workflow else None,
         workflow_configurations=run_configs,
@@ -841,9 +834,7 @@ async def _run_pipeline_impl(
     # include recording response mode instructions in all node prompts.
     has_recordings = await db_client.has_active_recordings(workflow.organization_id)
 
-    context_compaction_enabled = (workflow.workflow_configurations or {}).get(
-        "context_compaction_enabled", False
-    )
+    context_compaction_enabled = run_configs.get("context_compaction_enabled", False)
     # Context compaction doesn't apply in realtime mode: the speech-to-speech
     # service manages its own conversation state server-side.
     if is_realtime and context_compaction_enabled:
@@ -993,9 +984,7 @@ async def _run_pipeline_impl(
     )
     engine.set_fetch_recording_audio(fetch_audio)
 
-    voicemail_config = (workflow.workflow_configurations or {}).get(
-        "voicemail_detection", {}
-    )
+    voicemail_config = run_configs.get("voicemail_detection", {})
     if is_realtime and voicemail_config.get("enabled", False):
         logger.info(
             f"Disabling voicemail detection for realtime workflow run {workflow_run_id}"

--- a/api/services/workflow/text_chat_runner.py
+++ b/api/services/workflow/text_chat_runner.py
@@ -601,9 +601,8 @@ async def execute_text_chat_pending_turn(
         embeddings_api_version = getattr(user_config.embeddings, "api_version", None)
 
     has_recordings = await db_client.has_active_recordings(workflow.organization_id)
-    context_compaction_enabled = (workflow.workflow_configurations or {}).get(
-        "context_compaction_enabled", False
-    )
+    # Pinned definition, not the workflow row (which mirrors the draft).
+    context_compaction_enabled = run_configs.get("context_compaction_enabled", False)
     engine = PipecatEngine(
         llm=llm,
         inference_llm=inference_llm,

--- a/api/tests/integrations/test_run_pipeline.py
+++ b/api/tests/integrations/test_run_pipeline.py
@@ -15,6 +15,7 @@ completion flag, and ``gathered_context`` entries.
 """
 
 import asyncio
+from unittest.mock import patch
 
 import pytest
 from pipecat.tests.mock_transport import MockTransport
@@ -215,3 +216,81 @@ async def test_call_stays_registered_for_drain_until_artifacts_uploaded(
     assert observed["count_during_upload"] == 1
     assert observed["run_task_done_during_upload"] is False
     assert active_calls.active_call_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_reads_configuration_from_pinned_definition(
+    workflow_run_setup, db_session
+):
+    """An unpublished draft must not change the behaviour of a run pinned to
+    the published definition.
+
+    ``save_workflow_draft`` mirrors the draft into the legacy
+    ``WorkflowModel.workflow_configurations`` column; the pipeline used to read
+    ``context_compaction_enabled`` and ``voicemail_detection`` from that column
+    instead of from ``workflow_run.definition``.
+    """
+    from pipecat.extensions.voicemail.voicemail_detector import VoicemailDetector
+
+    from api.services.workflow.pipecat_engine import PipecatEngine
+
+    workflow_run, user, workflow = workflow_run_setup
+    # The run is pinned to V1 (published, empty configuration). Create a draft
+    # that enables both knobs; it also lands in the workflow row.
+    await db_session.save_workflow_draft(
+        workflow.id,
+        workflow_configurations={
+            "context_compaction_enabled": True,
+            "voicemail_detection": {"enabled": True},
+        },
+    )
+    refreshed_workflow = await db_session.get_workflow(
+        workflow.id, organization_id=workflow.organization_id
+    )
+    assert refreshed_workflow.workflow_configurations["context_compaction_enabled"]
+
+    transport = MockTransport(
+        TransportParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+            audio_out_end_silence_secs=0,
+        )
+    )
+    captured_task: list = []
+    audio_config = create_audio_config(WorkflowRunMode.SMALLWEBRTC.value)
+    with (
+        patch_run_pipeline_externals(captured_task),
+        patch(
+            "api.services.pipecat.run_pipeline.PipecatEngine", wraps=PipecatEngine
+        ) as engine_cls,
+        patch(
+            "api.services.pipecat.run_pipeline.VoicemailDetector",
+            wraps=VoicemailDetector,
+        ) as voicemail_cls,
+    ):
+        run_task = asyncio.create_task(
+            _run_pipeline(
+                transport=transport,
+                workflow_id=workflow.id,
+                workflow_run_id=workflow_run.id,
+                user_id=user.id,
+                audio_config=audio_config,
+                user_provider_id=user.provider_id,
+            )
+        )
+        for _ in range(60):
+            if captured_task or run_task.done():
+                break
+            await asyncio.sleep(0.05)
+        if run_task.done() and not captured_task:
+            run_task.result()
+        assert captured_task, "create_pipeline_task was never invoked"
+        pipeline_task = captured_task[0]
+        await wait_for_pipeline_worker_started(
+            pipeline_task, timeout=3.0, run_task=run_task
+        )
+        await pipeline_task.cancel()
+        await asyncio.wait_for(run_task, timeout=5.0)
+
+    assert engine_cls.call_args.kwargs["context_compaction_enabled"] is False
+    voicemail_cls.assert_not_called()

--- a/api/tests/test_run_pipeline_pinned_ambient_noise.py
+++ b/api/tests/test_run_pipeline_pinned_ambient_noise.py
@@ -1,0 +1,102 @@
+"""The transport entry points read ambient noise from the run's pinned definition.
+
+``save_workflow_draft`` mirrors the draft into ``WorkflowModel.workflow_configurations``,
+so reading that column would let an unpublished draft change the ambient noise of
+a live call. Both entry points must hand the transport the configuration pinned on
+``workflow_run.definition`` instead. The DB layer is mocked so this runs without
+Postgres; the end-to-end counterpart for the pipeline-level knobs lives in
+``tests/integrations/test_run_pipeline.py``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.services.pipecat import run_pipeline as run_pipeline_module
+
+DRAFT_AMBIENT = {"enabled": True, "storage_key": "ambient-noise/1/1/draft.wav"}
+PINNED_AMBIENT = {"enabled": True, "storage_key": "ambient-noise/1/1/published.wav"}
+
+
+def _stub_db(monkeypatch):
+    workflow = SimpleNamespace(
+        id=1,
+        organization_id=5,
+        user_id=7,
+        workflow_configurations={"ambient_noise_configuration": DRAFT_AMBIENT},
+    )
+    workflow_run = SimpleNamespace(
+        id=42,
+        workflow_id=1,
+        initial_context=None,
+        definition=SimpleNamespace(
+            workflow_configurations={"ambient_noise_configuration": PINNED_AMBIENT}
+        ),
+    )
+    monkeypatch.setattr(
+        run_pipeline_module.db_client, "get_workflow", AsyncMock(return_value=workflow)
+    )
+    monkeypatch.setattr(
+        run_pipeline_module.db_client,
+        "get_workflow_run",
+        AsyncMock(return_value=workflow_run),
+    )
+
+
+def _patch_effective_config():
+    return patch(
+        "api.services.configuration.ai_model_configuration."
+        "get_effective_ai_model_configuration_for_workflow",
+        AsyncMock(return_value=SimpleNamespace(is_realtime=False, realtime=None)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_webrtc_transport_gets_pinned_ambient_noise(monkeypatch):
+    _stub_db(monkeypatch)
+    create_transport = AsyncMock(return_value=object())
+    monkeypatch.setattr(
+        run_pipeline_module, "create_webrtc_transport", create_transport
+    )
+    monkeypatch.setattr(run_pipeline_module, "_run_pipeline_impl", AsyncMock())
+
+    with _patch_effective_config():
+        await run_pipeline_module._run_pipeline_smallwebrtc_impl(
+            webrtc_connection=object(),
+            workflow_id=1,
+            workflow_run_id=42,
+            user_id=7,
+        )
+
+    create_transport.assert_awaited_once()
+    assert create_transport.await_args.args[3] == PINNED_AMBIENT
+
+
+@pytest.mark.asyncio
+async def test_telephony_transport_gets_pinned_ambient_noise(monkeypatch):
+    _stub_db(monkeypatch)
+    transport_factory = AsyncMock(return_value=object())
+    monkeypatch.setattr(
+        run_pipeline_module.telephony_registry,
+        "get",
+        lambda name: SimpleNamespace(transport_factory=transport_factory),
+    )
+    monkeypatch.setattr(
+        run_pipeline_module, "create_audio_config", lambda provider: object()
+    )
+    monkeypatch.setattr(run_pipeline_module, "_run_pipeline_impl", AsyncMock())
+
+    with _patch_effective_config():
+        await run_pipeline_module._run_pipeline_telephony_impl(
+            websocket=object(),
+            provider_name="twilio",
+            workflow_id=1,
+            workflow_run_id=42,
+            organization_id=5,
+            call_id="CA123",
+            transport_kwargs={},
+        )
+
+    transport_factory.assert_awaited_once()
+    assert transport_factory.await_args.kwargs["ambient_noise_config"] == PINNED_AMBIENT


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Workflow runs now consistently use the settings captured in their pinned definition rather than later unpublished draft edits. This preserves published ambient-noise, context-compaction, and voicemail behavior across call and chat execution.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The executed before-and-after validation confirmed that the changed runtime paths read pinned workflow-definition settings instead of mutable draft settings.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the verify\_pinned\_workflow\_settings.py script from /home/user/repo; it exited with code 0 and showed that the prior workflow-row draft settings differ from the current run\_configs derived from the pinned definition, with the final result: 'RESULT: reproduced before the PR and disproved on the PR revision'.
- Validated the plain-code validator output for pinned workflow settings, confirming the validation completed successfully.
- Observed environment blockers during pytest validation, including ambient-noise and voice-compaction blockers.
- Ran a second verification attempt and encountered a ModuleNotFoundError: No module named 'pipecat.utils.run\_context' during import, indicating an environment/dependency incompatibility rather than a PR defect.
- The second run showed the same pattern of results: parent settings reported as unpublished, PR settings reported as pinned, and the final assessment aligned with the previous result that the PR revision disproves the unpublished behavior.

<a href="https://app.greptile.com/trex/runs/22781520/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["test(api): cover ambient noise read from..."](https://github.com/dograh-hq/dograh/commit/0809b319c6fe4f6443393efe2211d063a4e3d417) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59654235)</sub>

<!-- /greptile_comment -->