### PR TITLE
fix(api): duplicated workflows publish V1 with their configuration

### DIFF
--- a/api/db/workflow_client.py
+++ b/api/db/workflow_client.py
@@ -27,7 +27,15 @@ class WorkflowClient(BaseDBClient):
         workflow_definition: dict,
         user_id: int,
         organization_id: int = None,
+        workflow_configurations: dict | None = None,
+        template_context_variables: dict | None = None,
     ) -> WorkflowModel:
+        """Create a workflow whose published V1 carries the given settings.
+
+        ``workflow_configurations`` / ``template_context_variables`` land on the
+        V1 definition (and the legacy workflow columns); passing them later via
+        ``update_workflow`` would only create an unpublished draft.
+        """
         async with self.async_session() as session:
             try:
                 new_workflow = WorkflowModel(
@@ -35,6 +43,8 @@ class WorkflowClient(BaseDBClient):
                     workflow_definition=workflow_definition,  # Keep for backwards compatibility
                     user_id=user_id,
                     organization_id=organization_id,
+                    workflow_configurations=workflow_configurations,
+                    template_context_variables=template_context_variables,
                 )
                 session.add(new_workflow)
                 await session.flush()  # Flush to get the workflow ID

--- a/api/services/workflow/duplicate.py
+++ b/api/services/workflow/duplicate.py
@@ -108,15 +108,26 @@ async def duplicate_workflow(
             logger.error(f"Error copying ambient noise file: {e}")
         if copied:
             ambient_cfg["storage_key"] = new_key
-            await db_client.update_workflow(
-                workflow_id=new_workflow.id,
-                name=None,
-                workflow_definition=None,
-                template_context_variables=None,
-                workflow_configurations=source_wc,
-                organization_id=organization_id,
-            )
-            await db_client.publish_workflow_draft(new_workflow.id)
+            # The copy is already durable (workflow + storage object), so a
+            # failure here must not escape and leave it half-built: the V1
+            # published above keeps the source reference, exactly like the
+            # copy-failed branch below, and the copied object stays under
+            # new_key for a manual retry.
+            try:
+                await db_client.update_workflow(
+                    workflow_id=new_workflow.id,
+                    name=None,
+                    workflow_definition=None,
+                    template_context_variables=None,
+                    workflow_configurations=source_wc,
+                    organization_id=organization_id,
+                )
+                await db_client.publish_workflow_draft(new_workflow.id)
+            except Exception as e:
+                logger.error(
+                    f"Failed to publish rewritten ambient noise key {new_key} for "
+                    f"workflow {new_workflow.id}, keeping original reference: {e}"
+                )
         else:
             logger.warning(
                 f"Failed to copy ambient noise file {old_key}, keeping original reference"

--- a/api/services/workflow/duplicate.py
+++ b/api/services/workflow/duplicate.py
@@ -99,26 +99,28 @@ async def duplicate_workflow(
         old_key = ambient_cfg["storage_key"]
         filename = posixpath.basename(old_key)
         new_key = f"ambient-noise/{organization_id}/{new_workflow.id}/{filename}"
+        copied = False
         try:
-            if await _copy_storage_object(
+            copied = await _copy_storage_object(
                 old_key, new_key, ambient_cfg.get("storage_backend", "")
-            ):
-                ambient_cfg["storage_key"] = new_key
-                await db_client.update_workflow(
-                    workflow_id=new_workflow.id,
-                    name=None,
-                    workflow_definition=None,
-                    template_context_variables=None,
-                    workflow_configurations=source_wc,
-                    organization_id=organization_id,
-                )
-                await db_client.publish_workflow_draft(new_workflow.id)
-            else:
-                logger.warning(
-                    f"Failed to copy ambient noise file {old_key}, keeping original reference"
-                )
+            )
         except Exception as e:
             logger.error(f"Error copying ambient noise file: {e}")
+        if copied:
+            ambient_cfg["storage_key"] = new_key
+            await db_client.update_workflow(
+                workflow_id=new_workflow.id,
+                name=None,
+                workflow_definition=None,
+                template_context_variables=None,
+                workflow_configurations=source_wc,
+                organization_id=organization_id,
+            )
+            await db_client.publish_workflow_draft(new_workflow.id)
+        else:
+            logger.warning(
+                f"Failed to copy ambient noise file {old_key}, keeping original reference"
+            )
 
     # 6. Sync triggers for the new workflow
     if workflow_definition:

--- a/api/services/workflow/duplicate.py
+++ b/api/services/workflow/duplicate.py
@@ -74,51 +74,51 @@ async def duplicate_workflow(
     if workflow_definition:
         workflow_definition = _regenerate_trigger_uuids(workflow_definition)
 
-    # 4. Create the new workflow
+    # 4. Create the new workflow with the source configuration and template
+    #    variables, so its published V1 carries them. Passing them afterwards
+    #    via update_workflow would only create an unpublished draft, leaving
+    #    production runs (which pin the published definition) with an empty
+    #    configuration until someone publishes.
+    source_tcv = copy.deepcopy(source_def.template_context_variables or None)
+    source_wc = copy.deepcopy(source_def.workflow_configurations or None)
     new_name = f"{source.name} - Duplicate"
     new_workflow = await db_client.create_workflow(
         name=new_name,
         workflow_definition=workflow_definition,
         user_id=user_id,
         organization_id=organization_id,
+        workflow_configurations=source_wc,
+        template_context_variables=source_tcv,
     )
 
-    # 5. Copy template_context_variables and workflow_configurations from source definition
-    source_tcv = source_def.template_context_variables
-    source_wc = (
-        copy.deepcopy(source_def.workflow_configurations)
-        if source_def.workflow_configurations
-        else None
-    )
-
-    # 5a. Copy custom ambient noise file if present
-    if source_wc:
-        ambient_cfg = source_wc.get("ambient_noise_configuration")
-        if ambient_cfg and ambient_cfg.get("storage_key"):
-            old_key = ambient_cfg["storage_key"]
-            filename = posixpath.basename(old_key)
-            new_key = f"ambient-noise/{organization_id}/{new_workflow.id}/{filename}"
-            try:
-                if await _copy_storage_object(
-                    old_key, new_key, ambient_cfg.get("storage_backend", "")
-                ):
-                    ambient_cfg["storage_key"] = new_key
-                else:
-                    logger.warning(
-                        f"Failed to copy ambient noise file {old_key}, keeping original reference"
-                    )
-            except Exception as e:
-                logger.error(f"Error copying ambient noise file: {e}")
-
-    if source_tcv or source_wc:
-        new_workflow = await db_client.update_workflow(
-            workflow_id=new_workflow.id,
-            name=None,
-            workflow_definition=None,
-            template_context_variables=copy.deepcopy(source_tcv),
-            workflow_configurations=source_wc,
-            organization_id=organization_id,
-        )
+    # 5. Copy a custom ambient noise file if present. Its storage key embeds
+    #    the new workflow id, so this has to happen after creation; the
+    #    rewritten configuration is then published as V2.
+    ambient_cfg = (source_wc or {}).get("ambient_noise_configuration")
+    if ambient_cfg and ambient_cfg.get("storage_key"):
+        old_key = ambient_cfg["storage_key"]
+        filename = posixpath.basename(old_key)
+        new_key = f"ambient-noise/{organization_id}/{new_workflow.id}/{filename}"
+        try:
+            if await _copy_storage_object(
+                old_key, new_key, ambient_cfg.get("storage_backend", "")
+            ):
+                ambient_cfg["storage_key"] = new_key
+                await db_client.update_workflow(
+                    workflow_id=new_workflow.id,
+                    name=None,
+                    workflow_definition=None,
+                    template_context_variables=None,
+                    workflow_configurations=source_wc,
+                    organization_id=organization_id,
+                )
+                await db_client.publish_workflow_draft(new_workflow.id)
+            else:
+                logger.warning(
+                    f"Failed to copy ambient noise file {old_key}, keeping original reference"
+                )
+        except Exception as e:
+            logger.error(f"Error copying ambient noise file: {e}")
 
     # 6. Sync triggers for the new workflow
     if workflow_definition:

--- a/api/tests/test_workflow_versioning.py
+++ b/api/tests/test_workflow_versioning.py
@@ -13,12 +13,15 @@ Modules under test:
 These are DB integration tests using the transactional test session.
 """
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from api.db.models import (
     OrganizationModel,
     UserModel,
 )
+from api.services.workflow.duplicate import duplicate_workflow
 
 # Sample workflow definitions (graph JSON)
 GRAPH_V1 = {
@@ -737,3 +740,72 @@ class TestRunDefinitionBinding:
                 organization_id=org.id,
                 definition_id=workflow_b_definition.id,
             )
+
+
+# ---------------------------------------------------------------------------
+# Duplicate → the copy's published V1 carries the source configuration
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicate:
+    async def _published_source(self, db_session, org, user, configurations):
+        source = await db_session.create_workflow(
+            name="Source",
+            workflow_definition=GRAPH_V1,
+            user_id=user.id,
+            organization_id=org.id,
+        )
+        await db_session.save_workflow_draft(
+            source.id,
+            workflow_configurations=configurations,
+            template_context_variables={"greeting": "hi"},
+        )
+        await db_session.publish_workflow_draft(source.id)
+        return source
+
+    async def test_duplicate_publishes_source_configuration(
+        self, db_session, org_and_user
+    ):
+        """Production runs pin the published definition, so the copy must be
+        born with the configuration published — not parked in a draft."""
+        org, user = org_and_user
+        configurations = {"max_call_duration": 600, "dictionary": "Dograh"}
+        source = await self._published_source(db_session, org, user, configurations)
+
+        copied = await duplicate_workflow(source.id, org.id, user.id)
+
+        versions = await db_session.get_workflow_versions(copied.id)
+        assert [v.status for v in versions] == ["published"]
+        assert copied.released_definition.workflow_configurations == configurations
+        assert copied.released_definition.template_context_variables == {
+            "greeting": "hi"
+        }
+        assert copied.workflow_configurations == configurations
+
+    async def test_duplicate_publishes_rewritten_ambient_noise_key(
+        self, db_session, org_and_user
+    ):
+        org, user = org_and_user
+        configurations = {
+            "ambient_noise_configuration": {
+                "enabled": True,
+                "storage_key": "ambient-noise/1/1/office.wav",
+            }
+        }
+        source = await self._published_source(db_session, org, user, configurations)
+
+        with patch(
+            "api.services.workflow.duplicate._copy_storage_object",
+            AsyncMock(return_value=True),
+        ):
+            copied = await duplicate_workflow(source.id, org.id, user.id)
+
+        published = copied.released_definition
+        assert published.version_number == 2
+        assert (
+            published.workflow_configurations["ambient_noise_configuration"][
+                "storage_key"
+            ]
+            == f"ambient-noise/{org.id}/{copied.id}/office.wav"
+        )
+        assert await db_session.get_draft_version(copied.id) is None

--- a/api/tests/test_workflow_versioning.py
+++ b/api/tests/test_workflow_versioning.py
@@ -794,12 +794,14 @@ class TestDuplicate:
         }
         source = await self._published_source(db_session, org, user, configurations)
 
-        with patch(
-            "api.services.workflow.duplicate._copy_storage_object",
-            AsyncMock(return_value=True),
-        ):
+        copy_object = AsyncMock(return_value=True)
+        with patch("api.services.workflow.duplicate._copy_storage_object", copy_object):
             copied = await duplicate_workflow(source.id, org.id, user.id)
 
+        new_key = f"ambient-noise/{org.id}/{copied.id}/office.wav"
+        copy_object.assert_awaited_once_with(
+            "ambient-noise/1/1/office.wav", new_key, ""
+        )
         versions = await db_session.get_workflow_versions(copied.id)
         assert sorted(v.status for v in versions) == ["archived", "published"]
         published = next(v for v in versions if v.status == "published")
@@ -808,7 +810,37 @@ class TestDuplicate:
             published.workflow_configurations["ambient_noise_configuration"][
                 "storage_key"
             ]
-            == f"ambient-noise/{org.id}/{copied.id}/office.wav"
+            == new_key
         )
         refreshed = await db_session.get_workflow_by_id(copied.id)
         assert refreshed.released_definition_id == published.id
+
+    async def test_duplicate_survives_failed_ambient_noise_republish(
+        self, db_session, org_and_user
+    ):
+        """The workflow and the copied object are durable before the rewritten
+        key is published; a failure there degrades to the source reference
+        instead of surfacing as a failed duplicate."""
+        org, user = org_and_user
+        configurations = {
+            "ambient_noise_configuration": {
+                "enabled": True,
+                "storage_key": "ambient-noise/1/1/office.wav",
+            }
+        }
+        source = await self._published_source(db_session, org, user, configurations)
+
+        with (
+            patch(
+                "api.services.workflow.duplicate._copy_storage_object",
+                AsyncMock(return_value=True),
+            ),
+            patch(
+                "api.services.workflow.duplicate.db_client.publish_workflow_draft",
+                AsyncMock(side_effect=RuntimeError("db down")),
+            ),
+        ):
+            copied = await duplicate_workflow(source.id, org.id, user.id)
+
+        assert copied.released_definition.version_number == 1
+        assert copied.released_definition.workflow_configurations == configurations

--- a/api/tests/test_workflow_versioning.py
+++ b/api/tests/test_workflow_versioning.py
@@ -800,7 +800,9 @@ class TestDuplicate:
         ):
             copied = await duplicate_workflow(source.id, org.id, user.id)
 
-        published = copied.released_definition
+        versions = await db_session.get_workflow_versions(copied.id)
+        assert sorted(v.status for v in versions) == ["archived", "published"]
+        published = next(v for v in versions if v.status == "published")
         assert published.version_number == 2
         assert (
             published.workflow_configurations["ambient_noise_configuration"][
@@ -808,4 +810,5 @@ class TestDuplicate:
             ]
             == f"ambient-noise/{org.id}/{copied.id}/office.wav"
         )
-        assert await db_session.get_draft_version(copied.id) is None
+        refreshed = await db_session.get_workflow_by_id(copied.id)
+        assert refreshed.released_definition_id == published.id


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change ensures a duplicated workflow’s initial published definition includes the source configuration and template variables, then publishes a second version when a custom ambient-noise storage key is rewritten. The previously reported post-copy update failure is resolved: an injected `update_workflow` exception was caught, the duplicate was returned, and trigger synchronization still ran. A publication failure after the rewritten ambient-noise draft is saved still leaves the duplicate reporting success with released and draft definitions pointing to different storage objects.

<h3>Confidence Score: 4/5</h3>

The ambient-noise duplication path can report success after publication fails, leaving the released workflow on the source file while an unpublished draft points to the copied file.

One actionable workflow-consistency failure remains: callers receive a completed duplicate even though the copied ambient-noise configuration was not published and requires later reconciliation.

**Files Needing Attention:** api/services/workflow/duplicate.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Attempted an ambient re-publish test to demonstrate the durable state, but the run failed with ModuleNotFoundError: No module named 'api' before importing the target function, so no execution evidence was established.
- Ran a controlled duplicate workflow update-failure repro harness and observed that the parent exception escaped and synchronization was skipped in the old path, while the current implementation logged the error, re-fetched the workflow, and awaited sync\_triggers\_for\_workflow once.
- Generated and attached a P1 finding proof for the posted review comment, including the harness source and observed outputs for the parent and current revisions.
- Compared the parent and current behavior and confirmed there were no production code changes; the current behavior shows exception\_escaped=False, a re-fetched workflow, and a single await of sync\_triggers\_for\_workflow.
- Uploaded source and both observed command outputs; the current run demonstrates caller success and durability/published storage-key invariants after the controlled publish\_workflow\_draft failure.

<a href="https://app.greptile.com/trex/runs/22781522/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(api): duplicate never fails after th..."](https://github.com/dograh-hq/dograh/commit/3098b1bfe06f3fb15b398e6c2284df54d0835f95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59658904)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->