### PR TITLE
feat(voicemail): leave a configured message after the greeting, then hang up

### DIFF
--- a/api/services/pipecat/pipeline_builder.py
+++ b/api/services/pipecat/pipeline_builder.py
@@ -38,6 +38,7 @@ def build_pipeline(
     termination_funnel,
     voicemail_detector=None,
     recording_router=None,
+    user_speech_monitor=None,
 ):
     """Build the main pipeline with all components.
 
@@ -49,6 +50,9 @@ def build_pipeline(
         recording_router: Optional RecordingRouterProcessor. When provided,
             inserts between callback processor and TTS to route between
             pre-recorded audio playback and dynamic TTS.
+        user_speech_monitor: Optional UserSpeechMonitor. When provided, sits
+            right after STT so the voicemail-message step can wait for the
+            far end's greeting to finish before speaking.
     """
     # Build processors list with optional voicemail detection.
     #
@@ -61,6 +65,8 @@ def build_pipeline(
         termination_funnel,
         stt,
     ]
+    if user_speech_monitor:
+        processors.append(user_speech_monitor)
 
     # Insert voicemail detector after STT if enabled
     # Note: We intentionally do NOT use voicemail_detector.gate() to allow TTS

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -990,6 +990,9 @@ async def _run_pipeline_impl(
     voicemail_detector = None
     recording_router = None
     user_speech_monitor = None
+    # Message-delivery tasks spawned by the voicemail detector's handler;
+    # cancelled with the pipeline so none outlives the call it belongs to.
+    voicemail_tasks: set[asyncio.Task] = set()
 
     # Create recording audio fetcher (used by recording router, audio greetings,
     # and audio transition speech)
@@ -999,9 +1002,10 @@ async def _run_pipeline_impl(
     )
     engine.set_fetch_recording_audio(fetch_audio)
 
-    voicemail_config = (workflow.workflow_configurations or {}).get(
-        "voicemail_detection", {}
-    )
+    # From the run's pinned definition, not the live workflow row: a
+    # republish mid-call must not change what this call detects, or says,
+    # at a mailbox.
+    voicemail_config = run_configs.get("voicemail_detection") or {}
     if is_realtime and voicemail_config.get("enabled", False):
         logger.info(
             f"Disabling voicemail detection for realtime workflow run {workflow_run_id}"
@@ -1045,7 +1049,27 @@ async def _run_pipeline_impl(
                 f"Voicemail message configured for workflow run {workflow_run_id}; "
                 "it will be left after the greeting ends"
             )
-        voicemail_tasks: set[asyncio.Task] = set()
+        def _on_voicemail_task_done(task: asyncio.Task) -> None:
+            voicemail_tasks.discard(task)
+            if task.cancelled():
+                return
+            exc = task.exception()  # retrieving it also silences the loop's warning
+            if exc is None:
+                return
+            # handle_voicemail_detected catches its own failures; this is the
+            # net under that net, so even a bug there ends the call instead of
+            # leaving it open until max_call_duration.
+            logger.error(
+                f"[run {workflow_run_id}] voicemail message task failed: {exc!r}",
+                exc_info=exc,
+            )
+            if not engine.is_call_disposed():
+                asyncio.create_task(
+                    engine.end_call_with_reason(
+                        EndTaskReason.VOICEMAIL_DETECTED.value,
+                        abort_immediately=True,
+                    )
+                )
 
         @voicemail_detector.event_handler("on_voicemail_detected")
         async def _on_voicemail_detected(_processor):
@@ -1067,7 +1091,7 @@ async def _run_pipeline_impl(
                 )
             )
             voicemail_tasks.add(task)
-            task.add_done_callback(voicemail_tasks.discard)
+            task.add_done_callback(_on_voicemail_task_done)
 
     # Recording router is only meaningful in non-realtime mode (it routes between
     # pre-recorded audio playback and dynamic TTS; realtime LLMs produce audio
@@ -1213,6 +1237,10 @@ async def _run_pipeline_impl(
     except asyncio.CancelledError:
         logger.warning("Received CancelledError in _run_pipeline")
     finally:
+        # A voicemail-message task still waiting on the far end has nothing
+        # left to speak into once the pipeline is gone.
+        for pending in list(voicemail_tasks):
+            pending.cancel()
         # Close MCP sessions here, not in engine.cleanup(). The anyio cancel
         # scopes opened by MCPClient.start() in engine.initialize() are
         # task-affine; this finally runs in the same task as initialize(),

--- a/api/services/pipecat/run_pipeline.py
+++ b/api/services/pipecat/run_pipeline.py
@@ -57,6 +57,11 @@ from api.services.pipecat.recording_audio_cache import (
     warm_recording_cache,
 )
 from api.services.pipecat.recording_router_processor import RecordingRouterProcessor
+from api.services.pipecat.voicemail_message import (
+    UserSpeechMonitor,
+    VoicemailMessageConfig,
+    handle_voicemail_detected,
+)
 from api.services.pipecat.service_factory import (
     create_llm_service,
     create_llm_service_from_provider,
@@ -984,6 +989,7 @@ async def _run_pipeline_impl(
 
     voicemail_detector = None
     recording_router = None
+    user_speech_monitor = None
 
     # Create recording audio fetcher (used by recording router, audio greetings,
     # and audio transition speech)
@@ -1027,14 +1033,41 @@ async def _run_pipeline_impl(
             custom_system_prompt=custom_system_prompt,
         )
 
-        # Register event handler to end task when voicemail is detected
+        # What to do once a machine is recognised: end the call on the spot
+        # (the default), or wait for the greeting to finish, leave the
+        # configured message and then hang up (see voicemail_message.py).
+        voicemail_message_config = VoicemailMessageConfig.from_voicemail_config(
+            voicemail_config
+        )
+        if voicemail_message_config.active:
+            user_speech_monitor = UserSpeechMonitor()
+            logger.info(
+                f"Voicemail message configured for workflow run {workflow_run_id}; "
+                "it will be left after the greeting ends"
+            )
+        voicemail_tasks: set[asyncio.Task] = set()
+
         @voicemail_detector.event_handler("on_voicemail_detected")
         async def _on_voicemail_detected(_processor):
-            logger.info(f"Voicemail detected for workflow run {workflow_run_id}")
-            await engine.end_call_with_reason(
-                call_status=EndTaskReason.VOICEMAIL_DETECTED.value,
-                abort_immediately=True,
+            if not voicemail_message_config.active:
+                await handle_voicemail_detected(
+                    engine, None, voicemail_message_config, workflow_run_id=workflow_run_id
+                )
+                return
+            # This runs inside the classifier branch's frame processing. The
+            # message path waits on the far end and then on playback, so it
+            # must not block frame flow: hand it to a task and keep a
+            # reference so it is not garbage-collected mid-wait.
+            task = asyncio.create_task(
+                handle_voicemail_detected(
+                    engine,
+                    user_speech_monitor,
+                    voicemail_message_config,
+                    workflow_run_id=workflow_run_id,
+                )
             )
+            voicemail_tasks.add(task)
+            task.add_done_callback(voicemail_tasks.discard)
 
     # Recording router is only meaningful in non-realtime mode (it routes between
     # pre-recorded audio playback and dynamic TTS; realtime LLMs produce audio
@@ -1080,6 +1113,7 @@ async def _run_pipeline_impl(
             termination_funnel,
             voicemail_detector=voicemail_detector,
             recording_router=recording_router,
+            user_speech_monitor=user_speech_monitor,
         )
 
     # Create pipeline task with audio configuration

--- a/api/services/pipecat/voicemail_message.py
+++ b/api/services/pipecat/voicemail_message.py
@@ -1,0 +1,229 @@
+"""Leave a configured message on an answering machine, then hang up.
+
+The native ``VoicemailDetector`` classifies the callee's first turn and fires
+``on_voicemail_detected`` the instant a machine is recognised — usually while
+the greeting is still playing. Until now the only handler ended the call on
+the spot. This module adds the other thing an outbound dialer needs to do at a
+mailbox: wait for the greeting (and the beep) to finish, speak a configured
+message once, and *then* hang up — with a disposition that says the message
+was actually delivered rather than merely that a machine answered.
+
+Configuration lives next to the detector's own settings, under
+``workflow_configurations.voicemail_detection.leave_message``::
+
+    {
+      "enabled": true,
+      "text": "Hi {{first_name | there}}, this is Ava from Acme …",
+      "greeting_end_silence_secs": 2.0,   # optional
+      "max_greeting_wait_secs": 30.0,     # optional
+      "playback_timeout_secs": 60.0       # optional
+    }
+
+``text`` is rendered with the run's call context — the same ``{{…}}``
+template variables prompts and greetings use — so a message can name the
+contact. When ``enabled`` is false or ``text`` is empty the call ends
+immediately on detection, exactly as before.
+
+Why "silence" rather than a beep detector: the pipeline has no tone detector,
+and a mailbox greeting is followed by the beep within a second or two of the
+recorded voice stopping. Waiting for the far end to be quiet for
+``greeting_end_silence_secs`` lands the message after the beep on the
+overwhelming majority of mailboxes without any audio-analysis machinery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
+
+from loguru import logger
+from pipecat.frames.frames import (
+    Frame,
+    InterimTranscriptionFrame,
+    TranscriptionFrame,
+    TTSSpeakFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
+    VADUserStartedSpeakingFrame,
+    VADUserStoppedSpeakingFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.utils.enums import EndTaskReason
+
+from api.services.workflow.end_reasons import VOICEMAIL_MESSAGE_LEFT
+
+if TYPE_CHECKING:
+    from api.services.workflow.pipecat_engine import PipecatEngine
+
+
+def _positive_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+@dataclass(frozen=True)
+class VoicemailMessageConfig:
+    """What to do at a mailbox once the detector has spoken."""
+
+    enabled: bool = False
+    text: str = ""
+    # Quiet period after the greeting's last speech before the message starts.
+    greeting_end_silence_secs: float = 2.0
+    # Give up (and just hang up) if the far end never goes quiet — an IVR loop.
+    max_greeting_wait_secs: float = 30.0
+    # Give up waiting for the message's own playback to finish.
+    playback_timeout_secs: float = 60.0
+
+    @classmethod
+    def from_voicemail_config(
+        cls, voicemail_config: Optional[dict[str, Any]]
+    ) -> "VoicemailMessageConfig":
+        raw = (voicemail_config or {}).get("leave_message")
+        if not isinstance(raw, dict):
+            return cls()
+        text = raw.get("text")
+        return cls(
+            enabled=bool(raw.get("enabled", False)),
+            text=text.strip() if isinstance(text, str) else "",
+            greeting_end_silence_secs=_positive_float(
+                raw.get("greeting_end_silence_secs"), cls.greeting_end_silence_secs
+            ),
+            max_greeting_wait_secs=_positive_float(
+                raw.get("max_greeting_wait_secs"), cls.max_greeting_wait_secs
+            ),
+            playback_timeout_secs=_positive_float(
+                raw.get("playback_timeout_secs"), cls.playback_timeout_secs
+            ),
+        )
+
+    @property
+    def active(self) -> bool:
+        """True when there is a message to leave."""
+        return self.enabled and bool(self.text)
+
+
+class UserSpeechMonitor(FrameProcessor):
+    """Tracks whether the far end is producing speech, so a later step can wait
+    for it to stop.
+
+    Sits right after STT. Speech boundaries arrive from two places — the
+    transport's VAD (``VADUser*SpeakingFrame``) and the user aggregator's turn
+    strategies downstream (``User*SpeakingFrame``, which it also broadcasts
+    upstream) — and transcript frames prove speech content is still arriving
+    even when a boundary frame was missed. All of them count as activity.
+    Every frame is passed through untouched.
+    """
+
+    _STARTED = (UserStartedSpeakingFrame, VADUserStartedSpeakingFrame)
+    _STOPPED = (UserStoppedSpeakingFrame, VADUserStoppedSpeakingFrame)
+    _ACTIVITY = (TranscriptionFrame, InterimTranscriptionFrame)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._speaking = False
+        self._last_activity: Optional[float] = None
+
+    @property
+    def speaking(self) -> bool:
+        return self._speaking
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+        if isinstance(frame, self._STARTED):
+            self._speaking = True
+            self._last_activity = self._now()
+        elif isinstance(frame, self._STOPPED):
+            self._speaking = False
+            self._last_activity = self._now()
+        elif isinstance(frame, self._ACTIVITY):
+            self._last_activity = self._now()
+        await self.push_frame(frame, direction)
+
+    async def wait_for_silence(
+        self, quiet_secs: float, *, timeout: float, poll_secs: float = 0.1
+    ) -> bool:
+        """Resolve True once the far end has been quiet for ``quiet_secs``:
+        not mid-utterance, and no boundary or transcript activity in that
+        window. ``timeout`` bounds the whole wait; False means the far end
+        never went quiet (the caller should not speak over it)."""
+        deadline = self._now() + timeout
+        if self._last_activity is None:
+            # Nothing heard yet: start the quiet clock now rather than
+            # treating "no data" as instant silence.
+            self._last_activity = self._now()
+        while True:
+            now = self._now()
+            if not self._speaking and now - self._last_activity >= quiet_secs:
+                return True
+            if now >= deadline:
+                return False
+            await asyncio.sleep(poll_secs)
+
+    @staticmethod
+    def _now() -> float:
+        return asyncio.get_running_loop().time()
+
+
+async def handle_voicemail_detected(
+    engine: "PipecatEngine",
+    monitor: Optional[UserSpeechMonitor],
+    config: VoicemailMessageConfig,
+    *,
+    workflow_run_id: int,
+) -> str:
+    """Runs once the native detector has classified the far end as a machine.
+
+    Returns the reason the call was ended with: ``voicemail_message_left`` when
+    the configured message played to completion, otherwise
+    ``EndTaskReason.VOICEMAIL_DETECTED`` — the same outcome as before this
+    feature existed, so a mailbox that never goes quiet or a TTS that never
+    starts degrades to the old behaviour rather than to a half-left message
+    reported as delivered.
+    """
+    engine.mark_voicemail_detected()
+    detected = EndTaskReason.VOICEMAIL_DETECTED.value
+
+    if not config.active or monitor is None:
+        logger.info(f"[run {workflow_run_id}] voicemail detected; ending call")
+        await engine.end_call_with_reason(detected, abort_immediately=True)
+        return detected
+
+    logger.info(
+        f"[run {workflow_run_id}] voicemail detected; waiting for the greeting "
+        f"to end (quiet {config.greeting_end_silence_secs}s) before leaving the message"
+    )
+    quiet = await monitor.wait_for_silence(
+        config.greeting_end_silence_secs, timeout=config.max_greeting_wait_secs
+    )
+    if not quiet:
+        logger.warning(
+            f"[run {workflow_run_id}] far end never went quiet within "
+            f"{config.max_greeting_wait_secs}s; hanging up without the message"
+        )
+        await engine.end_call_with_reason(detected, abort_immediately=True)
+        return detected
+
+    text = engine.render_call_text(config.text)
+    engine.arm_speech_playback()
+    await engine.task.queue_frame(
+        TTSSpeakFrame(text, append_to_context=False, persist_to_logs=True)
+    )
+    played = await engine.wait_for_speech_playback(
+        start_timeout=5.0, playback_timeout=config.playback_timeout_secs
+    )
+    if not played:
+        stage = "finish" if engine.speech_playback_started else "start"
+        logger.warning(
+            f"[run {workflow_run_id}] voicemail message did not {stage} playing; "
+            "recording the call as voicemail, not as message left"
+        )
+        await engine.end_call_with_reason(detected)
+        return detected
+
+    logger.info(f"[run {workflow_run_id}] voicemail message left ({len(text)} chars)")
+    await engine.end_call_with_reason(VOICEMAIL_MESSAGE_LEFT)
+    return VOICEMAIL_MESSAGE_LEFT

--- a/api/services/pipecat/voicemail_message.py
+++ b/api/services/pipecat/voicemail_message.py
@@ -34,6 +34,7 @@ overwhelming majority of mailboxes without any audio-analysis machinery.
 from __future__ import annotations
 
 import asyncio
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -62,7 +63,19 @@ def _positive_float(value: Any, default: float) -> float:
         parsed = float(value)
     except (TypeError, ValueError):
         return default
-    return parsed if parsed > 0 else default
+    # Infinity parses as a float and passes ``> 0``; it would make a wait
+    # unbounded, which is the one thing these knobs exist to prevent.
+    return parsed if parsed > 0 and math.isfinite(parsed) else default
+
+
+def _as_bool(value: Any) -> bool:
+    """Only a real boolean — or the unambiguous strings a form field may send —
+    switches the feature on. ``bool("false")`` is True, and nobody meant that."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return False
 
 
 @dataclass(frozen=True)
@@ -87,7 +100,7 @@ class VoicemailMessageConfig:
             return cls()
         text = raw.get("text")
         return cls(
-            enabled=bool(raw.get("enabled", False)),
+            enabled=_as_bool(raw.get("enabled")),
             text=text.strip() if isinstance(text, str) else "",
             greeting_end_silence_secs=_positive_float(
                 raw.get("greeting_end_silence_secs"), cls.greeting_end_silence_secs
@@ -192,6 +205,35 @@ async def handle_voicemail_detected(
         await engine.end_call_with_reason(detected, abort_immediately=True)
         return detected
 
+    try:
+        return await _leave_message(
+            engine, monitor, config, workflow_run_id=workflow_run_id, detected=detected
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        # This handler is the only thing that ends the call once a machine
+        # answered: a failure anywhere in the message path (a bad template, a
+        # TTS error, a queue that is already closed) must still hang up, with
+        # the same fallback disposition every other failed step gets.
+        logger.error(
+            f"[run {workflow_run_id}] voicemail message failed ({exc!r}); "
+            "hanging up as voicemail",
+            exc_info=exc,
+        )
+        if not engine.is_call_disposed():
+            await engine.end_call_with_reason(detected, abort_immediately=True)
+        return detected
+
+
+async def _leave_message(
+    engine: "PipecatEngine",
+    monitor: UserSpeechMonitor,
+    config: VoicemailMessageConfig,
+    *,
+    workflow_run_id: int,
+    detected: str,
+) -> str:
     logger.info(
         f"[run {workflow_run_id}] voicemail detected; waiting for the greeting "
         f"to end (quiet {config.greeting_end_silence_secs}s) before leaving the message"
@@ -199,6 +241,14 @@ async def handle_voicemail_detected(
     quiet = await monitor.wait_for_silence(
         config.greeting_end_silence_secs, timeout=config.max_greeting_wait_secs
     )
+    if engine.is_call_disposed():
+        # The far end hung up (or the run was cancelled) while we waited:
+        # the call is already being torn down, so there is nothing to speak
+        # into — and queueing audio now would land in a closing pipeline.
+        logger.info(
+            f"[run {workflow_run_id}] call ended during the greeting wait; no message left"
+        )
+        return detected
     if not quiet:
         logger.warning(
             f"[run {workflow_run_id}] far end never went quiet within "
@@ -215,13 +265,22 @@ async def handle_voicemail_detected(
     played = await engine.wait_for_speech_playback(
         start_timeout=5.0, playback_timeout=config.playback_timeout_secs
     )
+    if engine.is_call_disposed():
+        # Torn down mid-message (far-end hangup, max duration): the engine
+        # already stamped that mechanical reason; nothing to add.
+        logger.info(
+            f"[run {workflow_run_id}] call ended while the message was playing"
+        )
+        return detected
     if not played:
         stage = "finish" if engine.speech_playback_started else "start"
         logger.warning(
             f"[run {workflow_run_id}] voicemail message did not {stage} playing; "
             "recording the call as voicemail, not as message left"
         )
-        await engine.end_call_with_reason(detected)
+        # Abort rather than end gracefully: an audio path that never played
+        # (or never finished) is exactly the one that may never flush.
+        await engine.end_call_with_reason(detected, abort_immediately=True)
         return detected
 
     logger.info(f"[run {workflow_run_id}] voicemail message left ({len(text)} chars)")

--- a/api/services/workflow/disposition_codes.py
+++ b/api/services/workflow/disposition_codes.py
@@ -9,7 +9,9 @@ behind the code that produces the dispositions.
 Three kinds of built-in value feed that field:
 
 * the pipeline, via ``PipecatEngine.end_call_with_reason`` /
-  ``set_call_disposition`` — an ``EndTaskReason`` value;
+  ``set_call_disposition`` — an ``EndTaskReason`` value, or one of the
+  engine's own end reasons that live outside that enum
+  (``api.services.workflow.end_reasons``);
 * the telephony status callback, via ``status_processor`` and
   ``mark_workflow_run_failed`` — a ``TelephonyCallStatus`` value, for calls
   that never connected;
@@ -26,12 +28,17 @@ from pipecat.utils.enums import EndTaskReason
 
 from api.enums import TelephonyCallStatus
 from api.services.workflow.disposition_extraction import DEFAULT_DISPOSITION_CODES
+from api.services.workflow.end_reasons import VOICEMAIL_MESSAGE_LEFT
 
 # Keep this derived directly from the enum so every pipeline disposition is
 # available to clients without maintaining a second list.
 END_TASK_REASON_DISPOSITION_CODES: tuple[str, ...] = tuple(
     reason.value for reason in EndTaskReason
 )
+
+# Pipeline end reasons stamped by the engine that are not EndTaskReason
+# members (that enum lives in the pipecat submodule).
+_ENGINE_DISPOSITIONS: tuple[str, ...] = (VOICEMAIL_MESSAGE_LEFT,)
 
 # Statuses written when the call never reached the pipeline.
 _TELEPHONY_DISPOSITIONS: tuple[str, ...] = (
@@ -47,6 +54,7 @@ SYSTEM_DISPOSITION_CODES: tuple[str, ...] = tuple(
     # future Pipecat reason or telephony status adopts a business-outcome name.
     dict.fromkeys(
         END_TASK_REASON_DISPOSITION_CODES
+        + _ENGINE_DISPOSITIONS
         + _TELEPHONY_DISPOSITIONS
         + DEFAULT_DISPOSITION_CODES
     )

--- a/api/services/workflow/end_reasons.py
+++ b/api/services/workflow/end_reasons.py
@@ -1,0 +1,11 @@
+"""End-of-call reasons the engine stamps that ``pipecat.utils.enums.EndTaskReason`` lacks.
+
+``EndTaskReason.VOICEMAIL_DETECTED`` means "the native detector recognised an
+answering machine and the call ended there". This one means the configured
+voicemail message was played to completion *first*. Consumers that treat a
+voicemail as "nobody was reached" must not count this as undelivered, and a
+dialer that retries voicemails should not redial a mailbox that already holds
+the message — so the two reasons are deliberately distinct strings.
+"""
+
+VOICEMAIL_MESSAGE_LEFT = "voicemail_message_left"

--- a/api/services/workflow/pipecat_engine.py
+++ b/api/services/workflow/pipecat_engine.py
@@ -80,6 +80,7 @@ from api.services.workflow.tools.knowledge_base import (
     retrieve_from_knowledge_base,
 )
 from api.utils.template_renderer import render_template
+from api.services.workflow.end_reasons import VOICEMAIL_MESSAGE_LEFT
 
 CALL_STATUS_CONTEXT_KEY = "call_status"
 
@@ -188,6 +189,12 @@ class PipecatEngine:
         # "nothing started yet", so both events start cleared.
         self._speech_playback_started: asyncio.Event = asyncio.Event()
         self._speech_playback_finished: asyncio.Event = asyncio.Event()
+
+        # Set once the native voicemail detector classifies the far end as a
+        # machine. Idle handling consults it: an answering machine is never
+        # "quiet", so the are-you-still-there escalation (and its hangup)
+        # must not fire while a voicemail message is being left.
+        self._voicemail_detected: bool = False
 
         # Custom tool manager (initialized in initialize())
         self._custom_tool_manager: Optional[CustomToolManager] = None
@@ -320,6 +327,24 @@ class PipecatEngine:
         """Delegate prompt formatting to the shared workflow.utils implementation."""
 
         return render_template(prompt, self._call_context_vars)
+
+    def render_call_text(self, text: str) -> str:
+        """Render ``{{…}}`` call-context variables in caller-facing text — the
+        same substitution node prompts and greetings receive."""
+        return self._format_prompt(text)
+
+    def mark_voicemail_detected(self) -> None:
+        """Record that the native detector classified the far end as a machine."""
+        self._voicemail_detected = True
+
+    @property
+    def voicemail_detected(self) -> bool:
+        return self._voicemail_detected
+
+    @property
+    def speech_playback_started(self) -> bool:
+        """True once speech armed via ``arm_speech_playback`` has begun playing."""
+        return self._speech_playback_started.is_set()
 
     async def _create_transition_func(
         self,
@@ -1059,6 +1084,7 @@ class PipecatEngine:
         if call_status not in (
             EndTaskReason.PIPELINE_ERROR.value,
             EndTaskReason.VOICEMAIL_DETECTED.value,
+            VOICEMAIL_MESSAGE_LEFT,
         ):
             # Finish ordinary node extraction, then classify the call outcome
             # independently when the mechanical status is only a fallback.

--- a/api/services/workflow/pipecat_engine_callbacks.py
+++ b/api/services/workflow/pipecat_engine_callbacks.py
@@ -41,6 +41,12 @@ class UserIdleHandler:
 
     async def handle_idle(self, aggregator):
         """Handle user idle event with escalating prompts."""
+        if self._engine.voicemail_detected:
+            # A mailbox will never answer "are you still there?", and the
+            # second escalation hangs up — which would cut a voicemail
+            # message off mid-sentence while it is being left.
+            logger.debug("Ignoring user_idle: an answering machine answered")
+            return
         self._retry_count += 1
         logger.debug(f"Handling user_idle, attempt: {self._retry_count}")
 

--- a/api/tasks/run_integrations.py
+++ b/api/tasks/run_integrations.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, Optional
 
 from loguru import logger
 from pipecat.utils.enums import EndTaskReason
+
+from api.services.workflow.end_reasons import VOICEMAIL_MESSAGE_LEFT
 from pipecat.utils.run_context import set_current_org_id, set_current_run_id
 from pydantic import ValidationError
 
@@ -57,7 +59,10 @@ def _should_skip_qa(
     if not qa_data.qa_voicemail_calls:
         gathered_context = workflow_run.gathered_context or {}
         call_disposition = gathered_context.get("call_disposition", "")
-        if call_disposition == EndTaskReason.VOICEMAIL_DETECTED.value:
+        if call_disposition in (
+            EndTaskReason.VOICEMAIL_DETECTED.value,
+            VOICEMAIL_MESSAGE_LEFT,
+        ):
             return "voicemail call and QA voicemail calls is disabled"
 
     if qa_data.qa_sample_rate < 100:

--- a/api/tests/test_disposition_codes_route.py
+++ b/api/tests/test_disposition_codes_route.py
@@ -76,6 +76,9 @@ def test_mapping_catalog_includes_default_business_dispositions():
     assert "do_not_call" in catalog["system_codes"]
     assert "voicemail" not in catalog["system_codes"]
     assert catalog["system_codes"].count("voicemail_detected") == 1
+    # the engine's own end reason for a delivered voicemail message
+    assert "voicemail_message_left" in catalog["system_codes"]
+    assert "voicemail_message_left" not in catalog["end_task_reason_codes"]
 
 
 def test_org_custom_codes_are_appended_without_duplicating_builtins():

--- a/api/tests/test_voicemail_leave_message.py
+++ b/api/tests/test_voicemail_leave_message.py
@@ -53,8 +53,12 @@ class FakeEngine:
         self.ends: list[tuple[str, bool]] = []
         self.events: list[str] = []
         self.marked = False
+        self.disposed = False
         self._playback = playback
         self.speech_playback_started = started
+
+    def is_call_disposed(self) -> bool:
+        return self.disposed
 
     def mark_voicemail_detected(self):
         self.marked = True
@@ -116,6 +120,32 @@ class TestVoicemailMessageConfig:
         assert cfg.max_greeting_wait_secs == 30.0
         assert cfg.playback_timeout_secs == 60.0
 
+    def test_only_a_real_true_enables_it(self):
+        for value in ("false", "0", "", None, 0, [], {}):
+            cfg = VoicemailMessageConfig.from_voicemail_config(
+                {"leave_message": {"enabled": value, "text": "Hi"}}
+            )
+            assert cfg.active is False, repr(value)
+        for value in (True, "true", "1", "yes"):
+            cfg = VoicemailMessageConfig.from_voicemail_config(
+                {"leave_message": {"enabled": value, "text": "Hi"}}
+            )
+            assert cfg.active is True, repr(value)
+
+    def test_non_finite_timeouts_fall_back_to_defaults(self):
+        cfg = VoicemailMessageConfig.from_voicemail_config(
+            {
+                "leave_message": {
+                    "enabled": True,
+                    "text": "Hi",
+                    "greeting_end_silence_secs": float("inf"),
+                    "max_greeting_wait_secs": "nan",
+                    "playback_timeout_secs": "Infinity",
+                }
+            }
+        )
+        assert (cfg.greeting_end_silence_secs, cfg.max_greeting_wait_secs, cfg.playback_timeout_secs) == (2.0, 30.0, 60.0)
+
     def test_non_dict_config_is_ignored(self):
         assert VoicemailMessageConfig.from_voicemail_config({"leave_message": "yes"}).active is False
 
@@ -167,7 +197,34 @@ class TestHandleVoicemailDetected:
         )
         assert reason == DETECTED
         assert len(engine.task.frames) == 1  # it did try
-        assert engine.ends == [(DETECTED, False)]
+        # aborted, not ended gracefully: the audio path that never played is
+        # the one that may never flush
+        assert engine.ends == [(DETECTED, True)]
+
+    @pytest.mark.asyncio
+    async def test_a_failure_inside_the_message_path_still_hangs_up(self):
+        engine = FakeEngine()
+
+        async def boom(_frame):
+            raise RuntimeError("tts service is gone")
+
+        engine.task.queue_frame = boom  # type: ignore[assignment]
+        reason = await handle_voicemail_detected(
+            engine, FakeMonitor(quiet=True), ACTIVE, workflow_run_id=1
+        )
+        assert reason == DETECTED
+        assert engine.ends == [(DETECTED, True)]
+
+    @pytest.mark.asyncio
+    async def test_call_ended_during_the_greeting_wait_leaves_nothing(self):
+        engine = FakeEngine()
+        engine.disposed = True  # far end hung up while we waited
+        reason = await handle_voicemail_detected(
+            engine, FakeMonitor(quiet=True), ACTIVE, workflow_run_id=1
+        )
+        assert reason == DETECTED
+        assert engine.task.frames == []
+        assert engine.ends == []  # already torn down; nothing to end twice
 
 
 class TestUserSpeechMonitor:

--- a/api/tests/test_voicemail_leave_message.py
+++ b/api/tests/test_voicemail_leave_message.py
@@ -1,0 +1,266 @@
+"""Tests for leaving a configured message at an answering machine.
+
+Covers the three pieces added around the native VoicemailDetector:
+- ``VoicemailMessageConfig`` parsing of ``voicemail_detection.leave_message``;
+- ``UserSpeechMonitor`` deciding when the far end has gone quiet;
+- ``handle_voicemail_detected`` ordering: wait → speak → wait for playback →
+  hang up, and every fallback ending as plain ``voicemail_detected`` so a
+  message that was not actually delivered is never reported as left.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+from pipecat.frames.frames import (
+    LLMMessagesAppendFrame,
+    TranscriptionFrame,
+    TTSSpeakFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
+    VADUserStartedSpeakingFrame,
+    VADUserStoppedSpeakingFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.tests.utils import run_test
+from pipecat.utils.enums import EndTaskReason
+
+from api.services.pipecat.voicemail_message import (
+    UserSpeechMonitor,
+    VoicemailMessageConfig,
+    handle_voicemail_detected,
+)
+from api.services.workflow.end_reasons import VOICEMAIL_MESSAGE_LEFT
+from api.services.workflow.pipecat_engine import PipecatEngine
+from api.services.workflow.pipecat_engine_callbacks import UserIdleHandler
+
+DETECTED = EndTaskReason.VOICEMAIL_DETECTED.value
+
+
+class FakeTask:
+    def __init__(self):
+        self.frames: list[Any] = []
+
+    async def queue_frame(self, frame):
+        self.frames.append(frame)
+
+
+class FakeEngine:
+    """Just the surface handle_voicemail_detected touches, with call recording."""
+
+    def __init__(self, *, playback: bool = True, started: bool = True):
+        self.task = FakeTask()
+        self.ends: list[tuple[str, bool]] = []
+        self.events: list[str] = []
+        self.marked = False
+        self._playback = playback
+        self.speech_playback_started = started
+
+    def mark_voicemail_detected(self):
+        self.marked = True
+
+    def render_call_text(self, text: str) -> str:
+        return text.replace("{{first_name | there}}", "Dana")
+
+    def arm_speech_playback(self):
+        self.events.append("arm")
+
+    async def wait_for_speech_playback(self, *, start_timeout, playback_timeout):
+        self.events.append(f"wait_playback:{playback_timeout}")
+        return self._playback
+
+    async def end_call_with_reason(self, reason, abort_immediately=False):
+        self.events.append(f"end:{reason}")
+        self.ends.append((reason, abort_immediately))
+
+
+class FakeMonitor:
+    def __init__(self, quiet: bool = True):
+        self.quiet = quiet
+        self.calls: list[tuple[float, float]] = []
+
+    async def wait_for_silence(self, quiet_secs, *, timeout):
+        self.calls.append((quiet_secs, timeout))
+        return self.quiet
+
+
+ACTIVE = VoicemailMessageConfig(enabled=True, text="Hi {{first_name | there}}, call us back.")
+
+
+class TestVoicemailMessageConfig:
+    def test_absent_means_disabled(self):
+        assert VoicemailMessageConfig.from_voicemail_config({"enabled": True}).active is False
+        assert VoicemailMessageConfig.from_voicemail_config(None).active is False
+
+    def test_enabled_without_text_is_not_active(self):
+        cfg = VoicemailMessageConfig.from_voicemail_config(
+            {"leave_message": {"enabled": True, "text": "   "}}
+        )
+        assert cfg.enabled is True and cfg.text == "" and cfg.active is False
+
+    def test_parses_text_and_timings_with_defaults(self):
+        cfg = VoicemailMessageConfig.from_voicemail_config(
+            {
+                "leave_message": {
+                    "enabled": True,
+                    "text": "  Hello there  ",
+                    "greeting_end_silence_secs": "1.5",
+                    "max_greeting_wait_secs": -4,
+                }
+            }
+        )
+        assert cfg.active is True
+        assert cfg.text == "Hello there"
+        assert cfg.greeting_end_silence_secs == 1.5
+        # invalid values fall back to the defaults rather than breaking the run
+        assert cfg.max_greeting_wait_secs == 30.0
+        assert cfg.playback_timeout_secs == 60.0
+
+    def test_non_dict_config_is_ignored(self):
+        assert VoicemailMessageConfig.from_voicemail_config({"leave_message": "yes"}).active is False
+
+
+class TestHandleVoicemailDetected:
+    @pytest.mark.asyncio
+    async def test_disabled_ends_the_call_immediately_as_before(self):
+        engine = FakeEngine()
+        reason = await handle_voicemail_detected(
+            engine, None, VoicemailMessageConfig(), workflow_run_id=1
+        )
+        assert reason == DETECTED
+        assert engine.ends == [(DETECTED, True)]
+        assert engine.task.frames == []
+        assert engine.marked is True
+
+    @pytest.mark.asyncio
+    async def test_waits_speaks_then_hangs_up_as_message_left(self):
+        engine = FakeEngine()
+        monitor = FakeMonitor(quiet=True)
+        reason = await handle_voicemail_detected(engine, monitor, ACTIVE, workflow_run_id=7)
+
+        assert reason == VOICEMAIL_MESSAGE_LEFT
+        assert monitor.calls == [(2.0, 30.0)]
+        # arm BEFORE queueing, wait for playback AFTER, and only then end
+        assert engine.events == ["arm", "wait_playback:60.0", f"end:{VOICEMAIL_MESSAGE_LEFT}"]
+        [frame] = engine.task.frames
+        assert isinstance(frame, TTSSpeakFrame)
+        assert frame.text == "Hi Dana, call us back."
+        assert frame.append_to_context is False
+        # graceful EndFrame so the audio path is torn down after playback
+        assert engine.ends == [(VOICEMAIL_MESSAGE_LEFT, False)]
+
+    @pytest.mark.asyncio
+    async def test_far_end_never_quiet_hangs_up_without_speaking(self):
+        engine = FakeEngine()
+        reason = await handle_voicemail_detected(
+            engine, FakeMonitor(quiet=False), ACTIVE, workflow_run_id=1
+        )
+        assert reason == DETECTED
+        assert engine.task.frames == []
+        assert engine.ends == [(DETECTED, True)]
+
+    @pytest.mark.asyncio
+    async def test_playback_failure_is_not_reported_as_message_left(self):
+        engine = FakeEngine(playback=False, started=False)
+        reason = await handle_voicemail_detected(
+            engine, FakeMonitor(quiet=True), ACTIVE, workflow_run_id=1
+        )
+        assert reason == DETECTED
+        assert len(engine.task.frames) == 1  # it did try
+        assert engine.ends == [(DETECTED, False)]
+
+
+class TestUserSpeechMonitor:
+    @pytest.mark.asyncio
+    async def test_passes_frames_through_and_tracks_boundaries(self):
+        monitor = UserSpeechMonitor()
+        frames = [
+            VADUserStartedSpeakingFrame(),
+            TranscriptionFrame(text="you have reached", user_id="u", timestamp="t"),
+            VADUserStoppedSpeakingFrame(),
+        ]
+        # System frames (the VAD boundaries) overtake queued data frames, so
+        # arrival order is not asserted here — passthrough is pinned by the
+        # single-frame tests below; this one pins the tracked state.
+        down, _ = await run_test(monitor, frames_to_send=frames)
+        assert {type(f) for f in down} >= {
+            VADUserStartedSpeakingFrame,
+            TranscriptionFrame,
+            VADUserStoppedSpeakingFrame,
+        }
+        assert monitor.speaking is False
+        assert await monitor.wait_for_silence(0.05, timeout=1.0) is True
+
+    @pytest.mark.asyncio
+    async def test_aggregator_boundaries_count_in_either_direction(self):
+        monitor = UserSpeechMonitor()
+        await run_test(
+            monitor,
+            frames_to_send=[UserStartedSpeakingFrame()],
+            frames_to_send_direction=FrameDirection.UPSTREAM,
+            expected_up_frames=[UserStartedSpeakingFrame],
+        )
+        assert monitor.speaking is True
+        # mid-utterance is never "quiet", however long the window
+        assert await monitor.wait_for_silence(0.0, timeout=0.3, poll_secs=0.05) is False
+
+        await run_test(
+            monitor,
+            frames_to_send=[UserStoppedSpeakingFrame()],
+            expected_down_frames=[UserStoppedSpeakingFrame],
+        )
+        assert monitor.speaking is False
+        assert await monitor.wait_for_silence(0.05, timeout=1.0) is True
+
+    @pytest.mark.asyncio
+    async def test_transcript_activity_resets_the_quiet_window(self):
+        monitor = UserSpeechMonitor()
+        await run_test(
+            monitor,
+            frames_to_send=[UserStoppedSpeakingFrame()],
+            expected_down_frames=[UserStoppedSpeakingFrame],
+        )
+        # a late transcript proves speech was still arriving
+        await run_test(
+            monitor,
+            frames_to_send=[TranscriptionFrame(text="beep", user_id="u", timestamp="t")],
+            expected_down_frames=[TranscriptionFrame],
+        )
+        assert await monitor.wait_for_silence(5.0, timeout=0.2, poll_secs=0.05) is False
+
+
+class FakeAggregator:
+    def __init__(self):
+        self.frames: list[Any] = []
+
+    async def push_frame(self, frame):
+        self.frames.append(frame)
+
+
+def make_engine(**call_context_vars) -> PipecatEngine:
+    return PipecatEngine(workflow=None, call_context_vars=call_context_vars, workflow_run_id=1)
+
+
+class TestEngineSurface:
+    def test_render_call_text_uses_call_context(self):
+        engine = make_engine(first_name="Dana")
+        assert engine.render_call_text("Hi {{first_name | there}}") == "Hi Dana"
+        assert make_engine().render_call_text("Hi {{first_name | there}}") == "Hi there"
+
+    @pytest.mark.asyncio
+    async def test_idle_escalation_is_suppressed_after_voicemail_detection(self):
+        engine = make_engine()
+        handler = UserIdleHandler(engine)
+        aggregator = FakeAggregator()
+
+        await handler.handle_idle(aggregator)
+        assert len(aggregator.frames) == 1
+        assert isinstance(aggregator.frames[0], LLMMessagesAppendFrame)
+
+        engine.mark_voicemail_detected()
+        assert engine.voicemail_detected is True
+        aggregator.frames.clear()
+        # second escalation would normally hang the call up
+        await handler.handle_idle(aggregator)
+        assert aggregator.frames == []
+        assert engine._call_disposed is False

--- a/ui/src/types/workflow-configurations.ts
+++ b/ui/src/types/workflow-configurations.ts
@@ -45,6 +45,14 @@ export const TURN_START_STRATEGY_OPTIONS: Array<{
     },
 ];
 
+export interface VoicemailLeaveMessageConfiguration {
+    enabled: boolean;
+    text?: string;  // rendered with the run's call context ({{first_name | there}} …)
+    greeting_end_silence_secs?: number;  // quiet period after the greeting before speaking (default 2)
+    max_greeting_wait_secs?: number;  // give up and just hang up if the far end never goes quiet (default 30)
+    playback_timeout_secs?: number;  // give up waiting for the message's own playback (default 60)
+}
+
 export interface VoicemailDetectionConfiguration {
     enabled: boolean;
     use_workflow_llm: boolean;
@@ -53,6 +61,7 @@ export interface VoicemailDetectionConfiguration {
     api_key?: string;
     system_prompt?: string;
     long_speech_timeout: number;  // seconds cutoff for long speech detection
+    leave_message?: VoicemailLeaveMessageConfiguration;  // speak a message after the greeting, then hang up
 }
 
 export const DEFAULT_VOICEMAIL_DETECTION_CONFIGURATION: VoicemailDetectionConfiguration = {


### PR DESCRIPTION
## What

The native `VoicemailDetector` fires `on_voicemail_detected` the instant a machine is recognised, and the only handler ended the call on the spot. An outbound dialer also needs the other behaviour at a mailbox: wait for the greeting (and the beep) to finish, speak a configured message once, then hang up — and record that the message was actually delivered rather than merely that a machine answered.

## How

Configuration lives next to the detector's own settings:

```json
"voicemail_detection": {
  "enabled": true,
  "use_workflow_llm": true,
  "long_speech_timeout": 8,
  "leave_message": {
    "enabled": true,
    "text": "Hi {{first_name | there}}, this is Ava from Acme. Please call us back at …",
    "greeting_end_silence_secs": 2.0,
    "max_greeting_wait_secs": 30.0,
    "playback_timeout_secs": 60.0
  }
}
```

`text` is rendered with the run's call context (the same `{{…}}` variables prompts and greetings use). Absent or disabled = exactly the previous behaviour (immediate `voicemail_detected` hang-up, still awaited inline in the handler).

- `api/services/pipecat/voicemail_message.py` (new)
  - `VoicemailMessageConfig.from_voicemail_config()` — parsing with safe defaults.
  - `UserSpeechMonitor` — a pass-through processor placed after STT that tracks VAD / turn boundaries (in either direction) and transcript activity, exposing `wait_for_silence(quiet_secs, timeout)`.
  - `handle_voicemail_detected()` — wait for the far end to go quiet → `arm_speech_playback()` → `TTSSpeakFrame` → `wait_for_speech_playback()` → `end_call_with_reason("voicemail_message_left")`. Every fallback (never quiet, TTS never started or never finished) ends as plain `voicemail_detected`, so an undelivered message is never reported as left.
- `run_pipeline.py` — builds the monitor when a message is configured; the handler hands the message path to a task so it never blocks the classifier branch's frame processing.
- `pipeline_builder.build_pipeline(user_speech_monitor=…)`.
- `PipecatEngine` — `mark_voicemail_detected()` / `voicemail_detected`, `render_call_text()`, `speech_playback_started`; `voicemail_message_left` skips terminal extraction like `voicemail_detected` does.
- `UserIdleHandler.handle_idle` — no-op once a machine answered: its second escalation hangs up, which would cut the message off mid-sentence.
- `run_integrations.py` — the QA voicemail skip covers both reasons.
- `end_reasons.py` — `VOICEMAIL_MESSAGE_LEFT = "voicemail_message_left"` as a plain string so the pipecat submodule's `EndTaskReason` enum is untouched. A dialer that redials voicemails (`retry_on_voicemail`) should not redial a mailbox that already holds the message, which is why the two reasons are distinct; the campaign redial query keys on `voicemail_detected` only, so message-left runs are not redialed.
- UI: `VoicemailLeaveMessageConfiguration` type on `VoicemailDetectionConfiguration.leave_message` (no editor yet).

Why silence rather than beep detection: the pipeline has no tone detector, and a mailbox beep follows the recorded voice within a second or two; waiting for `greeting_end_silence_secs` of quiet lands the message after the beep on the overwhelming majority of mailboxes without audio-analysis machinery.

## Tests

`api/tests/test_voicemail_leave_message.py` — config parsing, the monitor under `run_test`, handler ordering and every fallback with a fake engine, `render_call_text` and idle suppression on a real `PipecatEngine`. `pytest tests/test_voicemail_leave_message.py tests/test_voicemail_detector.py tests/test_transfer_message_playback.py tests/test_pipecat_engine_end_call.py` → 45 passed.

Also verified against a running engine (v1.45.0 image with these files bind-mounted): boots healthy, the config survives `PUT /workflow/{id}` + `publish` into the published version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional leave-message step for outbound calls that reach an answering machine. When `voicemail_detection.leave_message` is enabled, the call now waits for the greeting to end, speaks the configured message once, then hangs up and records `voicemail_message_left` instead of ending immediately on `voicemail_detected`.

**New Features**
- Message text uses the run's call context (`{{…}}` variables) and comes from the run's pinned config, so a mid-call republish can't change what a mailbox hears; absent or disabled keeps the old immediate hang-up.
- Every failure path — greeting never ends, TTS never starts or finishes, call torn down mid-wait — ends as plain `voicemail_detected`, so an undelivered message is never reported as left.
- Idle escalation is suppressed after a machine answers, and `voicemail_message_left` is a distinct end reason that's also in the system disposition catalog, so voicemail-retry dialers don't redial mailboxes that already got the message; the QA voicemail skip covers both reasons.

<sup>Written for commit f00785e5d6bb44abe8d1db312f06065dcf7b2c94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change lets workflow owners optionally wait for an answering-machine greeting to finish, play a personalized message, and record a delivered-message disposition. The immediate voicemail hangup remains the fallback when delivery is disabled or cannot complete.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains in the voicemail message delivery path.

The exercised voicemail flow passed greeting monitoring, message queueing, playback completion, and final disposition ordering without identifying a blocking failure.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the standalone voicemail leave-message runtime check against the local Pipecat checkout.
- Validated the end-to-end flow by observing the pre- and post-state transitions: VAD and transcription frames pass downstream, the system waits for greeting silence, queues the rendered message, waits for playback completion, and records delivery only after playback finishes.
- Confirmed that no product code changes were introduced; validation artifacts were captured to support review.
- Collected and linked validation artifacts, including the runtime source and before/after output logs, to help reviewers inspect the run.

<a href="https://app.greptile.com/trex/runs/22608448/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(voicemail): pinned run config, failu..."](https://github.com/dograh-hq/dograh/commit/f00785e5d6bb44abe8d1db312f06065dcf7b2c94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60088423)</sub>

<!-- /greptile_comment -->