### PR TITLE
fix: drop hardcoded reasoning_effort for gpt-5 models to unblock tool calling

### DIFF
--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -974,7 +974,7 @@ def create_llm_service_from_provider(
                 api_key=api_key,
                 settings=OpenAILLMSettings(
                     model=model,
-                    extra={"reasoning_effort": "minimal", "verbosity": "low"},
+                    extra={"verbosity": "low"},
                 ),
                 **kwargs,
             )

--- a/api/tests/test_service_factory_failure_reporting.py
+++ b/api/tests/test_service_factory_failure_reporting.py
@@ -67,3 +67,23 @@ def test_managed_service_constructor_failure_is_attributed_to_dograh(monkeypatch
 
     assert captured[0].type == ErrorType.SYSTEM_ERROR
     assert captured[0].error_owner.value == "operator"
+
+
+def test_gpt5_model_does_not_hardcode_reasoning_effort():
+    with patch(
+        "api.services.pipecat.service_factory.OpenAILLMService"
+    ) as mock_service:
+        create_llm_service_from_provider(
+            provider="openai",
+            model="gpt-5",
+            api_key="test-key",
+        )
+
+    mock_service.assert_called_once()
+
+    settings = mock_service.call_args.kwargs["settings"]
+
+    assert settings.model == "gpt-5"
+
+    extra_args = getattr(settings, "extra", None) or {}
+    assert "reasoning_effort" not in extra_args

--- a/api/tests/test_service_factory_failure_reporting.py
+++ b/api/tests/test_service_factory_failure_reporting.py
@@ -85,5 +85,7 @@ def test_gpt5_model_does_not_hardcode_reasoning_effort():
 
     assert settings.model == "gpt-5"
 
+    # Strictly verify that reasoning_effort is absent and verbosity='low' is preserved
     extra_args = getattr(settings, "extra", None) or {}
     assert "reasoning_effort" not in extra_args
+    assert extra_args == {"verbosity": "low"}


### PR DESCRIPTION
Fixes #721

### Changes Made
- Removed the hardcoded `reasoning_effort="minimal"` from the `gpt-5*` provider initialization block in `service_factory.py`.
- Kept the existing `verbosity="low"` setting unchanged.
- Allows `gpt-5*` models such as `gpt-5.6-luna` to use their provider-supported reasoning defaults instead of sending the invalid hardcoded value.
- Added a regression test (`test_gpt5_model_does_not_hardcode_reasoning_effort`) to verify that `reasoning_effort` is not hardcoded for `gpt-5`.

## Testing
- `pytest api/tests/test_service_factory_failure_reporting.py` ✅ 4 passed
- Broader `*service_factory*.py` test run was blocked during collection by a missing optional `groq` dependency.

## Checklist
- [x] I have read and followed the [contributing guidelines](https://github.com/dograh-hq/dograh/blob/main/CONTRIBUTING.md).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #721 by removing the hardcoded `reasoning_effort="minimal"` sent for `gpt-5*` models, which was blocking tool calling. These models now use their provider-supported reasoning defaults while `verbosity="low"` is preserved.

Added a regression test asserting `reasoning_effort` is absent and `verbosity` stays `"low"` for `gpt-5`.

<sup>Written for commit e601dacdc5efb8fc95a800d9711c8a822aae9084. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the GPT-5-specific minimal reasoning-effort override while retaining low response verbosity, allowing the provider’s supported reasoning default to apply.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted blocking findings remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The code-execution attempt for the pull request completed with exit code 1, blocked by an import in api/errors/failure.py that references pipecat.utils.run\_context.get\_current\_org\_id which is not provided by pipecat-ai 1.8.1.

<a href="https://app.greptile.com/trex/runs/22296068/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["test: tighten gpt-5 regression test to a..."](https://github.com/dograh-hq/dograh/commit/e601dacdc5efb8fc95a800d9711c8a822aae9084) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59965310)</sub>

<!-- /greptile_comment -->