### PR TITLE
ci: amd64-only API image build for the EKS deploy path

### DIFF
--- a/.github/workflows/build-api-image.yml
+++ b/.github/workflows/build-api-image.yml
@@ -1,0 +1,78 @@
+name: Build API Image
+
+# The deploy path for the EKS cluster: one image, one platform, pushed under a
+# tag derived from the commit. docker-image.yml is the release path — it builds
+# api and ui for amd64 and arm64 and assembles manifest lists in a merge job.
+#
+# The cluster's nodes are x86_64 and app.dograh.com is served by Vercel, so of
+# the four images a release builds, the cluster pulls one.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag or SHA to build. Defaults to main."
+        required: false
+        default: main
+        type: string
+
+permissions:
+  contents: read
+
+# Queue rather than cancel: a cancelled deploy build leaves a tag that was
+# announced but never pushed.
+concurrency:
+  group: build-api-image
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: false
+          dotnet: false
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: true
+
+      - name: Compute tag
+        id: tag
+        run: echo "tag=prod-$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: api/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/dograh-api:${{ steps.tag.outputs.tag }}
+          # Same scope as docker-image.yml's amd64 api build, so the two share
+          # layers in both directions.
+          cache-from: type=gha,scope=dograh-api-amd64
+          cache-to: type=gha,mode=max,scope=dograh-api-amd64
+
+      - name: Summary
+        run: |
+          echo "\`${{ secrets.DOCKERHUB_USERNAME }}/dograh-api:${{ steps.tag.outputs.tag }}\`" \
+            >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
docker-image.yml builds api and ui for amd64 and arm64, then blocks on a merge job that assembles manifest lists from all four digests. The cluster's nodes are x86_64 and app.dograh.com is served by Vercel, so it pulls one of those four.

This builds that one and pushes it directly under prod-<sha8>, no digest merge. Shares the gha cache scope with docker-image.yml's amd64 api build.


Claude-Session: https://claude.ai/code/session_011AjGsSJbRx1ngXp4rvyWE3

## Checklist

- [ ] I have read and followed the [contributing guidelines](https://github.com/dograh-hq/dograh/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated CI workflow that builds the API image for amd64 only and pushes it directly under `prod-<sha8>`, so the EKS deploy path no longer depends on the release workflow's four-image manifest list. The workflow is manually triggered, defaults to `main`, and shares its Docker layer cache scope with the existing amd64 API build in `docker-image.yml`.

<sup>Written for commit 0444794267a1baee92bf6e1c3195af8ec0b6d683. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a manually dispatched workflow to build and publish an amd64 API image for the EKS deployment path from a selected branch, tag, or SHA. The workflow was checked and confirmed to run five external actions through mutable references in the same job that receives DockerHub credentials and pushes a production image. Pin those action references to reviewed commit SHAs before merging.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until the external action references in the production publishing workflow are pinned to immutable reviewed commits.

A focused executed check confirmed the mutable action references, the DockerHub token passed to the login action, and the later image push in the same job.

**Files Needing Attention:** .github/workflows/build-api-image.yml

<details open><summary><h3>Security Review</h3></summary>

The production image-publishing job executes third-party GitHub Actions referenced by a mutable branch or major-version tag. An upstream retarget could change code that runs with DockerHub image-publishing credentials, including the token passed to the login action. Immutable, audited commit-SHA pins are required to contain this supply-chain risk.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P2 finding in review comment 0.
- T-Rex produced a proof for the posted P2 finding in review comment 1.
- T-Rex ran the requested general contract validation; the validation completed but local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Production DockerHub publishing workflow uses mutable external action references**

   - **Bug**
     - The workflow uses `jlumbroso/free-disk-space@main` (line 33), `actions/checkout@v4` (line 44), `docker/setup-buildx-action@v4` (line 54), `docker/login-action@v4` (line 57), and `docker/build-push-action@v7` (line 63), none of which is a full 40-character commit SHA. A ref retarget can therefore alter code run by this production image-publishing workflow. The mutable login action is given `${{ secrets.DOCKERHUB_TOKEN }}` on line 60, and the mutable build/push action subsequently pushes at line 68.
   - **Cause**
     - External actions are referenced by mutable branch/version labels instead of immutable reviewed commit SHAs.
   - **Fix**
     - Replace each external action ref with its audited full 40-character commit SHA; retain the intended release version in a comment and update SHAs through a reviewed dependency-update process.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci: amd64-only API image build for the E..."](https://github.com/dograh-hq/dograh/commit/0444794267a1baee92bf6e1c3195af8ec0b6d683) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59781166)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->