### PR TITLE
fix(api): report HTTP >= 400 tool responses as errors

### DIFF
--- a/api/services/workflow/tools/custom_tool.py
+++ b/api/services/workflow/tools/custom_tool.py
@@ -477,10 +477,12 @@ async def execute_http_tool(
             except Exception:
                 response_data = {"raw_response": response.text}
 
-            # A 4xx/5xx is a failed call: report it as such so the LLM does
-            # not treat an error body as a successful result.
+            # Only a 2xx is a successful call. A 4xx/5xx carries an error body,
+            # and the client does not follow redirects, so a 3xx body is the
+            # redirect page, not the resource; neither may reach the LLM as a
+            # successful result.
             result = {
-                "status": "error" if response.status_code >= 400 else "success",
+                "status": "success" if 200 <= response.status_code < 300 else "error",
                 "status_code": response.status_code,
                 "data": response_data,
             }

--- a/api/services/workflow/tools/custom_tool.py
+++ b/api/services/workflow/tools/custom_tool.py
@@ -477,8 +477,10 @@ async def execute_http_tool(
             except Exception:
                 response_data = {"raw_response": response.text}
 
+            # A 4xx/5xx is a failed call: report it as such so the LLM does
+            # not treat an error body as a successful result.
             result = {
-                "status": "success",
+                "status": "error" if response.status_code >= 400 else "success",
                 "status_code": response.status_code,
                 "data": response_data,
             }

--- a/api/tests/test_custom_tools.py
+++ b/api/tests/test_custom_tools.py
@@ -877,12 +877,19 @@ class TestExecuteHttpTool:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "status_code,expected_status",
-        [(200, "success"), (204, "success"), (400, "error"), (500, "error")],
+        [
+            (200, "success"),
+            (204, "success"),
+            (302, "error"),
+            (400, "error"),
+            (500, "error"),
+        ],
     )
     async def test_http_status_code_drives_result_status(
         self, status_code, expected_status
     ):
-        """4xx/5xx responses are reported as errors, not successes."""
+        """Only 2xx is a success: 4xx/5xx are errors, and so is an unfollowed
+        3xx (the client does not follow redirects)."""
         tool = MockToolModel(
             tool_uuid="test-uuid",
             name="Status API",
@@ -901,8 +908,15 @@ class TestExecuteHttpTool:
             mock_client = AsyncMock()
             mock_response = Mock()
             mock_response.status_code = status_code
-            mock_response.text = '{"detail": "boom"}'
-            mock_response.json.return_value = {"detail": "boom"}
+            if status_code == 204:
+                # No Content: an empty body that does not parse as JSON.
+                mock_response.text = ""
+                mock_response.json.side_effect = ValueError("no content")
+                expected_data = {"raw_response": ""}
+            else:
+                mock_response.text = '{"detail": "boom"}'
+                mock_response.json.return_value = {"detail": "boom"}
+                expected_data = {"detail": "boom"}
             mock_client.request.return_value = mock_response
             mock_client_class.return_value.__aenter__.return_value = mock_client
 
@@ -910,7 +924,7 @@ class TestExecuteHttpTool:
 
             assert result["status"] == expected_status
             assert result["status_code"] == status_code
-            assert result["data"] == {"detail": "boom"}
+            assert result["data"] == expected_data
 
     @pytest.mark.asyncio
     async def test_request_includes_custom_headers(self):

--- a/api/tests/test_custom_tools.py
+++ b/api/tests/test_custom_tools.py
@@ -875,6 +875,44 @@ class TestExecuteHttpTool:
             assert "timed out" in result["error"]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status_code,expected_status",
+        [(200, "success"), (204, "success"), (400, "error"), (500, "error")],
+    )
+    async def test_http_status_code_drives_result_status(
+        self, status_code, expected_status
+    ):
+        """4xx/5xx responses are reported as errors, not successes."""
+        tool = MockToolModel(
+            tool_uuid="test-uuid",
+            name="Status API",
+            description="Returns a given status",
+            category="http_api",
+            definition={
+                "schema_version": 1,
+                "type": "http_api",
+                "config": {"method": "GET", "url": "https://api.example.com/x"},
+            },
+        )
+
+        with patch(
+            "api.services.workflow.tools.custom_tool.httpx.AsyncClient"
+        ) as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = Mock()
+            mock_response.status_code = status_code
+            mock_response.text = '{"detail": "boom"}'
+            mock_response.json.return_value = {"detail": "boom"}
+            mock_client.request.return_value = mock_response
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await execute_http_tool(tool, {})
+
+            assert result["status"] == expected_status
+            assert result["status_code"] == status_code
+            assert result["data"] == {"detail": "boom"}
+
+    @pytest.mark.asyncio
     async def test_request_includes_custom_headers(self):
         """Test that custom headers are included in the request."""
         tool = MockToolModel(

--- a/api/tests/test_failure_emission_seams.py
+++ b/api/tests/test_failure_emission_seams.py
@@ -27,7 +27,7 @@ def _async_client(*, response=None, error=None):
 
 
 @pytest.mark.asyncio
-async def test_custom_tool_http_error_is_classified_without_changing_result():
+async def test_custom_tool_http_error_is_classified_and_reported_as_error():
     response = MagicMock(status_code=401, text="Unauthorized")
     response.json.return_value = {"error": "Unauthorized"}
     captured = []
@@ -54,8 +54,10 @@ async def test_custom_tool_http_error_is_classified_without_changing_result():
     ):
         result = await execute_http_tool(tool, {}, organization_id=42)
 
+    # The failure is classified for observability *and* surfaced to the LLM:
+    # the body is still returned, but a 4xx/5xx is not a successful call.
     assert result == {
-        "status": "success",
+        "status": "error",
         "status_code": 401,
         "data": {"error": "Unauthorized"},
     }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Custom HTTP tools now report success only for completed 2xx responses. The previously reported redirect-success issue was disproved by an exercised request path: HTTP 302, 400, and 500 responses returned errors, while HTTP 200 returned success.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The custom HTTP tool response path was exercised with mocked 200, 302, 400, and 500 responses. Redirect and error responses were correctly classified as errors, so the earlier redirect-success behavior is no longer present.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the HTTP status test command with the T-Rex environment to validate contract behavior.
- Observed that the command completed with exit code 0 and that the HTTP status mappings were 200 for success and 302, 400, 500 as errors.
- Verified that no tracked source files were modified and that git diff --check passed, indicating a clean working tree for the test run.
- Uploaded artifacts comprising the test script and its run logs for verification and review.

<a href="https://app.greptile.com/trex/runs/22781521/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(api): only 2xx custom tool responses..."](https://github.com/dograh-hq/dograh/commit/3be61cc9efaab9414ec19cd14351290389516d9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59655867)</sub>

<!-- /greptile_comment -->