### PR TITLE
fix(api): mask voicemail_detection.api_key like the other service secrets

### DIFF
--- a/api/routes/workflow.py
+++ b/api/routes/workflow.py
@@ -1138,6 +1138,21 @@ async def update_workflow(
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         except ExternalPBXConfigurationDisabledError as exc:
             raise HTTPException(status_code=403, detail=str(exc)) from exc
+        if workflow_configurations:
+            # Responses mask secrets, and clients send the whole document back,
+            # so masked (or omitted) secrets must be restored from what is
+            # stored before anything below validates or persists them.
+            existing_workflow = await db_client.get_workflow(
+                workflow_id, organization_id=user.selected_organization_id
+            )
+            if existing_workflow:
+                existing_draft = await db_client.get_draft_version(workflow_id)
+                workflow_configurations = merge_workflow_configuration_secrets(
+                    workflow_configurations,
+                    existing_draft.workflow_configurations
+                    if existing_draft
+                    else existing_workflow.released_definition.workflow_configurations,
+                )
         if workflow_configurations and workflow_configurations.get(
             WORKFLOW_MODEL_CONFIGURATION_V2_OVERRIDE_KEY
         ):

--- a/api/routes/workflow.py
+++ b/api/routes/workflow.py
@@ -1102,22 +1102,33 @@ async def update_workflow(
                 tool_name_errors,
                 status_code=409,
             )
-        if workflow_definition:
+        # What the user was editing (draft or published): loaded once and
+        # reused by every secret merge below.
+        existing_workflow = None
+        existing_draft = None
+        existing_configs = None
+        if workflow_definition or request.workflow_configurations is not None:
             existing_workflow = await db_client.get_workflow(
                 workflow_id, organization_id=user.selected_organization_id
             )
             if existing_workflow:
-                # Merge against what the user was editing (draft or published)
                 existing_draft = await db_client.get_draft_version(workflow_id)
-                existing_def = (
-                    existing_draft.workflow_json
+                existing_configs = (
+                    existing_draft.workflow_configurations
                     if existing_draft
-                    else existing_workflow.released_definition.workflow_json
+                    else existing_workflow.released_definition.workflow_configurations
                 )
-                workflow_definition = merge_workflow_api_keys(
-                    workflow_definition,
-                    existing_def,
-                )
+
+        if workflow_definition and existing_workflow:
+            existing_def = (
+                existing_draft.workflow_json
+                if existing_draft
+                else existing_workflow.released_definition.workflow_json
+            )
+            workflow_definition = merge_workflow_api_keys(
+                workflow_definition,
+                existing_def,
+            )
 
         # Validate model overrides. v2 uses a complete workflow-level model
         # configuration; legacy v1 uses partial service overlays.
@@ -1138,37 +1149,21 @@ async def update_workflow(
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         except ExternalPBXConfigurationDisabledError as exc:
             raise HTTPException(status_code=403, detail=str(exc)) from exc
-        if workflow_configurations:
+        if workflow_configurations and existing_workflow:
             # Responses mask secrets, and clients send the whole document back,
             # so masked (or omitted) secrets must be restored from what is
             # stored before anything below validates or persists them.
-            existing_workflow = await db_client.get_workflow(
-                workflow_id, organization_id=user.selected_organization_id
+            workflow_configurations = merge_workflow_configuration_secrets(
+                workflow_configurations,
+                existing_configs,
             )
-            if existing_workflow:
-                existing_draft = await db_client.get_draft_version(workflow_id)
-                workflow_configurations = merge_workflow_configuration_secrets(
-                    workflow_configurations,
-                    existing_draft.workflow_configurations
-                    if existing_draft
-                    else existing_workflow.released_definition.workflow_configurations,
-                )
         if workflow_configurations and workflow_configurations.get(
             WORKFLOW_MODEL_CONFIGURATION_V2_OVERRIDE_KEY
         ):
-            existing_workflow = await db_client.get_workflow(
-                workflow_id, organization_id=user.selected_organization_id
-            )
             if existing_workflow is None:
                 raise HTTPException(
                     status_code=404, detail=f"Workflow with id {workflow_id} not found"
                 )
-            existing_draft = await db_client.get_draft_version(workflow_id)
-            existing_configs = (
-                existing_draft.workflow_configurations
-                if existing_draft
-                else existing_workflow.released_definition.workflow_configurations
-            )
             existing_v2_override = (existing_configs or {}).get(
                 WORKFLOW_MODEL_CONFIGURATION_V2_OVERRIDE_KEY
             )
@@ -1217,23 +1212,10 @@ async def update_workflow(
             }
             workflow_configurations.pop("model_overrides", None)
         elif workflow_configurations and workflow_configurations.get("model_overrides"):
-            existing_workflow = await db_client.get_workflow(
-                workflow_id, organization_id=user.selected_organization_id
-            )
             if existing_workflow is None:
                 raise HTTPException(
                     status_code=404, detail=f"Workflow with id {workflow_id} not found"
                 )
-            existing_draft = await db_client.get_draft_version(workflow_id)
-            existing_configs = (
-                existing_draft.workflow_configurations
-                if existing_draft
-                else existing_workflow.released_definition.workflow_configurations
-            )
-            workflow_configurations = merge_workflow_configuration_secrets(
-                workflow_configurations,
-                existing_configs,
-            )
             resolved_config = await get_resolved_ai_model_configuration(
                 organization_id=user.selected_organization_id,
             )

--- a/api/services/configuration/masking.py
+++ b/api/services/configuration/masking.py
@@ -169,8 +169,8 @@ def mask_workflow_configurations(config: Optional[Dict]) -> Optional[Dict]:
     # Voicemail detection can carry its own provider key when it does not
     # reuse the workflow LLM (use_workflow_llm=False).
     voicemail = masked.get(VOICEMAIL_DETECTION_KEY)
-    if isinstance(voicemail, dict) and voicemail.get("api_key"):
-        voicemail["api_key"] = _mask_secret_value(voicemail["api_key"])
+    if isinstance(voicemail, dict) and isinstance(voicemail.get("api_key"), str):
+        voicemail["api_key"] = mask_key(voicemail["api_key"])
 
     return masked
 

--- a/api/services/configuration/masking.py
+++ b/api/services/configuration/masking.py
@@ -21,6 +21,7 @@ MASK_CHAR = "*"
 MASK_MARKER = "***"  # substring that indicates a masked key
 SERVICE_SECRET_FIELDS = ("api_key", "credentials", "aws_access_key", "aws_secret_key")
 MODEL_OVERRIDE_FIELDS = ("llm", "tts", "stt", "realtime")
+VOICEMAIL_DETECTION_KEY = "voicemail_detection"
 
 
 def contains_masked_key(value: str | list[str] | None) -> bool:
@@ -164,6 +165,12 @@ def mask_workflow_configurations(config: Optional[Dict]) -> Optional[Dict]:
     v2_override = masked.get("model_configuration_v2_override")
     if isinstance(v2_override, dict):
         _mask_nested_service_secrets(v2_override)
+
+    # Voicemail detection can carry its own provider key when it does not
+    # reuse the workflow LLM (use_workflow_llm=False).
+    voicemail = masked.get(VOICEMAIL_DETECTION_KEY)
+    if isinstance(voicemail, dict) and voicemail.get("api_key"):
+        voicemail["api_key"] = _mask_secret_value(voicemail["api_key"])
 
     return masked
 

--- a/api/services/configuration/merge.py
+++ b/api/services/configuration/merge.py
@@ -123,18 +123,29 @@ def _merge_voicemail_secret(merged: dict, existing_config: dict) -> None:
     Responses mask the key, and the settings dialog re-sends the whole
     ``voicemail_detection`` object (sometimes without ``api_key`` at all when
     toggling ``use_workflow_llm``), so a masked or missing key means "keep the
-    stored one"; only a new plain value replaces it.
+    stored one"; only a new plain value replaces it. The stored key belongs to
+    the stored provider: when the request names a different one, the mask is
+    dropped instead of restored so the old key never authenticates against the
+    new provider. Non-string values are left as they are (the block is
+    ``extra="allow"``, so nothing upstream typed them).
     """
     incoming = merged.get(VOICEMAIL_DETECTION_KEY)
     existing = existing_config.get(VOICEMAIL_DETECTION_KEY)
     if not isinstance(incoming, dict) or not isinstance(existing, dict):
         return
     existing_key = existing.get("api_key")
-    if not existing_key:
+    if not isinstance(existing_key, str) or not existing_key:
         return
     incoming_key = incoming.get("api_key")
-    if incoming_key is None or contains_masked_key(incoming_key):
-        incoming["api_key"] = existing_key
+    if incoming_key is not None and not (
+        isinstance(incoming_key, str) and contains_masked_key(incoming_key)
+    ):
+        return
+    incoming_provider = incoming.get("provider")
+    if incoming_provider is not None and incoming_provider != existing.get("provider"):
+        incoming.pop("api_key", None)
+        return
+    incoming["api_key"] = existing_key
 
 
 def merge_workflow_configuration_secrets(

--- a/api/services/configuration/merge.py
+++ b/api/services/configuration/merge.py
@@ -11,6 +11,7 @@ from api.schemas.ai_model_configuration import EffectiveAIModelConfiguration
 from api.services.configuration.masking import (
     MODEL_OVERRIDE_FIELDS,
     SERVICE_SECRET_FIELDS,
+    VOICEMAIL_DETECTION_KEY,
     contains_masked_key,
     resolve_masked_api_keys,
 )
@@ -116,6 +117,26 @@ def merge_user_configurations(
     return EffectiveAIModelConfiguration.model_validate(merged)
 
 
+def _merge_voicemail_secret(merged: dict, existing_config: dict) -> None:
+    """Restore the stored voicemail_detection.api_key in place.
+
+    Responses mask the key, and the settings dialog re-sends the whole
+    ``voicemail_detection`` object (sometimes without ``api_key`` at all when
+    toggling ``use_workflow_llm``), so a masked or missing key means "keep the
+    stored one"; only a new plain value replaces it.
+    """
+    incoming = merged.get(VOICEMAIL_DETECTION_KEY)
+    existing = existing_config.get(VOICEMAIL_DETECTION_KEY)
+    if not isinstance(incoming, dict) or not isinstance(existing, dict):
+        return
+    existing_key = existing.get("api_key")
+    if not existing_key:
+        return
+    incoming_key = incoming.get("api_key")
+    if incoming_key is None or contains_masked_key(incoming_key):
+        incoming["api_key"] = existing_key
+
+
 def merge_workflow_configuration_secrets(
     incoming_config: dict | None,
     existing_config: dict | None,
@@ -134,6 +155,8 @@ def merge_workflow_configuration_secrets(
         return incoming_config
 
     merged = copy.deepcopy(incoming_config)
+    _merge_voicemail_secret(merged, existing_config)
+
     incoming_overrides = merged.get("model_overrides")
     existing_overrides = existing_config.get("model_overrides")
     if not isinstance(incoming_overrides, dict) or not isinstance(

--- a/api/tests/test_resolve_effective_config.py
+++ b/api/tests/test_resolve_effective_config.py
@@ -551,6 +551,66 @@ class TestWorkflowConfigurationSecrets:
         assert masked["ambient_noise_configuration"] == {"enabled": True}
         assert configs["model_overrides"]["llm"]["api_key"] == "sk-real-llm-key"
 
+    def test_masks_voicemail_detection_api_key(self):
+        configs = {
+            "voicemail_detection": {
+                "enabled": True,
+                "use_workflow_llm": False,
+                "provider": "openai",
+                "model": "gpt-4.1",
+                "api_key": "sk-real-voicemail-key",
+            },
+            "max_call_duration": 300,
+        }
+
+        masked = mask_workflow_configurations(configs)
+
+        assert masked["voicemail_detection"]["api_key"] != "sk-real-voicemail-key"
+        assert contains_masked_key(masked["voicemail_detection"]["api_key"])
+        assert masked["voicemail_detection"]["api_key"].endswith("-key")
+        assert masked["voicemail_detection"]["provider"] == "openai"
+        assert masked["max_call_duration"] == 300
+        assert configs["voicemail_detection"]["api_key"] == "sk-real-voicemail-key"
+
+    def test_masking_leaves_voicemail_without_key_untouched(self):
+        configs = {"voicemail_detection": {"enabled": True, "use_workflow_llm": True}}
+
+        assert mask_workflow_configurations(configs) == configs
+
+    @pytest.mark.parametrize(
+        "incoming_key",
+        ["MASKED", None, "ABSENT"],
+        ids=["masked", "null", "absent"],
+    )
+    def test_restores_stored_voicemail_api_key(self, incoming_key):
+        existing = {
+            "voicemail_detection": {
+                "enabled": True,
+                "use_workflow_llm": False,
+                "api_key": "sk-real-voicemail-key",
+            }
+        }
+        incoming = mask_workflow_configurations(existing)
+        incoming["voicemail_detection"]["enabled"] = False
+        if incoming_key is None:
+            incoming["voicemail_detection"]["api_key"] = None
+        elif incoming_key == "ABSENT":
+            del incoming["voicemail_detection"]["api_key"]
+
+        merged = merge_workflow_configuration_secrets(incoming, existing)
+
+        assert merged["voicemail_detection"]["api_key"] == "sk-real-voicemail-key"
+        assert merged["voicemail_detection"]["enabled"] is False
+        assert incoming["voicemail_detection"].get("api_key") != "sk-real-voicemail-key"
+
+    def test_new_voicemail_api_key_replaces_stored_one(self):
+        existing = {"voicemail_detection": {"api_key": "sk-old-voicemail-key"}}
+        incoming = {"voicemail_detection": {"api_key": "sk-new-voicemail-key"}}
+
+        merged = merge_workflow_configuration_secrets(incoming, existing)
+
+        assert merged["voicemail_detection"]["api_key"] == "sk-new-voicemail-key"
+
     def test_restores_masked_model_override_secrets_from_existing_config(self):
         existing = {
             "model_overrides": {

--- a/api/tests/test_resolve_effective_config.py
+++ b/api/tests/test_resolve_effective_config.py
@@ -611,6 +611,35 @@ class TestWorkflowConfigurationSecrets:
 
         assert merged["voicemail_detection"]["api_key"] == "sk-new-voicemail-key"
 
+    def test_masked_voicemail_key_is_restored_only_for_the_same_provider(self):
+        existing = {
+            "voicemail_detection": {"provider": "openai", "api_key": "sk-openai-key"}
+        }
+        same = mask_workflow_configurations(existing)
+        assert (
+            merge_workflow_configuration_secrets(same, existing)["voicemail_detection"][
+                "api_key"
+            ]
+            == "sk-openai-key"
+        )
+
+        # Switching provider while still sending the masked placeholder must
+        # not carry the OpenAI key over to Groq.
+        switched = mask_workflow_configurations(existing)
+        switched["voicemail_detection"]["provider"] = "groq"
+        merged = merge_workflow_configuration_secrets(switched, existing)
+        assert "api_key" not in merged["voicemail_detection"]
+        assert merged["voicemail_detection"]["provider"] == "groq"
+
+    @pytest.mark.parametrize("bad_key", [123, ["sk-a", 5], {"nested": True}])
+    def test_non_string_voicemail_key_is_neither_masked_nor_merged(self, bad_key):
+        stored = {"voicemail_detection": {"api_key": bad_key}}
+        assert mask_workflow_configurations(stored) == stored
+
+        existing = {"voicemail_detection": {"api_key": "sk-real-voicemail-key"}}
+        merged = merge_workflow_configuration_secrets(stored, existing)
+        assert merged["voicemail_detection"]["api_key"] == bad_key
+
     def test_restores_masked_model_override_secrets_from_existing_config(self):
         existing = {
             "model_overrides": {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Workflow configuration updates now mask voicemail API keys in responses while preserving a stored key for unchanged providers. The save flow was exercised with masked, provider-change, and replacement-key inputs.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No blocking product failure remains after exercising the voicemail key masking and merge behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the voicemail secret merge validation script from the repository with exit code 0 and observed three PASS results indicating that masking and merge preserve provider-aware credentials.
- T-Rex evaluated the same run and concluded that the results contradict the hypothesized overwrite or cross-provider restoration failure.

<a href="https://app.greptile.com/trex/runs/22781519/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(api): voicemail key merge honours pr..."](https://github.com/dograh-hq/dograh/commit/483f0c614670972a5b936e4914c11c9305501e07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59655142)</sub>

<!-- /greptile_comment -->