### PR TITLE
feat(telephony): add WhatsApp inbound calling integration

### DIFF
--- a/api/constants.py
+++ b/api/constants.py
@@ -270,11 +270,3 @@ OSS_JWT_SECRET = os.getenv("OSS_JWT_SECRET", "change-me-in-production")
 OSS_JWT_EXPIRY_HOURS = int(os.getenv("OSS_JWT_EXPIRY_HOURS", "720"))  # 30 days
 
 TUNER_BASE_URL = os.getenv("TUNER_BASE_URL", "https://api.usetuner.ai")
-
-# Deepgram Flux STT via Dograh managed service (MPS) proxy.
-# Defaults to true only in test environment; in local/production deployments,
-# defaults to false so Dograh uses standard Nova-2 streaming STT unless explicitly enabled.
-ENABLE_DOGRAH_FLUX_STT = os.getenv(
-    "ENABLE_DOGRAH_FLUX_STT",
-    "true" if os.getenv("ENVIRONMENT") == Environment.TEST.value else "false",
-).lower() == "true"

--- a/api/constants.py
+++ b/api/constants.py
@@ -78,6 +78,7 @@ STACK_PUBLISHABLE_CLIENT_KEY = os.getenv("STACK_PUBLISHABLE_CLIENT_KEY")
 DOGRAH_MPS_SECRET_KEY = os.getenv("DOGRAH_MPS_SECRET_KEY", None)
 MPS_API_URL = os.getenv("MPS_API_URL", "https://services.dograh.com")
 DOGRAH_DEVOPS_SECRET = os.getenv("DOGRAH_DEVOPS_SECRET") or None
+WHATSAPP_WEBHOOK_VERIFY_TOKEN = os.getenv("WHATSAPP_WEBHOOK_VERIFY_TOKEN") or None
 
 # Storage Configuration
 ENABLE_AWS_S3 = os.getenv("ENABLE_AWS_S3", "false").lower() == "true"
@@ -269,3 +270,11 @@ OSS_JWT_SECRET = os.getenv("OSS_JWT_SECRET", "change-me-in-production")
 OSS_JWT_EXPIRY_HOURS = int(os.getenv("OSS_JWT_EXPIRY_HOURS", "720"))  # 30 days
 
 TUNER_BASE_URL = os.getenv("TUNER_BASE_URL", "https://api.usetuner.ai")
+
+# Deepgram Flux STT via Dograh managed service (MPS) proxy.
+# Defaults to true only in test environment; in local/production deployments,
+# defaults to false so Dograh uses standard Nova-2 streaming STT unless explicitly enabled.
+ENABLE_DOGRAH_FLUX_STT = os.getenv(
+    "ENABLE_DOGRAH_FLUX_STT",
+    "true" if os.getenv("ENVIRONMENT") == Environment.TEST.value else "false",
+).lower() == "true"

--- a/api/db/telephony_configuration_client.py
+++ b/api/db/telephony_configuration_client.py
@@ -243,15 +243,16 @@ class TelephonyConfigurationClient(BaseDBClient):
             )
             result_phone = await session.execute(stmt_phone)
             rows_phone = result_phone.scalars().all()
-            if len(rows_phone) > 1:
-                ids = ", ".join(str(r.id) for r in rows_phone)
+            unique_configs = {r.id: r for r in rows_phone}
+            if len(unique_configs) > 1:
+                ids = ", ".join(str(cid) for cid in unique_configs.keys())
                 logger.error(
                     f"[WhatsApp] Ambiguous phone_number_id={phone_number_id!r} via extra_metadata: "
-                    f"matches {len(rows_phone)} active configurations ({ids}). "
+                    f"matches {len(unique_configs)} active configurations ({ids}). "
                     f"Rejecting inbound call."
                 )
                 return None
-            return rows_phone[0] if rows_phone else None
+            return next(iter(unique_configs.values())) if unique_configs else None
 
     async def get_whatsapp_configuration_by_verify_token(
         self, verify_token: str

--- a/api/db/telephony_configuration_client.py
+++ b/api/db/telephony_configuration_client.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.future import select
 
 from api.db.base_client import BaseDBClient
-from api.db.models import CampaignModel, TelephonyConfigurationModel
+from api.db.models import CampaignModel, TelephonyConfigurationModel, TelephonyPhoneNumberModel
 
 
 class TelephonyConfigurationInUseError(Exception):
@@ -179,6 +179,75 @@ class TelephonyConfigurationClient(BaseDBClient):
                 )
             )
             return list(result.scalars().all())
+
+    async def get_whatsapp_configuration_by_phone_number_id(
+        self, phone_number_id: str
+    ) -> Optional[TelephonyConfigurationModel]:
+        """Look up an active WhatsApp telephony configuration by phone_number_id.
+
+        Matches either the phone_number_id stored directly in configuration
+        credentials or the phone_number_id stored in attached active phone
+        number extra_metadata (supporting WABA-level account setups).
+        """
+        async with self.async_session() as session:
+            # 1. Direct match on configuration credentials
+            stmt = select(TelephonyConfigurationModel).where(
+                TelephonyConfigurationModel.provider == "whatsapp",
+                TelephonyConfigurationModel.credentials.op("->>")(
+                    "phone_number_id"
+                )
+                == phone_number_id,
+                TelephonyConfigurationModel.inactive.is_(False),
+            )
+            result = await session.execute(stmt)
+            config = result.scalars().first()
+            if config:
+                return config
+
+            # 2. Match via attached phone number extra_metadata
+            stmt_phone = (
+                select(TelephonyConfigurationModel)
+                .join(
+                    TelephonyPhoneNumberModel,
+                    TelephonyPhoneNumberModel.telephony_configuration_id
+                    == TelephonyConfigurationModel.id,
+                )
+                .where(
+                    TelephonyConfigurationModel.provider == "whatsapp",
+                    TelephonyConfigurationModel.inactive.is_(False),
+                    TelephonyPhoneNumberModel.is_active.is_(True),
+                    (
+                        TelephonyPhoneNumberModel.extra_metadata.op("->>")(
+                            "phone_number_id"
+                        )
+                        == phone_number_id
+                    )
+                    | (
+                        TelephonyPhoneNumberModel.extra_metadata.op("->>")(
+                            "meta_phone_number_id"
+                        )
+                        == phone_number_id
+                    ),
+                )
+            )
+            result_phone = await session.execute(stmt_phone)
+            return result_phone.scalars().first()
+
+    async def get_whatsapp_configuration_by_verify_token(
+        self, verify_token: str
+    ) -> Optional[TelephonyConfigurationModel]:
+        """Look up an active WhatsApp config matching a webhook verify token."""
+        async with self.async_session() as session:
+            stmt = select(TelephonyConfigurationModel).where(
+                TelephonyConfigurationModel.provider == "whatsapp",
+                TelephonyConfigurationModel.credentials.op("->>")(
+                    "webhook_verify_token"
+                )
+                == verify_token,
+                TelephonyConfigurationModel.inactive.is_(False),
+            )
+            result = await session.execute(stmt)
+            return result.scalars().first()
 
     async def set_telephony_configuration_inactive(
         self, config_id: int, organization_id: int, reason: str

--- a/api/db/telephony_configuration_client.py
+++ b/api/db/telephony_configuration_client.py
@@ -6,6 +6,8 @@ Each row represents one provider account that an organization has connected
 """
 
 from datetime import UTC, datetime
+
+from loguru import logger
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import func, update
@@ -200,7 +202,16 @@ class TelephonyConfigurationClient(BaseDBClient):
                 TelephonyConfigurationModel.inactive.is_(False),
             )
             result = await session.execute(stmt)
-            config = result.scalars().first()
+            rows = result.scalars().all()
+            if len(rows) > 1:
+                ids = ", ".join(str(r.id) for r in rows)
+                logger.error(
+                    f"[WhatsApp] Ambiguous phone_number_id={phone_number_id!r}: "
+                    f"matches {len(rows)} active configurations ({ids}). "
+                    f"Rejecting inbound call to prevent wrong-tenant routing."
+                )
+                return None  # caller will reject the call
+            config = rows[0] if rows else None
             if config:
                 return config
 
@@ -231,7 +242,16 @@ class TelephonyConfigurationClient(BaseDBClient):
                 )
             )
             result_phone = await session.execute(stmt_phone)
-            return result_phone.scalars().first()
+            rows_phone = result_phone.scalars().all()
+            if len(rows_phone) > 1:
+                ids = ", ".join(str(r.id) for r in rows_phone)
+                logger.error(
+                    f"[WhatsApp] Ambiguous phone_number_id={phone_number_id!r} via extra_metadata: "
+                    f"matches {len(rows_phone)} active configurations ({ids}). "
+                    f"Rejecting inbound call."
+                )
+                return None
+            return rows_phone[0] if rows_phone else None
 
     async def get_whatsapp_configuration_by_verify_token(
         self, verify_token: str

--- a/api/db/telephony_phone_number_client.py
+++ b/api/db/telephony_phone_number_client.py
@@ -260,8 +260,6 @@ class TelephonyPhoneNumberClient(BaseDBClient):
                     TelephonyPhoneNumberModel.address_normalized.in_(
                         list(addresses_normalized)
                     ),
-                    TelephonyPhoneNumberModel.is_active.is_(True),
-                    TelephonyConfigurationModel.inactive.is_(False),
                 )
             )
             if exclude_configuration_id is not None:

--- a/api/db/telephony_phone_number_client.py
+++ b/api/db/telephony_phone_number_client.py
@@ -260,6 +260,8 @@ class TelephonyPhoneNumberClient(BaseDBClient):
                     TelephonyPhoneNumberModel.address_normalized.in_(
                         list(addresses_normalized)
                     ),
+                    TelephonyPhoneNumberModel.is_active.is_(True),
+                    TelephonyConfigurationModel.inactive.is_(False),
                 )
             )
             if exclude_configuration_id is not None:
@@ -319,6 +321,7 @@ class TelephonyPhoneNumberClient(BaseDBClient):
         inbound_workflow_id: Optional[int] = None,
         telephony_trunk_id: Optional[int] = None,
         is_active: Optional[bool] = None,
+        is_default_caller_id: Optional[bool] = None,
         country_code: Optional[str] = None,
         extra_metadata: Optional[Dict[str, Any]] = None,
         clear_inbound_workflow: bool = False,
@@ -344,6 +347,8 @@ class TelephonyPhoneNumberClient(BaseDBClient):
                 row.telephony_trunk_id = None
             if is_active is not None:
                 row.is_active = is_active
+            if is_default_caller_id is not None:
+                row.is_default_caller_id = is_default_caller_id
             if country_code is not None:
                 row.country_code = country_code
             if extra_metadata is not None:

--- a/api/db/workflow_run_client.py
+++ b/api/db/workflow_run_client.py
@@ -364,6 +364,7 @@ class WorkflowRunClient(BaseDBClient):
         state: str | None = None,
         annotations: dict | None = None,
         extra: dict | None = None,
+        only_if_incomplete: bool = False,
     ) -> WorkflowRunModel:
         async with self.async_session() as session:
             # Use SELECT FOR UPDATE to lock the row during the update
@@ -375,6 +376,8 @@ class WorkflowRunClient(BaseDBClient):
             run = result.scalars().first()
             if not run:
                 raise ValueError(f"Workflow run with ID {run_id} not found")
+            if only_if_incomplete and run.is_completed:
+                return run
             if recording_url:
                 run.recording_url = recording_url
             if transcript_url:

--- a/api/db/workflow_run_client.py
+++ b/api/db/workflow_run_client.py
@@ -365,7 +365,7 @@ class WorkflowRunClient(BaseDBClient):
         annotations: dict | None = None,
         extra: dict | None = None,
         only_if_incomplete: bool = False,
-    ) -> WorkflowRunModel:
+    ) -> Optional[WorkflowRunModel]:
         async with self.async_session() as session:
             # Use SELECT FOR UPDATE to lock the row during the update
             result = await session.execute(
@@ -377,7 +377,7 @@ class WorkflowRunClient(BaseDBClient):
             if not run:
                 raise ValueError(f"Workflow run with ID {run_id} not found")
             if only_if_incomplete and run.is_completed:
-                return run
+                return None
             if recording_url:
                 run.recording_url = recording_url
             if transcript_url:

--- a/api/enums.py
+++ b/api/enums.py
@@ -51,6 +51,7 @@ class WorkflowRunMode(Enum):
     VOBIZ = "vobiz"
     CLOUDONIX = "cloudonix"
     TELNYX = "telnyx"
+    WHATSAPP = "whatsapp"
     WEBRTC = "webrtc"
     SMALLWEBRTC = "smallwebrtc"
     TEXTCHAT = "textchat"
@@ -86,6 +87,7 @@ WORKFLOW_RUN_MODES_BY_CHANNEL: dict[str, tuple[str, ...]] = {
         WorkflowRunMode.VOBIZ.value,
         WorkflowRunMode.CLOUDONIX.value,
         WorkflowRunMode.TELNYX.value,
+        WorkflowRunMode.WHATSAPP.value,
         WorkflowRunMode.STASIS.value,
         WorkflowRunMode.VOICE.value,
     ),

--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -652,11 +652,11 @@ async def get_model_configuration_preferences_legacy(
 
 
 def preserve_masked_fields(provider: str, request_dict: dict, existing: dict):
-    """If the client re-submitted a masked sensitive field, restore the original."""
+    """If the client re-submitted a masked sensitive field or omitted it on update, restore the original."""
     for field_name in _sensitive_fields(provider):
         v = _get_nested_field(request_dict, field_name)
         existing_value = _get_nested_field(existing, field_name)
-        if v and is_mask_of(v, existing_value or ""):
+        if existing_value and (v is None or v == "" or is_mask_of(v, existing_value)):
             _set_nested_field(request_dict, field_name, existing_value)
 
 
@@ -894,6 +894,16 @@ async def create_telephony_configuration(
         raise HTTPException(status_code=400, detail="No organization selected")
 
     credentials = _credentials_from_payload(request.config)
+    if request.config.provider == "whatsapp":
+        missing = [
+            f for f in ("access_token", "app_secret", "webhook_verify_token")
+            if not credentials.get(f)
+        ]
+        if missing:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Missing required WhatsApp credentials: {', '.join(missing)}",
+            )
     credentials = await _run_preprocess_hook(request.config.provider, credentials)
 
     try:

--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -68,7 +68,12 @@ from api.services.configuration.ai_model_configuration import (
 )
 from api.services.configuration.check_validity import UserConfigurationValidator
 from api.services.configuration.defaults import DEFAULT_SERVICE_PROVIDERS
-from api.services.configuration.masking import is_mask_of, mask_key, mask_user_config
+from api.services.configuration.masking import (
+    is_mask_of,
+    mask_key,
+    mask_user_config,
+    restore_masked_fields,
+)
 from api.services.configuration.registry import (
     DOGRAH_MULTILINGUAL_AUTODETECT_LANGUAGES,
     DOGRAH_STT_LANGUAGES,
@@ -651,61 +656,13 @@ async def get_model_configuration_preferences_legacy(
     return await get_preferences(user=user)
 
 
-def _has_nested_field(value: dict, dotted_path: str) -> bool:
+def _get_nested_field(value: dict, dotted_path: str) -> Any:
+    """Resolve a dotted path in a nested dict, or None when it is not there."""
     current = value
     for part in dotted_path.split("."):
         if not isinstance(current, dict) or part not in current:
-            return False
-        current = current[part]
-    return True
-
-
-def _get_model_fields_set_paths(model: Any, prefix: str = "") -> set[str]:
-    """Recursively collect dotted field paths that were explicitly set on a Pydantic model."""
-    if not hasattr(model, "model_fields_set"):
-        return set()
-    paths = set()
-    for field in model.model_fields_set:
-        full_path = f"{prefix}.{field}" if prefix else field
-        paths.add(full_path)
-        val = getattr(model, field, None)
-        if hasattr(val, "model_fields_set"):
-            paths.update(_get_model_fields_set_paths(val, prefix=full_path))
-    return paths
-
-
-def preserve_masked_fields(
-    provider: str,
-    request_dict: dict,
-    existing: dict,
-    fields_set: set[str] | None = None,
-):
-    """If the client re-submitted a masked sensitive field or omitted it on update, restore the original.
-
-    Preserves omitted fields from stored configuration while allowing explicit
-    null/empty clears.
-    """
-    for field_name in _sensitive_fields(provider):
-        v = _get_nested_field(request_dict, field_name)
-        existing_value = _get_nested_field(existing, field_name)
-        if not existing_value:
-            continue
-
-        if fields_set is not None:
-            is_omitted = field_name not in fields_set
-        else:
-            is_omitted = not _has_nested_field(request_dict, field_name)
-
-        if is_omitted or (v and is_mask_of(v, existing_value)):
-            _set_nested_field(request_dict, field_name, existing_value)
-
-
-def _get_nested_field(value: dict, dotted_path: str):
-    current = value
-    for part in dotted_path.split("."):
-        if not isinstance(current, dict):
             return None
-        current = current.get(part)
+        current = current[part]
     return current
 
 
@@ -719,6 +676,44 @@ def _set_nested_field(value: dict, dotted_path: str, field_value) -> None:
             current[part] = child
         current = child
     current[parts[-1]] = field_value
+
+
+def _get_model_fields_set_paths(model: BaseModel, prefix: str = "") -> set[str]:
+    """Recursively collect dotted field paths that were explicitly set on a Pydantic model.
+
+    A nested path is only recorded under a parent that was itself set, so the
+    result is ancestor-closed: ``"a.b" in paths`` implies ``"a" in paths``.
+    ``preserve_masked_fields`` leans on that — it can settle "did the caller
+    say anything about this path?" with one membership test.
+    """
+    paths = set()
+    for field in model.model_fields_set:
+        full_path = f"{prefix}.{field}" if prefix else field
+        paths.add(full_path)
+        val = getattr(model, field, None)
+        if isinstance(val, BaseModel):
+            paths.update(_get_model_fields_set_paths(val, prefix=full_path))
+    return paths
+
+
+def preserve_masked_fields(
+    provider: str,
+    request_dict: dict,
+    existing: dict,
+    fields_set: set[str],
+) -> None:
+    """Restore stored secrets the caller re-submitted masked or left out.
+
+    Provider-aware wrapper: the registry says which paths are sensitive, and
+    ``restore_masked_fields`` does the merge. ``fields_set`` comes from
+    ``_get_model_fields_set_paths``, whose ancestor-closure it relies on.
+    """
+    restore_masked_fields(
+        request_dict,
+        existing,
+        fields_set,
+        sensitive_paths=_sensitive_fields(provider),
+    )
 
 
 def _credentials_from_payload(config: TelephonyConfigRequest) -> dict:

--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -98,6 +98,9 @@ from api.services.telephony.factory import (
     get_sip_connectivity_details,
     get_telephony_provider_by_id,
 )
+from api.services.telephony.phone_number_sync import (
+    sync_available_phone_numbers_for_config,
+)
 from api.services.telephony.inbound_routing import (
     InboundRoutingConflictError,
     assert_no_inbound_routing_conflict,
@@ -817,117 +820,6 @@ async def _sync_inbound_for_phone_number(
     return ProviderSyncStatus(ok=result.ok, message=result.message)
 
 
-async def _sync_available_phone_numbers_for_config(
-    config_id: int, organization_id: int
-) -> ProviderSyncStatus:
-    """Import provider-owned outbound numbers into Dograh if the provider exposes them."""
-    try:
-        provider = await get_telephony_provider_by_id(config_id, organization_id)
-    except Exception as e:
-        logger.error(f"Failed to load telephony provider for config {config_id}: {e}")
-        return ProviderSyncStatus(ok=False, message=f"Provider load failed: {e}")
-
-    discover_records = getattr(provider, "get_available_phone_number_records", None)
-    records: list[dict[str, Any]] = []
-    if callable(discover_records):
-        try:
-            records = await discover_records()
-        except Exception as e:
-            logger.error(
-                f"Failed to discover phone number records for config {config_id}: {e}"
-            )
-            return ProviderSyncStatus(ok=False, message=f"Provider sync failed: {e}")
-    else:
-        discover_numbers = getattr(provider, "get_available_phone_numbers", None)
-        if not callable(discover_numbers):
-            return ProviderSyncStatus(
-                ok=True,
-                message="Provider does not expose discoverable outbound numbers.",
-            )
-
-        try:
-            available_numbers = await discover_numbers()
-            records = [{"address": num} for num in available_numbers]
-        except Exception as e:
-            logger.error(
-                f"Failed to discover phone numbers for config {config_id}: {e}"
-            )
-            return ProviderSyncStatus(ok=False, message=f"Provider sync failed: {e}")
-
-    existing_rows = await db_client.list_phone_numbers_for_config(config_id)
-    existing_map = {
-        row.address_normalized: row for row in existing_rows if row.address_normalized
-    }
-    has_default_caller = any(row.is_default_caller_id for row in existing_rows)
-    imported = 0
-    skipped = 0
-
-    for item in records:
-        address = item.get("address")
-        if not address:
-            continue
-        try:
-            normalized = normalize_telephony_address(address).canonical
-        except ValueError:
-            skipped += 1
-            logger.warning(
-                f"Skipping unparseable phone number discovered for config {config_id}: "
-                f"{address!r}"
-            )
-            continue
-
-        extra_metadata = item.get("extra_metadata") or {}
-
-        if normalized in existing_map:
-            existing_row = existing_map[normalized]
-            if existing_row and extra_metadata:
-                merged = {**(existing_row.extra_metadata or {}), **extra_metadata}
-                if merged != existing_row.extra_metadata:
-                    await db_client.update_phone_number(
-                        phone_number_id=existing_row.id,
-                        telephony_configuration_id=config_id,
-                        extra_metadata=merged,
-                    )
-            continue
-
-        try:
-            await db_client.create_phone_number(
-                organization_id=organization_id,
-                telephony_configuration_id=config_id,
-                address=address,
-                is_active=True,
-                is_default_caller_id=not has_default_caller and imported == 0,
-                extra_metadata=extra_metadata,
-            )
-            imported += 1
-            existing_map[normalized] = None
-            if not has_default_caller:
-                has_default_caller = True
-        except TelephonyPhoneNumberConflictError:
-            skipped += 1
-            logger.info(
-                f"Skipping already-existing phone number {address!r} while syncing "
-                f"config {config_id}"
-            )
-
-    if imported:
-        message = f"Imported {imported} phone number(s) from Meta."
-        if skipped:
-            message += f" Skipped {skipped} duplicate or invalid number(s)."
-        return ProviderSyncStatus(ok=True, message=message)
-
-    if skipped and not available_numbers:
-        return ProviderSyncStatus(
-            ok=True,
-            message="No discoverable phone numbers were returned by the provider.",
-        )
-
-    return ProviderSyncStatus(
-        ok=True,
-        message="No new phone numbers to import from Meta.",
-    )
-
-
 # ---------------------------------------------------------------------------
 # Multi-config CRUD
 # ---------------------------------------------------------------------------
@@ -1025,7 +917,7 @@ async def create_telephony_configuration(
         },
     )
 
-    sync_result = await _sync_available_phone_numbers_for_config(
+    sync_result = await sync_available_phone_numbers_for_config(
         row.id, user.selected_organization_id
     )
     if not sync_result.ok:
@@ -1113,7 +1005,7 @@ async def update_telephony_configuration(
         credentials=credentials,
     )
 
-    sync_result = await _sync_available_phone_numbers_for_config(
+    sync_result = await sync_available_phone_numbers_for_config(
         row.id, user.selected_organization_id
     )
     if not sync_result.ok:
@@ -1136,7 +1028,7 @@ async def sync_telephony_configuration_phone_numbers(
         raise HTTPException(status_code=400, detail="No organization selected")
 
     await _ensure_config_belongs_to_org(config_id, user.selected_organization_id)
-    result = await _sync_available_phone_numbers_for_config(
+    result = await sync_available_phone_numbers_for_config(
         config_id, user.selected_organization_id
     )
     if not result.ok:

--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -817,6 +817,117 @@ async def _sync_inbound_for_phone_number(
     return ProviderSyncStatus(ok=result.ok, message=result.message)
 
 
+async def _sync_available_phone_numbers_for_config(
+    config_id: int, organization_id: int
+) -> ProviderSyncStatus:
+    """Import provider-owned outbound numbers into Dograh if the provider exposes them."""
+    try:
+        provider = await get_telephony_provider_by_id(config_id, organization_id)
+    except Exception as e:
+        logger.error(f"Failed to load telephony provider for config {config_id}: {e}")
+        return ProviderSyncStatus(ok=False, message=f"Provider load failed: {e}")
+
+    discover_records = getattr(provider, "get_available_phone_number_records", None)
+    records: list[dict[str, Any]] = []
+    if callable(discover_records):
+        try:
+            records = await discover_records()
+        except Exception as e:
+            logger.error(
+                f"Failed to discover phone number records for config {config_id}: {e}"
+            )
+            return ProviderSyncStatus(ok=False, message=f"Provider sync failed: {e}")
+    else:
+        discover_numbers = getattr(provider, "get_available_phone_numbers", None)
+        if not callable(discover_numbers):
+            return ProviderSyncStatus(
+                ok=True,
+                message="Provider does not expose discoverable outbound numbers.",
+            )
+
+        try:
+            available_numbers = await discover_numbers()
+            records = [{"address": num} for num in available_numbers]
+        except Exception as e:
+            logger.error(
+                f"Failed to discover phone numbers for config {config_id}: {e}"
+            )
+            return ProviderSyncStatus(ok=False, message=f"Provider sync failed: {e}")
+
+    existing_rows = await db_client.list_phone_numbers_for_config(config_id)
+    existing_map = {
+        row.address_normalized: row for row in existing_rows if row.address_normalized
+    }
+    has_default_caller = any(row.is_default_caller_id for row in existing_rows)
+    imported = 0
+    skipped = 0
+
+    for item in records:
+        address = item.get("address")
+        if not address:
+            continue
+        try:
+            normalized = normalize_telephony_address(address).canonical
+        except ValueError:
+            skipped += 1
+            logger.warning(
+                f"Skipping unparseable phone number discovered for config {config_id}: "
+                f"{address!r}"
+            )
+            continue
+
+        extra_metadata = item.get("extra_metadata") or {}
+
+        if normalized in existing_map:
+            existing_row = existing_map[normalized]
+            if existing_row and extra_metadata:
+                merged = {**(existing_row.extra_metadata or {}), **extra_metadata}
+                if merged != existing_row.extra_metadata:
+                    await db_client.update_phone_number(
+                        phone_number_id=existing_row.id,
+                        telephony_configuration_id=config_id,
+                        extra_metadata=merged,
+                    )
+            continue
+
+        try:
+            await db_client.create_phone_number(
+                organization_id=organization_id,
+                telephony_configuration_id=config_id,
+                address=address,
+                is_active=True,
+                is_default_caller_id=not has_default_caller and imported == 0,
+                extra_metadata=extra_metadata,
+            )
+            imported += 1
+            existing_map[normalized] = None
+            if not has_default_caller:
+                has_default_caller = True
+        except TelephonyPhoneNumberConflictError:
+            skipped += 1
+            logger.info(
+                f"Skipping already-existing phone number {address!r} while syncing "
+                f"config {config_id}"
+            )
+
+    if imported:
+        message = f"Imported {imported} phone number(s) from Meta."
+        if skipped:
+            message += f" Skipped {skipped} duplicate or invalid number(s)."
+        return ProviderSyncStatus(ok=True, message=message)
+
+    if skipped and not available_numbers:
+        return ProviderSyncStatus(
+            ok=True,
+            message="No discoverable phone numbers were returned by the provider.",
+        )
+
+    return ProviderSyncStatus(
+        ok=True,
+        message="No new phone numbers to import from Meta.",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Multi-config CRUD
 # ---------------------------------------------------------------------------
@@ -914,6 +1025,15 @@ async def create_telephony_configuration(
         },
     )
 
+    sync_result = await _sync_available_phone_numbers_for_config(
+        row.id, user.selected_organization_id
+    )
+    if not sync_result.ok:
+        logger.warning(
+            f"Phone-number sync failed for telephony config {row.id}: "
+            f"{sync_result.message}"
+        )
+
     return await _detail_response(row)
 
 
@@ -993,7 +1113,38 @@ async def update_telephony_configuration(
         credentials=credentials,
     )
 
+    sync_result = await _sync_available_phone_numbers_for_config(
+        row.id, user.selected_organization_id
+    )
+    if not sync_result.ok:
+        logger.warning(
+            f"Phone-number sync failed for telephony config {row.id}: "
+            f"{sync_result.message}"
+        )
+
     return await _detail_response(row)
+
+
+@router.post(
+    "/telephony-configs/{config_id}/sync-phone-numbers",
+    response_model=ProviderSyncStatus,
+)
+async def sync_telephony_configuration_phone_numbers(
+    config_id: int, user: UserModel = Depends(get_user)
+):
+    if not user.selected_organization_id:
+        raise HTTPException(status_code=400, detail="No organization selected")
+
+    await _ensure_config_belongs_to_org(config_id, user.selected_organization_id)
+    result = await _sync_available_phone_numbers_for_config(
+        config_id, user.selected_organization_id
+    )
+    if not result.ok:
+        raise HTTPException(
+            status_code=502,
+            detail=result.message or "Phone-number sync failed",
+        )
+    return result
 
 
 @router.post(

--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -652,11 +652,11 @@ async def get_model_configuration_preferences_legacy(
 
 
 def preserve_masked_fields(provider: str, request_dict: dict, existing: dict):
-    """If the client re-submitted a masked sensitive field or omitted it on update, restore the original."""
+    """If the client re-submitted a masked sensitive field, restore the original."""
     for field_name in _sensitive_fields(provider):
         v = _get_nested_field(request_dict, field_name)
         existing_value = _get_nested_field(existing, field_name)
-        if existing_value and (v is None or v == "" or is_mask_of(v, existing_value)):
+        if v and is_mask_of(v, existing_value or ""):
             _set_nested_field(request_dict, field_name, existing_value)
 
 
@@ -894,16 +894,6 @@ async def create_telephony_configuration(
         raise HTTPException(status_code=400, detail="No organization selected")
 
     credentials = _credentials_from_payload(request.config)
-    if request.config.provider == "whatsapp":
-        missing = [
-            f for f in ("access_token", "app_secret", "webhook_verify_token")
-            if not credentials.get(f)
-        ]
-        if missing:
-            raise HTTPException(
-                status_code=422,
-                detail=f"Missing required WhatsApp credentials: {', '.join(missing)}",
-            )
     credentials = await _run_preprocess_hook(request.config.provider, credentials)
 
     try:

--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -651,12 +651,52 @@ async def get_model_configuration_preferences_legacy(
     return await get_preferences(user=user)
 
 
-def preserve_masked_fields(provider: str, request_dict: dict, existing: dict):
-    """If the client re-submitted a masked sensitive field, restore the original."""
+def _has_nested_field(value: dict, dotted_path: str) -> bool:
+    current = value
+    for part in dotted_path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return False
+        current = current[part]
+    return True
+
+
+def _get_model_fields_set_paths(model: Any, prefix: str = "") -> set[str]:
+    """Recursively collect dotted field paths that were explicitly set on a Pydantic model."""
+    if not hasattr(model, "model_fields_set"):
+        return set()
+    paths = set()
+    for field in model.model_fields_set:
+        full_path = f"{prefix}.{field}" if prefix else field
+        paths.add(full_path)
+        val = getattr(model, field, None)
+        if hasattr(val, "model_fields_set"):
+            paths.update(_get_model_fields_set_paths(val, prefix=full_path))
+    return paths
+
+
+def preserve_masked_fields(
+    provider: str,
+    request_dict: dict,
+    existing: dict,
+    fields_set: set[str] | None = None,
+):
+    """If the client re-submitted a masked sensitive field or omitted it on update, restore the original.
+
+    Preserves omitted fields from stored configuration while allowing explicit
+    null/empty clears.
+    """
     for field_name in _sensitive_fields(provider):
         v = _get_nested_field(request_dict, field_name)
         existing_value = _get_nested_field(existing, field_name)
-        if v and is_mask_of(v, existing_value or ""):
+        if not existing_value:
+            continue
+
+        if fields_set is not None:
+            is_omitted = field_name not in fields_set
+        else:
+            is_omitted = not _has_nested_field(request_dict, field_name)
+
+        if is_omitted or (v and is_mask_of(v, existing_value)):
             _set_nested_field(request_dict, field_name, existing_value)
 
 
@@ -982,8 +1022,12 @@ async def update_telephony_configuration(
                 detail="Provider cannot be changed; create a new configuration instead.",
             )
         credentials = _credentials_from_payload(request.config)
+        fields_set = _get_model_fields_set_paths(request.config)
         preserve_masked_fields(
-            existing.provider, credentials, existing.credentials or {}
+            existing.provider,
+            credentials,
+            existing.credentials or {},
+            fields_set=fields_set,
         )
         credentials = await _run_preprocess_hook(
             existing.provider,

--- a/api/routes/organization.py
+++ b/api/routes/organization.py
@@ -149,6 +149,17 @@ def _credentials_for_display(provider_name: str, value: dict) -> dict:
     if spec:
         for field_name in spec.server_managed_credential_fields:
             out.pop(field_name, None)
+        if spec.config_response_cls:
+            try:
+                payload = dict(out)
+                if "provider" not in payload:
+                    payload["provider"] = provider_name
+                return spec.config_response_cls(**payload).model_dump()
+            except Exception as e:
+                logger.warning(
+                    f"Failed to build response via {spec.config_response_cls.__name__} "
+                    f"for provider {provider_name}: {e}"
+                )
     return out
 
 

--- a/api/schemas/telephony_config.py
+++ b/api/schemas/telephony_config.py
@@ -36,6 +36,7 @@ from api.services.telephony.providers.vonage.config import (
 )
 from api.services.telephony.providers.whatsapp.config import (
     WhatsAppConfigurationRequest,
+    WhatsAppConfigurationResponse,
 )
 from api.services.telephony.registry import (
     ProviderConnectivity,
@@ -193,4 +194,5 @@ __all__ = [
     "VobizConfigurationRequest",
     "VonageConfigurationRequest",
     "WhatsAppConfigurationRequest",
+    "WhatsAppConfigurationResponse",
 ]

--- a/api/schemas/telephony_config.py
+++ b/api/schemas/telephony_config.py
@@ -34,6 +34,9 @@ from api.services.telephony.providers.vobiz.config import (
 from api.services.telephony.providers.vonage.config import (
     VonageConfigurationRequest,
 )
+from api.services.telephony.providers.whatsapp.config import (
+    WhatsAppConfigurationRequest,
+)
 from api.services.telephony.registry import (
     ProviderConnectivity,
     ProviderSetupChecklist,
@@ -51,6 +54,7 @@ TelephonyConfigRequest = Annotated[
         TwilioConfigurationRequest,
         VobizConfigurationRequest,
         VonageConfigurationRequest,
+        WhatsAppConfigurationRequest,
     ],
     Field(discriminator="provider"),
 ]
@@ -188,4 +192,5 @@ __all__ = [
     "TwilioConfigurationRequest",
     "VobizConfigurationRequest",
     "VonageConfigurationRequest",
+    "WhatsAppConfigurationRequest",
 ]

--- a/api/schemas/telephony_config.py
+++ b/api/schemas/telephony_config.py
@@ -36,7 +36,6 @@ from api.services.telephony.providers.vonage.config import (
 )
 from api.services.telephony.providers.whatsapp.config import (
     WhatsAppConfigurationRequest,
-    WhatsAppConfigurationResponse,
 )
 from api.services.telephony.registry import (
     ProviderConnectivity,
@@ -194,5 +193,4 @@ __all__ = [
     "VobizConfigurationRequest",
     "VonageConfigurationRequest",
     "WhatsAppConfigurationRequest",
-    "WhatsAppConfigurationResponse",
 ]

--- a/api/services/configuration/masking.py
+++ b/api/services/configuration/masking.py
@@ -10,6 +10,8 @@ The rules are simple:
 """
 
 import copy
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from typing import Any, Dict, Optional
 
 from api.schemas.ai_model_configuration import EffectiveAIModelConfiguration
@@ -108,6 +110,99 @@ def resolve_masked_api_keys(
         if not matched:
             resolved.append(key)
     return resolved
+
+
+# ---------------------------------------------------------------------------
+# Restoring masked or omitted secrets in a nested credential payload
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SensitiveNode:
+    """One node of a credential payload's sensitive-field tree.
+
+    ``secret`` and ``children`` are independent, because a dotted path can be
+    both: a maskable credential in its own right *and* an ancestor of other
+    credentials. Collapsing the two roles into one flag would silently drop
+    whichever role lost, so each is recorded explicitly.
+    """
+
+    secret: bool = False
+    children: Dict[str, "_SensitiveNode"] = dataclass_field(default_factory=dict)
+
+
+def build_sensitive_tree(sensitive_paths: list[str]) -> Dict[str, _SensitiveNode]:
+    """Nest dotted sensitive-field paths into a prefix tree."""
+    root: Dict[str, _SensitiveNode] = {}
+    for path in sensitive_paths:
+        children, node = root, None
+        for part in path.split("."):
+            node = children.setdefault(part, _SensitiveNode())
+            children = node.children
+        if node is not None:
+            node.secret = True
+    return root
+
+
+def restore_masked_fields(
+    request: dict,
+    existing: dict,
+    fields_set: set[str],
+    sensitive_paths: list[str],
+) -> None:
+    """Restore stored secrets *request* re-submitted masked or left out.
+
+    ``fields_set`` is the ancestor-closed set of dotted paths the client
+    explicitly sent (``"a.b" in fields_set`` implies ``"a" in fields_set``).
+    A serialised payload alone cannot tell "cleared this" from "never
+    mentioned it" — both look like a null once defaults are materialised —
+    so ``fields_set`` is what settles the difference.
+
+    *request* is edited in place.
+    """
+    _restore_unchanged(build_sensitive_tree(sensitive_paths), request, existing, fields_set)
+
+
+def _restore_unchanged(
+    tree: Dict[str, _SensitiveNode],
+    request: dict,
+    existing: dict,
+    fields_set: set[str],
+    prefix: str = "",
+) -> None:
+    """Merge stored credentials into *request* for everything the caller left alone.
+
+    One rule, applied top-down: a path absent from ``fields_set`` is one the
+    caller never mentioned, so what is stored stands — for a section that
+    means the whole stored subtree, non-sensitive members included, since they
+    were never in the payload to argue with. Descending only into sections the
+    caller did send is what makes an explicit null stick: a cleared section is
+    never recursed into, so its children cannot be resurrected one by one.
+
+    Which role a node plays is settled by the stored value's shape: a stored
+    dict is a section, anything else is a secret to compare against its mask.
+    """
+    for key, node in tree.items():
+        stored = existing.get(key)
+        is_section = bool(node.children) and isinstance(stored, dict)
+        is_secret = node.secret and bool(stored) and not isinstance(stored, dict)
+        if not is_section and not is_secret:
+            continue  # nothing stored here worth protecting
+
+        path = f"{prefix}.{key}" if prefix else key
+        if path not in fields_set:
+            request[key] = copy.deepcopy(stored)
+            continue
+
+        sent = request.get(key)
+        if sent is None:
+            continue  # explicitly nulled — let the clear through
+
+        if is_secret:
+            if is_mask_of(sent, stored):
+                request[key] = stored
+        elif isinstance(sent, dict):
+            _restore_unchanged(node.children, sent, stored, fields_set, path)
 
 
 # ---------------------------------------------------------------------------

--- a/api/services/pipecat/audio_config.py
+++ b/api/services/pipecat/audio_config.py
@@ -97,9 +97,11 @@ def create_audio_config(transport_type: str) -> AudioConfig:
         )
         rate = 16000
 
+    vad_rate = rate if rate in (8000, 16000) else 16000
+    pipeline_rate = min(rate, 16000)
     return AudioConfig(
         transport_in_sample_rate=rate,
         transport_out_sample_rate=rate,
-        vad_sample_rate=rate,
-        pipeline_sample_rate=rate,
+        vad_sample_rate=vad_rate,
+        pipeline_sample_rate=pipeline_rate,
     )

--- a/api/services/pipecat/audio_config.py
+++ b/api/services/pipecat/audio_config.py
@@ -100,6 +100,6 @@ def create_audio_config(transport_type: str) -> AudioConfig:
     return AudioConfig(
         transport_in_sample_rate=rate,
         transport_out_sample_rate=rate,
-        vad_sample_rate=rate,
-        pipeline_sample_rate=rate,
+        vad_sample_rate=min(rate, 16000),
+        pipeline_sample_rate=min(rate, 16000),
     )

--- a/api/services/pipecat/audio_config.py
+++ b/api/services/pipecat/audio_config.py
@@ -97,11 +97,9 @@ def create_audio_config(transport_type: str) -> AudioConfig:
         )
         rate = 16000
 
-    vad_rate = rate if rate in (8000, 16000) else 16000
-    pipeline_rate = min(rate, 16000)
     return AudioConfig(
         transport_in_sample_rate=rate,
         transport_out_sample_rate=rate,
-        vad_sample_rate=vad_rate,
-        pipeline_sample_rate=pipeline_rate,
+        vad_sample_rate=rate,
+        pipeline_sample_rate=rate,
     )

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -6,7 +6,7 @@ import aiohttp
 from fastapi import HTTPException
 from loguru import logger
 
-from api.constants import ENABLE_DOGRAH_FLUX_STT, MPS_API_URL
+from api.constants import MPS_API_URL
 from api.errors.failure import (
     ErrorSource,
     annotate_failure_metadata,
@@ -169,8 +169,6 @@ DEEPGRAM_FLUX_LANGUAGE_HINTS = {
 
 
 def dograh_stt_uses_flux_language(language: str | None) -> bool:
-    if not ENABLE_DOGRAH_FLUX_STT:
-        return False
     language = language or "multi"
     return language in DEEPGRAM_FLUX_MULTILINGUAL_LANGUAGE_OPTIONS
 
@@ -694,7 +692,6 @@ def create_tts_service(
             base_url=base_url,
             api_key=user_config.tts.api_key,
             correlation_id=correlation_id,
-            sample_rate=audio_config.transport_out_sample_rate,
             settings=DograhTTSSettings(
                 model=user_config.tts.model,
                 voice=user_config.tts.voice,

--- a/api/services/pipecat/service_factory.py
+++ b/api/services/pipecat/service_factory.py
@@ -6,7 +6,7 @@ import aiohttp
 from fastapi import HTTPException
 from loguru import logger
 
-from api.constants import MPS_API_URL
+from api.constants import ENABLE_DOGRAH_FLUX_STT, MPS_API_URL
 from api.errors.failure import (
     ErrorSource,
     annotate_failure_metadata,
@@ -169,6 +169,8 @@ DEEPGRAM_FLUX_LANGUAGE_HINTS = {
 
 
 def dograh_stt_uses_flux_language(language: str | None) -> bool:
+    if not ENABLE_DOGRAH_FLUX_STT:
+        return False
     language = language or "multi"
     return language in DEEPGRAM_FLUX_MULTILINGUAL_LANGUAGE_OPTIONS
 
@@ -692,6 +694,7 @@ def create_tts_service(
             base_url=base_url,
             api_key=user_config.tts.api_key,
             correlation_id=correlation_id,
+            sample_rate=audio_config.transport_out_sample_rate,
             settings=DograhTTSSettings(
                 model=user_config.tts.model,
                 voice=user_config.tts.voice,

--- a/api/services/telephony/phone_number_sync.py
+++ b/api/services/telephony/phone_number_sync.py
@@ -57,10 +57,15 @@ async def sync_available_phone_numbers_for_config(
     existing_map = {
         row.address_normalized: row for row in existing_rows if row.address_normalized
     }
-    has_default_caller = any(row.is_default_caller_id for row in existing_rows)
+    has_default_caller = any(
+        getattr(row, "is_default_caller_id", False)
+        for row in existing_rows
+        if getattr(row, "is_active", True)
+    )
     imported = 0
     skipped = 0
     deactivated = 0
+    discovered: set[str] = set()
 
     config_row = await db_client.get_telephony_configuration(config_id)
     provider_name = config_row.provider if config_row else None
@@ -80,18 +85,29 @@ async def sync_available_phone_numbers_for_config(
             )
             continue
 
+        discovered.add(normalized)
         extra_metadata = item.get("extra_metadata") or {}
 
         if normalized in existing_map:
             existing_row = existing_map[normalized]
-            if existing_row and extra_metadata:
-                merged = {**(existing_row.extra_metadata or {}), **extra_metadata}
-                if merged != existing_row.extra_metadata:
+            if existing_row:
+                updates: dict[str, Any] = {}
+                if not getattr(existing_row, "is_active", True):
+                    updates["is_active"] = True
+                if extra_metadata:
+                    merged = {**(existing_row.extra_metadata or {}), **extra_metadata}
+                    if merged != existing_row.extra_metadata:
+                        updates["extra_metadata"] = merged
+                if updates:
                     await db_client.update_phone_number(
                         phone_number_id=existing_row.id,
                         telephony_configuration_id=config_id,
-                        extra_metadata=merged,
+                        **updates,
                     )
+                    if updates.get("is_active"):
+                        logger.info(
+                            f"Reactivated returned phone number {normalized!r} for config {config_id}"
+                        )
             continue
 
         try:
@@ -127,24 +143,29 @@ async def sync_available_phone_numbers_for_config(
                 "already registered on another inbound route"
             )
 
-    # Issue 1: deactivate rows that are no longer present in the provider result.
-    discovered = {
-        normalize_telephony_address(item["address"]).canonical
-        for item in records
-        if item.get("address")
-    }
-    for row in existing_rows:
-        if row.is_active and row.address_normalized and row.address_normalized not in discovered:
-            await db_client.update_phone_number(
-                phone_number_id=row.id,
-                telephony_configuration_id=config_id,
-                is_active=False,
-            )
-            deactivated += 1
-            logger.info(
-                f"Deactivated stale phone number {row.address_normalized!r} for config {config_id}: "
-                "no longer present in provider result"
-            )
+    # Deactivate rows that are no longer present in the provider result, but only if
+    # the provider performed an account-wide inventory. Avoid deactivating valid numbers
+    # if discovery only returned a partial result (e.g. single directly queried number).
+    is_full_inventory = getattr(provider, "is_full_inventory", True)
+    if is_full_inventory:
+        for row in existing_rows:
+            if getattr(row, "is_active", True) and getattr(row, "address_normalized", None) and row.address_normalized not in discovered:
+                updates = {"is_active": False}
+                if getattr(row, "is_default_caller_id", False):
+                    updates["is_default_caller_id"] = False
+                row_id = getattr(row, "id", None)
+                if not row_id:
+                    continue
+                await db_client.update_phone_number(
+                    phone_number_id=row_id,
+                    telephony_configuration_id=config_id,
+                    **updates,
+                )
+                deactivated += 1
+                logger.info(
+                    f"Deactivated stale phone number {row.address_normalized!r} for config {config_id}: "
+                    "no longer present in provider result"
+                )
 
     if imported or deactivated:
         parts = []

--- a/api/services/telephony/phone_number_sync.py
+++ b/api/services/telephony/phone_number_sync.py
@@ -8,6 +8,10 @@ from api.db import db_client
 from api.db.telephony_phone_number_client import TelephonyPhoneNumberConflictError
 from api.schemas.telephony_phone_number import ProviderSyncStatus
 from api.services.telephony.factory import get_telephony_provider_by_id
+from api.services.telephony.inbound_routing import (
+    InboundRoutingConflictError,
+    assert_no_inbound_routing_conflict,
+)
 from api.utils.telephony_address import normalize_telephony_address
 
 
@@ -56,6 +60,11 @@ async def sync_available_phone_numbers_for_config(
     has_default_caller = any(row.is_default_caller_id for row in existing_rows)
     imported = 0
     skipped = 0
+    deactivated = 0
+
+    config_row = await db_client.get_telephony_configuration(config_id)
+    provider_name = config_row.provider if config_row else None
+    provider_credentials = config_row.credentials if config_row else None
 
     for item in records:
         address = item.get("address")
@@ -86,6 +95,13 @@ async def sync_available_phone_numbers_for_config(
             continue
 
         try:
+            if provider_name:
+                await assert_no_inbound_routing_conflict(
+                    provider=provider_name,
+                    credentials=provider_credentials,
+                    addresses=[normalized],
+                    organization_id=organization_id,
+                )
             await db_client.create_phone_number(
                 organization_id=organization_id,
                 telephony_configuration_id=config_id,
@@ -104,9 +120,39 @@ async def sync_available_phone_numbers_for_config(
                 f"Skipping already-existing phone number {address!r} while syncing "
                 f"config {config_id}"
             )
+        except InboundRoutingConflictError:
+            skipped += 1
+            logger.warning(
+                f"Skipping conflicting phone number {address!r} while syncing config {config_id}: "
+                "already registered on another inbound route"
+            )
 
-    if imported:
-        message = f"Imported {imported} phone number(s)."
+    # Issue 1: deactivate rows that are no longer present in the provider result.
+    discovered = {
+        normalize_telephony_address(item["address"]).canonical
+        for item in records
+        if item.get("address")
+    }
+    for row in existing_rows:
+        if row.is_active and row.address_normalized and row.address_normalized not in discovered:
+            await db_client.update_phone_number(
+                phone_number_id=row.id,
+                telephony_configuration_id=config_id,
+                is_active=False,
+            )
+            deactivated += 1
+            logger.info(
+                f"Deactivated stale phone number {row.address_normalized!r} for config {config_id}: "
+                "no longer present in provider result"
+            )
+
+    if imported or deactivated:
+        parts = []
+        if imported:
+            parts.append(f"Imported {imported} phone number(s).")
+        if deactivated:
+            parts.append(f"Deactivated {deactivated} stale phone number(s).")
+        message = " ".join(parts)
         if skipped:
             message += f" Skipped {skipped} duplicate or invalid number(s)."
         return ProviderSyncStatus(ok=True, message=message)

--- a/api/services/telephony/phone_number_sync.py
+++ b/api/services/telephony/phone_number_sync.py
@@ -1,0 +1,125 @@
+"""Phone number synchronization service for telephony providers."""
+
+from typing import Any
+
+from loguru import logger
+
+from api.db import db_client
+from api.db.telephony_phone_number_client import TelephonyPhoneNumberConflictError
+from api.schemas.telephony_phone_number import ProviderSyncStatus
+from api.services.telephony.factory import get_telephony_provider_by_id
+from api.utils.telephony_address import normalize_telephony_address
+
+
+async def sync_available_phone_numbers_for_config(
+    config_id: int, organization_id: int
+) -> ProviderSyncStatus:
+    """Import provider-owned outbound/inbound numbers into Dograh if the provider exposes them."""
+    try:
+        provider = await get_telephony_provider_by_id(config_id, organization_id)
+    except Exception as e:
+        logger.error(f"Failed to load telephony provider for config {config_id}: {e}")
+        return ProviderSyncStatus(ok=False, message=f"Provider load failed: {e}")
+
+    discover_records = getattr(provider, "get_available_phone_number_records", None)
+    records: list[dict[str, Any]] = []
+
+    if callable(discover_records):
+        try:
+            records = await discover_records()
+        except Exception as e:
+            logger.error(
+                f"Failed to discover phone number records for config {config_id}: {e}"
+            )
+            return ProviderSyncStatus(ok=False, message=f"Provider sync failed: {e}")
+    else:
+        discover_numbers = getattr(provider, "get_available_phone_numbers", None)
+        if not callable(discover_numbers):
+            return ProviderSyncStatus(
+                ok=True,
+                message="Provider does not expose discoverable outbound numbers.",
+            )
+
+        try:
+            available_numbers = await discover_numbers()
+            records = [{"address": num} for num in (available_numbers or [])]
+        except Exception as e:
+            logger.error(
+                f"Failed to discover phone numbers for config {config_id}: {e}"
+            )
+            return ProviderSyncStatus(ok=False, message=f"Provider sync failed: {e}")
+
+    existing_rows = await db_client.list_phone_numbers_for_config(config_id)
+    existing_map = {
+        row.address_normalized: row for row in existing_rows if row.address_normalized
+    }
+    has_default_caller = any(row.is_default_caller_id for row in existing_rows)
+    imported = 0
+    skipped = 0
+
+    for item in records:
+        address = item.get("address")
+        if not address:
+            continue
+        try:
+            normalized = normalize_telephony_address(address).canonical
+        except ValueError:
+            skipped += 1
+            logger.warning(
+                f"Skipping unparseable phone number discovered for config {config_id}: "
+                f"{address!r}"
+            )
+            continue
+
+        extra_metadata = item.get("extra_metadata") or {}
+
+        if normalized in existing_map:
+            existing_row = existing_map[normalized]
+            if existing_row and extra_metadata:
+                merged = {**(existing_row.extra_metadata or {}), **extra_metadata}
+                if merged != existing_row.extra_metadata:
+                    await db_client.update_phone_number(
+                        phone_number_id=existing_row.id,
+                        telephony_configuration_id=config_id,
+                        extra_metadata=merged,
+                    )
+            continue
+
+        try:
+            await db_client.create_phone_number(
+                organization_id=organization_id,
+                telephony_configuration_id=config_id,
+                address=address,
+                is_active=True,
+                is_default_caller_id=not has_default_caller and imported == 0,
+                extra_metadata=extra_metadata,
+            )
+            imported += 1
+            existing_map[normalized] = None
+            if not has_default_caller:
+                has_default_caller = True
+        except TelephonyPhoneNumberConflictError:
+            skipped += 1
+            logger.info(
+                f"Skipping already-existing phone number {address!r} while syncing "
+                f"config {config_id}"
+            )
+
+    if imported:
+        message = f"Imported {imported} phone number(s)."
+        if skipped:
+            message += f" Skipped {skipped} duplicate or invalid number(s)."
+        return ProviderSyncStatus(ok=True, message=message)
+
+    if not records:
+        return ProviderSyncStatus(
+            ok=True,
+            message="No discoverable phone numbers were returned by the provider.",
+        )
+
+    return ProviderSyncStatus(
+        ok=True,
+        message=f"No new phone numbers to import ({skipped} duplicate or invalid number(s) skipped)."
+        if skipped
+        else "No new phone numbers to import.",
+    )

--- a/api/services/telephony/providers/AGENTS.md
+++ b/api/services/telephony/providers/AGENTS.md
@@ -32,7 +32,7 @@ If you find yourself editing anything else, re-read the registry plumbing first:
 | Stored credentials → constructor dict            | `ProviderSpec.config_loader`                                                                                                                          |
 | Audio sample rate / VAD rate                     | `ProviderSpec.transport_sample_rate` (full `AudioConfig` is built in `pipecat/audio_config.py::create_audio_config`)                                  |
 | Which transport runs in `run_pipeline_telephony` | `ProviderSpec.transport_factory`                                                                                                                      |
-| Save-request validation + masked response shape  | `ProviderSpec.config_request_cls` / `config_response_cls`                                                                                             |
+| Save-request validation                          | `ProviderSpec.config_request_cls`                                                                                                                     |
 | Form rendered by the telephony-config UI         | `ProviderSpec.ui_metadata` (`ProviderUIField` list)                                                                                                   |
 | Which credential masks on read                   | `ui_metadata.fields[*].sensitive=True` (no separate list)                                                                                             |
 | Inbound webhook → config row matching            | `ProviderSpec.account_id_credential_field`                                                                                                            |
@@ -51,7 +51,6 @@ SPEC = ProviderSpec(
     transport_factory=create_transport,
     transport_sample_rate=8000,  # wire-format rate; pipecat derives the full AudioConfig
     config_request_cls=YourProviderConfigurationRequest,
-    config_response_cls=YourProviderConfigurationResponse,
     ui_metadata=ProviderUIMetadata(...),  # drives the form UI
     account_id_credential_field="api_key",  # "" if provider has no account-id concept
 )

--- a/api/services/telephony/providers/__init__.py
+++ b/api/services/telephony/providers/__init__.py
@@ -14,4 +14,5 @@ from api.services.telephony.providers import (  # noqa: F401  -- import for side
     twilio,
     vobiz,
     vonage,
+    whatsapp,
 )

--- a/api/services/telephony/providers/whatsapp/__init__.py
+++ b/api/services/telephony/providers/whatsapp/__init__.py
@@ -45,9 +45,7 @@ def _whatsapp_setup_checklist(
     state: ConfigurationSetupState,
 ) -> ProviderSetupChecklist:
     """Report that WhatsApp outbound calling is under development."""
-    return ProviderSetupChecklist(
-        ready_for_outbound=False,
-        outbound_blocked_reason="Outbound calling via WhatsApp is currently under development. Only inbound calling is supported.",
+    return ProviderSetupChecklist.from_steps(
         steps=[
             SetupStep(
                 key="outbound_unsupported",
@@ -79,7 +77,6 @@ def _config_loader(value: Dict[str, Any]) -> Dict[str, Any]:
         "phone_number_id": value.get("phone_number_id"),
         "webhook_verify_token": value.get("webhook_verify_token"),
         "app_secret": value.get("app_secret"),
-        "from_numbers": value.get("from_numbers", []),
         "business_initiated_calls_enabled": value.get("business_initiated_calls_enabled", False),
         "call_icon_visibility": value.get("call_icon_visibility", "enabled"),
     }
@@ -93,6 +90,7 @@ _UI_METADATA = ProviderUIMetadata(
             name="webhook_verify_token",
             label="Webhook Verify Token",
             type="text",
+            sensitive=True,
             section="Webhook Configuration",
             description="Paste this into Meta alongside Callback URL, click Verify and Save, and subscribe to the 'calls' field."
         ),
@@ -147,7 +145,7 @@ SPEC = ProviderSpec(
     provider_cls=WhatsAppProvider,
     config_loader=_config_loader,
     transport_factory=create_transport,
-    transport_sample_rate=48000,  # WhatsApp uses 48kHz OPUS codec
+    transport_sample_rate=16000,
     config_request_cls=WhatsAppConfigurationRequest,
     ui_metadata=_UI_METADATA,
     account_id_credential_field="phone_number_id",  # Used for webhook routing

--- a/api/services/telephony/providers/whatsapp/__init__.py
+++ b/api/services/telephony/providers/whatsapp/__init__.py
@@ -1,0 +1,170 @@
+"""WhatsApp telephony provider package.
+
+This package implements the WhatsApp Business Calling API integration
+for Dograh, following the TelephonyProvider interface pattern.
+
+The provider supports:
+- User-Initiated Calls (UIC): WhatsApp users calling the business
+- Business-Initiated Calls (BIC): Business calling WhatsApp users (with permissions)
+- WebRTC media transport with OPUS codec
+- Graph API + Webhook signaling
+- Call permission management
+
+Integration Points:
+- api.services.telephony.registry: Provider registration
+- api.services.telephony.base: TelephonyProvider interface
+- api.services.pipecat: Audio configuration and transport
+- api.routes.telephony: Webhook endpoint mounting
+
+Limitations:
+- Business-initiated calls require user permission
+- Webhook configuration must be done manually in Meta Developer Console
+- Geographic restrictions apply to business-initiated calls
+"""
+
+from typing import Any, Dict
+
+from api.services.telephony.registry import (
+    ConfigurationSetupState,
+    ProviderSetupChecklist,
+    ProviderSpec,
+    ProviderUIField,
+    ProviderUIMetadata,
+    ProviderUIOption,
+    SetupStep,
+    register,
+)
+
+from .config import WhatsAppConfigurationRequest
+from .provider import WhatsAppProvider
+from .transport import create_transport
+
+
+def _whatsapp_setup_checklist(
+    credentials: Dict[str, Any],
+    state: ConfigurationSetupState,
+) -> ProviderSetupChecklist:
+    """Report that WhatsApp outbound calling is under development."""
+    return ProviderSetupChecklist(
+        ready_for_outbound=False,
+        outbound_blocked_reason="Outbound calling via WhatsApp is currently under development. Only inbound calling is supported.",
+        steps=[
+            SetupStep(
+                key="outbound_unsupported",
+                title="Outbound calling under development",
+                description="Outbound calling via WhatsApp is currently under development. Only inbound calling is supported.",
+                complete=False,
+                blocks_outbound=True,
+            )
+        ],
+        docs_url="https://docs.dograh.com/integrations/telephony/whatsapp",
+    )
+
+
+def _config_loader(value: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize raw stored credentials into provider constructor format.
+    
+    Args:
+        value: Raw credentials dict from TelephonyConfigurationModel.credentials
+        
+    Returns:
+        Normalized dict matching WhatsAppProvider.__init__() signature
+        
+    Note:
+        This function must be pure (no I/O) as it runs on read paths.
+    """
+    return {
+        "provider": "whatsapp",
+        "access_token": value.get("access_token"),
+        "phone_number_id": value.get("phone_number_id"),
+        "webhook_verify_token": value.get("webhook_verify_token"),
+        "app_secret": value.get("app_secret"),
+        "from_numbers": value.get("from_numbers", []),
+        "business_initiated_calls_enabled": value.get("business_initiated_calls_enabled", False),
+        "call_icon_visibility": value.get("call_icon_visibility", "enabled"),
+    }
+
+
+_UI_METADATA = ProviderUIMetadata(
+    display_name="WhatsApp",
+    docs_url="https://docs.dograh.com/integrations/telephony/whatsapp",
+    fields=[
+        ProviderUIField(
+            name="webhook_verify_token",
+            label="Webhook Verify Token",
+            type="text",
+            section="Webhook Configuration",
+            description="Paste this into Meta alongside Callback URL, click Verify and Save, and subscribe to the 'calls' field."
+        ),
+        ProviderUIField(
+            name="access_token",
+            label="Access Token",
+            type="password",
+            sensitive=True,
+            section="Meta API Credentials",
+            description="WhatsApp Business API access token from Meta Developer Console"
+        ),
+        ProviderUIField(
+            name="phone_number_id",
+            label="Phone Number ID",
+            type="text",
+            section="Meta API Credentials",
+            description="Your WhatsApp Business phone number ID (found under WhatsApp > API Setup)"
+        ),
+        ProviderUIField(
+            name="app_secret",
+            label="App Secret",
+            type="password",
+            sensitive=True,
+            section="Meta API Credentials",
+            description="App secret for webhook signature validation"
+        ),
+        ProviderUIField(
+            name="business_initiated_calls_enabled",
+            label="Enable Business-Initiated Calls",
+            type="boolean",
+            section="Call Settings",
+            description="Allow your business to initiate calls to WhatsApp users"
+        ),
+        ProviderUIField(
+            name="call_icon_visibility",
+            label="Call Icon Visibility",
+            type="select",
+            options=[
+                ProviderUIOption(value="enabled", label="Enabled"),
+                ProviderUIOption(value="disabled", label="Disabled"),
+                ProviderUIOption(value="business_hours", label="Business Hours Only")
+            ],
+            section="Call Settings",
+            description="Control when the call icon appears to users"
+        )
+    ]
+)
+
+
+SPEC = ProviderSpec(
+    name="whatsapp",
+    provider_cls=WhatsAppProvider,
+    config_loader=_config_loader,
+    transport_factory=create_transport,
+    transport_sample_rate=48000,  # WhatsApp uses 48kHz OPUS codec
+    config_request_cls=WhatsAppConfigurationRequest,
+    ui_metadata=_UI_METADATA,
+    account_id_credential_field="phone_number_id",  # Used for webhook routing
+    # WhatsApp is a carrier you buy numbers from, not BYO-SIP
+    connectivity="api",
+    # Outbound calls require at least one phone number
+    requires_caller_id=True,
+    setup_checklist_resolver=_whatsapp_setup_checklist,
+)
+
+
+register(SPEC)
+
+
+__all__ = [
+    "SPEC",
+    "WhatsAppConfigurationRequest", 
+    "WhatsAppProvider",
+    "create_transport",
+]

--- a/api/services/telephony/providers/whatsapp/__init__.py
+++ b/api/services/telephony/providers/whatsapp/__init__.py
@@ -90,7 +90,6 @@ _UI_METADATA = ProviderUIMetadata(
             name="webhook_verify_token",
             label="Webhook Verify Token",
             type="text",
-            sensitive=True,
             section="Webhook Configuration",
             description="Paste this into Meta alongside Callback URL, click Verify and Save, and subscribe to the 'calls' field."
         ),

--- a/api/services/telephony/providers/whatsapp/__init__.py
+++ b/api/services/telephony/providers/whatsapp/__init__.py
@@ -35,7 +35,7 @@ from api.services.telephony.registry import (
     register,
 )
 
-from .config import WhatsAppConfigurationRequest
+from .config import WhatsAppConfigurationRequest, WhatsAppConfigurationResponse
 from .provider import WhatsAppProvider
 from .transport import create_transport
 
@@ -147,6 +147,7 @@ SPEC = ProviderSpec(
     transport_factory=create_transport,
     transport_sample_rate=16000,
     config_request_cls=WhatsAppConfigurationRequest,
+    config_response_cls=WhatsAppConfigurationResponse,
     ui_metadata=_UI_METADATA,
     account_id_credential_field="phone_number_id",  # Used for webhook routing
     # WhatsApp is a carrier you buy numbers from, not BYO-SIP
@@ -162,7 +163,8 @@ register(SPEC)
 
 __all__ = [
     "SPEC",
-    "WhatsAppConfigurationRequest", 
+    "WhatsAppConfigurationRequest",
+    "WhatsAppConfigurationResponse",
     "WhatsAppProvider",
     "create_transport",
 ]

--- a/api/services/telephony/providers/whatsapp/__init__.py
+++ b/api/services/telephony/providers/whatsapp/__init__.py
@@ -35,7 +35,7 @@ from api.services.telephony.registry import (
     register,
 )
 
-from .config import WhatsAppConfigurationRequest, WhatsAppConfigurationResponse
+from .config import WhatsAppConfigurationRequest
 from .provider import WhatsAppProvider
 from .transport import create_transport
 
@@ -147,7 +147,6 @@ SPEC = ProviderSpec(
     transport_factory=create_transport,
     transport_sample_rate=16000,
     config_request_cls=WhatsAppConfigurationRequest,
-    config_response_cls=WhatsAppConfigurationResponse,
     ui_metadata=_UI_METADATA,
     account_id_credential_field="phone_number_id",  # Used for webhook routing
     # WhatsApp is a carrier you buy numbers from, not BYO-SIP
@@ -164,7 +163,6 @@ register(SPEC)
 __all__ = [
     "SPEC",
     "WhatsAppConfigurationRequest",
-    "WhatsAppConfigurationResponse",
     "WhatsAppProvider",
     "create_transport",
 ]

--- a/api/services/telephony/providers/whatsapp/__init__.py
+++ b/api/services/telephony/providers/whatsapp/__init__.py
@@ -35,7 +35,7 @@ from api.services.telephony.registry import (
     register,
 )
 
-from .config import WhatsAppConfigurationRequest
+from .config import WhatsAppConfigurationRequest, WhatsAppConfigurationResponse
 from .provider import WhatsAppProvider
 from .transport import create_transport
 
@@ -90,6 +90,7 @@ _UI_METADATA = ProviderUIMetadata(
             name="webhook_verify_token",
             label="Webhook Verify Token",
             type="text",
+            sensitive=True,
             section="Webhook Configuration",
             description="Paste this into Meta alongside Callback URL, click Verify and Save, and subscribe to the 'calls' field."
         ),
@@ -146,6 +147,7 @@ SPEC = ProviderSpec(
     transport_factory=create_transport,
     transport_sample_rate=16000,
     config_request_cls=WhatsAppConfigurationRequest,
+    config_response_cls=WhatsAppConfigurationResponse,
     ui_metadata=_UI_METADATA,
     account_id_credential_field="phone_number_id",  # Used for webhook routing
     # WhatsApp is a carrier you buy numbers from, not BYO-SIP
@@ -162,6 +164,7 @@ register(SPEC)
 __all__ = [
     "SPEC",
     "WhatsAppConfigurationRequest",
+    "WhatsAppConfigurationResponse",
     "WhatsAppProvider",
     "create_transport",
 ]

--- a/api/services/telephony/providers/whatsapp/config.py
+++ b/api/services/telephony/providers/whatsapp/config.py
@@ -38,3 +38,17 @@ class WhatsAppConfigurationRequest(BaseModel):
         default="enabled",
         description="Control when call icon appears to users"
     )
+
+
+class WhatsAppConfigurationResponse(BaseModel):
+    """Response schema for WhatsApp configuration.
+
+    This schema defines the masked response returned to the UI,
+    ensuring sensitive credentials are never exposed.
+    """
+
+    provider: Literal["whatsapp"] = Field(default="whatsapp")
+    phone_number_id: str
+    webhook_verify_token: str
+    business_initiated_calls_enabled: bool = False
+    call_icon_visibility: Literal["enabled", "disabled", "business_hours"] = "enabled"

--- a/api/services/telephony/providers/whatsapp/config.py
+++ b/api/services/telephony/providers/whatsapp/config.py
@@ -38,17 +38,3 @@ class WhatsAppConfigurationRequest(BaseModel):
         default="enabled",
         description="Control when call icon appears to users"
     )
-
-
-class WhatsAppConfigurationResponse(BaseModel):
-    """Response schema for WhatsApp configuration.
-
-    This schema defines the masked response returned to the UI,
-    ensuring sensitive credentials are never exposed.
-    """
-
-    provider: Literal["whatsapp"] = Field(default="whatsapp")
-    phone_number_id: str
-    webhook_verify_token: str
-    business_initiated_calls_enabled: bool = False
-    call_icon_visibility: Literal["enabled", "disabled", "business_hours"] = "enabled"

--- a/api/services/telephony/providers/whatsapp/config.py
+++ b/api/services/telephony/providers/whatsapp/config.py
@@ -1,0 +1,55 @@
+"""WhatsApp telephony configuration schemas.
+
+This module defines Pydantic models for WhatsApp Business API configuration,
+following Dograh's telephony provider configuration pattern.
+"""
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class WhatsAppConfigurationRequest(BaseModel):
+    """Request schema for WhatsApp configuration.
+    
+    This schema validates incoming configuration save requests and
+    integrates with Dograh's metadata-driven UI forms.
+    
+    Attributes:
+        provider: Literal discriminator for union typing
+        access_token: WhatsApp Business API access token
+        phone_number_id: Business phone number ID from Meta
+        webhook_verify_token: Token for webhook verification
+        app_secret: App secret for webhook signature validation
+        business_initiated_calls_enabled: Enable outbound calling
+        call_icon_visibility: Control call icon display in WhatsApp
+    """
+    
+    provider: Literal["whatsapp"] = Field(default="whatsapp")
+    access_token: str = Field(..., description="WhatsApp Business API access token")
+    phone_number_id: str = Field(..., description="Business phone number ID")
+    webhook_verify_token: str = Field(..., description="Webhook verification token")
+    app_secret: str = Field(..., description="App secret for webhook signature validation")
+    business_initiated_calls_enabled: bool = Field(
+        default=False,
+        description="Enable business-initiated calls to WhatsApp users"
+    )
+    call_icon_visibility: str = Field(
+        default="enabled",
+        description="Control when call icon appears to users"
+    )
+
+
+class WhatsAppConfigurationResponse(BaseModel):
+    """Response schema for WhatsApp configuration.
+    
+    This schema defines the masked response returned to the UI,
+    ensuring sensitive credentials are never exposed.
+    """
+    
+    provider: Literal["whatsapp"]
+    phone_number_id: str
+    webhook_verify_token: str
+    business_initiated_calls_enabled: bool
+    call_icon_visibility: str
+    # Sensitive fields (access_token, app_secret) are excluded

--- a/api/services/telephony/providers/whatsapp/config.py
+++ b/api/services/telephony/providers/whatsapp/config.py
@@ -26,10 +26,16 @@ class WhatsAppConfigurationRequest(BaseModel):
     """
     
     provider: Literal["whatsapp"] = Field(default="whatsapp")
-    access_token: str = Field(..., min_length=1, description="WhatsApp Business API access token")
+    access_token: Optional[str] = Field(
+        default=None, description="WhatsApp Business API access token"
+    )
     phone_number_id: str = Field(..., min_length=1, description="Business phone number ID")
-    webhook_verify_token: str = Field(..., min_length=1, description="Webhook verification token")
-    app_secret: str = Field(..., min_length=1, description="App secret for webhook signature validation")
+    webhook_verify_token: Optional[str] = Field(
+        default=None, description="Webhook verification token"
+    )
+    app_secret: Optional[str] = Field(
+        default=None, description="App secret for webhook signature validation"
+    )
     business_initiated_calls_enabled: bool = Field(
         default=False,
         description="Enable business-initiated calls to WhatsApp users"
@@ -44,12 +50,14 @@ class WhatsAppConfigurationResponse(BaseModel):
     """Response schema for WhatsApp configuration.
 
     This schema defines the masked response returned to the UI,
-    ensuring sensitive credentials are never exposed.
+    ensuring sensitive credentials are never exposed unmasked.
     """
 
     provider: Literal["whatsapp"] = Field(default="whatsapp")
     phone_number_id: str
-    webhook_verify_token: str
+    access_token: Optional[str] = None
+    app_secret: Optional[str] = None
+    webhook_verify_token: Optional[str] = None
     business_initiated_calls_enabled: bool = False
     call_icon_visibility: Literal["enabled", "disabled", "business_hours"] = "enabled"
 

--- a/api/services/telephony/providers/whatsapp/config.py
+++ b/api/services/telephony/providers/whatsapp/config.py
@@ -26,30 +26,15 @@ class WhatsAppConfigurationRequest(BaseModel):
     """
     
     provider: Literal["whatsapp"] = Field(default="whatsapp")
-    access_token: str = Field(..., description="WhatsApp Business API access token")
-    phone_number_id: str = Field(..., description="Business phone number ID")
-    webhook_verify_token: str = Field(..., description="Webhook verification token")
-    app_secret: str = Field(..., description="App secret for webhook signature validation")
+    access_token: str = Field(..., min_length=1, description="WhatsApp Business API access token")
+    phone_number_id: str = Field(..., min_length=1, description="Business phone number ID")
+    webhook_verify_token: str = Field(..., min_length=1, description="Webhook verification token")
+    app_secret: str = Field(..., min_length=1, description="App secret for webhook signature validation")
     business_initiated_calls_enabled: bool = Field(
         default=False,
         description="Enable business-initiated calls to WhatsApp users"
     )
-    call_icon_visibility: str = Field(
+    call_icon_visibility: Literal["enabled", "disabled", "business_hours"] = Field(
         default="enabled",
         description="Control when call icon appears to users"
     )
-
-
-class WhatsAppConfigurationResponse(BaseModel):
-    """Response schema for WhatsApp configuration.
-    
-    This schema defines the masked response returned to the UI,
-    ensuring sensitive credentials are never exposed.
-    """
-    
-    provider: Literal["whatsapp"]
-    phone_number_id: str
-    webhook_verify_token: str
-    business_initiated_calls_enabled: bool
-    call_icon_visibility: str
-    # Sensitive fields (access_token, app_secret) are excluded

--- a/api/services/telephony/providers/whatsapp/config.py
+++ b/api/services/telephony/providers/whatsapp/config.py
@@ -26,16 +26,10 @@ class WhatsAppConfigurationRequest(BaseModel):
     """
     
     provider: Literal["whatsapp"] = Field(default="whatsapp")
-    access_token: Optional[str] = Field(
-        default=None, description="WhatsApp Business API access token"
-    )
+    access_token: str = Field(..., min_length=1, description="WhatsApp Business API access token")
     phone_number_id: str = Field(..., min_length=1, description="Business phone number ID")
-    webhook_verify_token: Optional[str] = Field(
-        default=None, description="Webhook verification token"
-    )
-    app_secret: Optional[str] = Field(
-        default=None, description="App secret for webhook signature validation"
-    )
+    webhook_verify_token: str = Field(..., min_length=1, description="Webhook verification token")
+    app_secret: str = Field(..., min_length=1, description="App secret for webhook signature validation")
     business_initiated_calls_enabled: bool = Field(
         default=False,
         description="Enable business-initiated calls to WhatsApp users"

--- a/api/services/telephony/providers/whatsapp/config.py
+++ b/api/services/telephony/providers/whatsapp/config.py
@@ -38,3 +38,18 @@ class WhatsAppConfigurationRequest(BaseModel):
         default="enabled",
         description="Control when call icon appears to users"
     )
+
+
+class WhatsAppConfigurationResponse(BaseModel):
+    """Response schema for WhatsApp configuration.
+
+    This schema defines the masked response returned to the UI,
+    ensuring sensitive credentials are never exposed.
+    """
+
+    provider: Literal["whatsapp"] = Field(default="whatsapp")
+    phone_number_id: str
+    webhook_verify_token: str
+    business_initiated_calls_enabled: bool = False
+    call_icon_visibility: Literal["enabled", "disabled", "business_hours"] = "enabled"
+

--- a/api/services/telephony/providers/whatsapp/provider.py
+++ b/api/services/telephony/providers/whatsapp/provider.py
@@ -630,17 +630,24 @@ class WhatsAppProvider(TelephonyProvider):
 
         # 1. Query the configured phone_number_id directly for display_phone_number
         phone_number_endpoint = f"{self.GRAPH_API_BASE_URL}/{self.phone_number_id}"
+        waba_id: Optional[str] = None
+        self.is_full_inventory = False
         async with aiohttp.ClientSession() as session:
             try:
                 async with session.get(
                     phone_number_endpoint,
                     headers=headers,
-                    params={"fields": "display_phone_number,verified_name,id"},
+                    params={
+                        "fields": "display_phone_number,verified_name,id,whatsapp_business_account"
+                    },
                 ) as response:
                     if response.status == 200:
                         payload = await response.json()
                         direct_number = payload.get("display_phone_number")
                         direct_id = payload.get("id") or self.phone_number_id
+                        waba_info = payload.get("whatsapp_business_account")
+                        if isinstance(waba_info, dict) and waba_info.get("id"):
+                            waba_id = str(waba_info["id"])
                         if direct_number:
                             try:
                                 canonical = normalize_telephony_address(
@@ -669,13 +676,18 @@ class WhatsAppProvider(TelephonyProvider):
             except Exception as e:
                 logger.warning(f"Error querying direct phone number endpoint: {e}")
 
-            # 2. If direct lookup did not resolve a number, try the /phone_numbers edge
-            # (useful when the configured ID is a WhatsApp Business Account / WABA ID)
-            if not records:
-                waba_endpoint = f"{self.GRAPH_API_BASE_URL}/{self.phone_number_id}/phone_numbers"
+            # 2. Query the /phone_numbers edge on the WABA:
+            # - If step 1 gave us waba_id, query {waba_id}/phone_numbers to discover
+            #   all other numbers belonging to this WhatsApp Business Account.
+            # - If direct lookup did not resolve a number (e.g. self.phone_number_id is
+            #   itself a WABA ID), query {self.phone_number_id}/phone_numbers.
+            target_waba = waba_id or (self.phone_number_id if not records else None)
+            if target_waba:
+                waba_endpoint = f"{self.GRAPH_API_BASE_URL}/{target_waba}/phone_numbers"
                 try:
                     async with session.get(waba_endpoint, headers=headers) as response:
                         if response.status == 200:
+                            self.is_full_inventory = True
                             payload = await response.json()
                             for record in payload.get("data") or []:
                                 display_phone_number = record.get("display_phone_number")
@@ -691,8 +703,8 @@ class WhatsAppProvider(TelephonyProvider):
                                         records.append({
                                             "address": canonical,
                                             "extra_metadata": {
-                                                "meta_phone_number_id": str(phone_id or self.phone_number_id),
-                                                "phone_number_id": str(phone_id or self.phone_number_id),
+                                                "meta_phone_number_id": str(phone_id or target_waba),
+                                                "phone_number_id": str(phone_id or target_waba),
                                             },
                                         })
                                 except ValueError:
@@ -703,7 +715,7 @@ class WhatsAppProvider(TelephonyProvider):
                         else:
                             error_text = await response.text()
                             logger.warning(
-                                f"Query on /phone_numbers edge for ID {self.phone_number_id} "
+                                f"Query on /phone_numbers edge for ID {target_waba} "
                                 f"returned {response.status}: {error_text}"
                             )
                 except Exception as e:

--- a/api/services/telephony/providers/whatsapp/provider.py
+++ b/api/services/telephony/providers/whatsapp/provider.py
@@ -1,0 +1,773 @@
+"""
+WhatsApp implementation of the TelephonyProvider interface.
+
+This module implements the core WhatsApp Business Calling API integration,
+handling both user-initiated and business-initiated calls with proper
+permission management and WebRTC media transport.
+
+Key Features:
+- User-Initiated Calls (UIC): Handle incoming WhatsApp voice calls
+- Business-Initiated Calls (BIC): Initiate calls with permission management
+- WebRTC Media: OPUS codec at 48kHz with DTLS/SRTP encryption
+- Graph API Integration: REST API for call control and status queries
+- Webhook Handling: Signature-validated webhook processing
+- Permission Management: Temporary and permanent call permissions
+"""
+
+import hashlib
+import hmac
+import json
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import aiohttp
+from fastapi import HTTPException
+from loguru import logger
+
+from api.enums import TelephonyCallStatus, WorkflowRunMode
+from api.services.telephony import ws_auth
+from api.services.telephony.base import (
+    AnsweringMachineDetectionResult,
+    CallInitiationResult,
+    NormalizedInboundData,
+    ProviderPhoneNumberLookupError,
+    ProviderSyncResult,
+    TelephonyProvider,
+)
+from api.utils.common import get_backend_endpoints
+from api.utils.telephony_address import normalize_telephony_address
+
+if TYPE_CHECKING:
+    from fastapi import WebSocket
+
+
+class WhatsAppProvider(TelephonyProvider):
+    """
+    WhatsApp implementation of TelephonyProvider.
+    
+    Supports both User-Initiated Calls (UIC) and Business-Initiated Calls (BIC)
+    through the WhatsApp Business Calling API with WebRTC media transport.
+    
+    Attributes:
+        PROVIDER_NAME: Provider identifier for registry
+        WEBHOOK_ENDPOINT: Webhook endpoint path
+        access_token: WhatsApp Business API access token
+        phone_number_id: Business phone number ID
+        webhook_verify_token: Token for webhook verification
+        app_secret: App secret for signature validation
+        from_numbers: List of available phone numbers
+        business_initiated_calls_enabled: Whether BIC is enabled
+    """
+
+    PROVIDER_NAME = WorkflowRunMode.WHATSAPP.value
+    WEBHOOK_ENDPOINT = "whatsapp"
+
+    # WhatsApp Graph API base URL
+    GRAPH_API_BASE_URL = "https://graph.facebook.com/v21.0"
+
+    def __init__(self, config: Dict[str, Any]):
+        """
+        Initialize WhatsAppProvider with configuration.
+
+        Args:
+            config: Dictionary containing:
+                - access_token: WhatsApp Business API access token
+                - phone_number_id: Business phone number ID
+                - webhook_verify_token: Webhook verification token
+                - app_secret: App secret for webhook signature validation
+                - from_numbers: List of phone numbers to use
+                - business_initiated_calls_enabled: Enable outbound calls
+                - call_icon_visibility: Call icon display setting
+
+        Raises:
+            ValueError: If required configuration fields are missing
+        """
+        self.access_token = config.get("access_token")
+        self.phone_number_id = config.get("phone_number_id")
+        self.webhook_verify_token = config.get("webhook_verify_token")
+        self.app_secret = config.get("app_secret")
+        self.from_numbers = config.get("from_numbers", [])
+        self.business_initiated_calls_enabled = config.get(
+            "business_initiated_calls_enabled", False
+        )
+        self.call_icon_visibility = config.get("call_icon_visibility", "enabled")
+
+        # Validate required fields
+        if not self.access_token:
+            raise ValueError("access_token is required for WhatsApp provider")
+        if not self.phone_number_id:
+            raise ValueError("phone_number_id is required for WhatsApp provider")
+        if not self.webhook_verify_token:
+            raise ValueError("webhook_verify_token is required for WhatsApp provider")
+        if not self.app_secret:
+            raise ValueError("app_secret is required for WhatsApp provider")
+
+        # Handle both single number (string) and multiple numbers (list)
+        if isinstance(self.from_numbers, str):
+            self.from_numbers = [self.from_numbers]
+
+        logger.info(
+            f"WhatsAppProvider initialized for phone_number_id={self.phone_number_id}, "
+            f"business_initiated_calls_enabled={self.business_initiated_calls_enabled}"
+        )
+
+    async def initiate_call(
+        self,
+        to_number: str,
+        webhook_url: str,
+        workflow_run_id: Optional[int] = None,
+        from_number: Optional[str] = None,
+        **kwargs: Any,
+    ) -> CallInitiationResult:
+        """
+        Initiate an outbound call via WhatsApp Business API.
+
+        For Business-Initiated Calls (BIC), this method requests user permission
+        before proceeding. The call will only connect after the user grants
+        permission through the WhatsApp interface.
+
+        Args:
+            to_number: The destination WhatsApp phone number (E.164 format)
+            webhook_url: The URL to receive call events from Meta
+            workflow_run_id: Optional workflow run ID for tracking
+            from_number: Optional caller ID (not used in WhatsApp, but kept for interface compatibility)
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            CallInitiationResult with call details and status
+
+        Raises:
+            ValueError: If business-initiated calls are not enabled
+            HTTPException: If Graph API call fails
+
+        Note:
+            WhatsApp requires user permission for business-initiated calls.
+            The call status will be "permission_requested" until the user
+            grants permission through the WhatsApp interface.
+        """
+        raise HTTPException(
+            status_code=400,
+            detail="Outbound calling via WhatsApp is currently under development. Only inbound calling is supported.",
+        )
+
+    async def get_call_status(self, call_id: str) -> Dict[str, Any]:
+        """
+        Get the current status of a WhatsApp call.
+
+        Args:
+            call_id: The WhatsApp call ID from Graph API
+
+        Returns:
+            Dict containing call status information:
+                - status: Mapped to TelephonyCallStatus enum
+                - direction: Call direction (inbound/outbound)
+                - duration: Call duration in seconds
+                - from_number: Caller phone number
+                - to_number: Called phone number
+
+        Raises:
+            HTTPException: If Graph API call fails
+
+        Note:
+            WhatsApp call statuses are mapped to Dograh's TelephonyCallStatus:
+            - queued/ringing -> INITIATED/RINGING
+            - in-progress -> IN_PROGRESS
+            - completed -> COMPLETED
+            - failed/busy/no-answer -> FAILED/BUSY/NO_ANSWER
+        """
+        logger.info(f"Querying WhatsApp call status for call_id={call_id}")
+
+        endpoint = f"{self.GRAPH_API_BASE_URL}/{self.phone_number_id}/calls/{call_id}"
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json"
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(endpoint, headers=headers) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    logger.error(f"Graph API error: {error_text}")
+                    raise HTTPException(
+                        status_code=response.status,
+                        detail=f"Failed to get call status: {error_text}"
+                    )
+
+                data = await response.json()
+
+        # Map WhatsApp status to Dograh TelephonyCallStatus
+        whatsapp_status = data.get("status", "unknown")
+        dograh_status = self._map_whatsapp_status_to_dograh(whatsapp_status)
+
+        return {
+            "status": dograh_status.value,
+            "direction": data.get("direction", "unknown"),
+            "duration": data.get("duration_seconds", 0),
+            "from_number": data.get("from", ""),
+            "to_number": data.get("to", ""),
+            "raw_status": whatsapp_status,
+        }
+
+    async def get_call_cost(self, call_id: str) -> Dict[str, Any]:
+        """WhatsApp does not expose call-cost data in this integration yet."""
+        return {
+            "cost_usd": 0.0,
+            "duration": 0,
+            "status": "unknown",
+            "raw_response": {"call_id": call_id, "provider": self.PROVIDER_NAME},
+            "error": "WhatsApp call-cost lookup is not implemented",
+        }
+
+    async def configure_inbound(
+        self, address: str, webhook_url: Optional[str] = None
+    ) -> ProviderSyncResult:
+        """Configure inbound call handling for WhatsApp.
+
+        WhatsApp requires manual webhook configuration in Meta Developer Console.
+        """
+        return ProviderSyncResult(
+            ok=True,
+            message="WhatsApp webhook configuration must be completed in Meta Developer Console.",
+        )
+
+    async def verify_inbound_signature(
+        self,
+        url: str,
+        webhook_data: Dict[str, Any],
+        headers: Dict[str, str],
+        body: str = "",
+    ) -> bool:
+        """Verify inbound webhook signature from Meta.
+
+        Meta uses HMAC-SHA256 with the app_secret to sign webhook payloads.
+        The signature is provided in the X-Hub-Signature-256 header.
+
+        Args:
+            url: The webhook URL (not used in signature calculation)
+            webhook_data: Parsed webhook payload
+            headers: Request headers containing X-Hub-Signature-256
+            body: Raw request body for signature verification
+
+        Returns:
+            True if signature is valid, False otherwise
+        """
+        if not self.app_secret:
+            logger.warning("Missing app_secret for WhatsApp signature verification")
+            return False
+
+        signature_header = None
+        for k, v in headers.items():
+            if k.lower() == "x-hub-signature-256":
+                signature_header = v
+                break
+
+        if not signature_header:
+            logger.warning("Missing X-Hub-Signature-256 header")
+            return False
+
+        if not signature_header.startswith("sha256="):
+            logger.warning(f"Invalid signature format: {signature_header}")
+            return False
+
+        expected_signature = signature_header[7:]
+
+        calculated_signature = hmac.new(
+            self.app_secret.encode("utf-8"),
+            body.encode("utf-8") if isinstance(body, str) else body,
+            hashlib.sha256,
+        ).hexdigest()
+
+        is_valid = hmac.compare_digest(calculated_signature, expected_signature)
+        if not is_valid:
+            logger.warning(
+                f"WhatsApp signature verification failed. "
+                f"Expected: {expected_signature}, Got: {calculated_signature}"
+            )
+        return is_valid
+
+    def normalize_inbound_data(self, raw_webhook_data: Dict[str, Any]) -> NormalizedInboundData:
+        """
+        Normalize WhatsApp webhook payload to standard format.
+
+        Extracts call information from Meta's webhook structure and converts
+        it to Dograh's NormalizedInboundData format for consistent processing.
+
+        Args:
+            raw_webhook_data: Raw webhook payload from Meta
+
+        Returns:
+            NormalizedInboundData with standardized call information
+
+        Raises:
+            ValueError: If webhook data structure is invalid
+
+        Note:
+            WhatsApp webhook structure:
+            {
+                "entry": [{
+                    "changes": [{
+                        "field": "calls",
+                        "value": {
+                            "display_phone_number": "+15551234567",
+                            "call": {
+                                "id": "call_id",
+                                "direction": "inbound",
+                                "from": "+15559876543",
+                                "to": "+15551234567",
+                                "status": "ringing"
+                            }
+                        }
+                    }]
+                }]
+            }
+        """
+        if (
+            not isinstance(raw_webhook_data, dict)
+            or "entry" not in raw_webhook_data
+            or not isinstance(raw_webhook_data.get("entry"), list)
+            or not raw_webhook_data["entry"]
+        ):
+            raise ValueError("Invalid webhook data structure")
+
+        try:
+            entry = raw_webhook_data.get("entry", [{}])[0]
+            changes = entry.get("changes", [{}])[0]
+            call_value = changes.get("value", {})
+            call_data = call_value.get("call", {})
+
+            call_id = call_data.get("id")
+            from_number = call_data.get("from")
+            to_number = call_data.get("to")
+            direction = call_data.get("direction")
+            status = call_data.get("status")
+
+            if not call_id:
+                raise ValueError("Missing call_id in webhook data")
+
+            return NormalizedInboundData(
+                provider=self.PROVIDER_NAME,
+                call_id=call_id,
+                from_number=(
+                    normalize_telephony_address(from_number).canonical
+                    if from_number
+                    else ""
+                ),
+                to_number=(
+                    normalize_telephony_address(to_number).canonical
+                    if to_number
+                    else ""
+                ),
+                direction=direction or "unknown",
+                call_status=status or "unknown",
+                account_id=self.phone_number_id,
+                raw_data=raw_webhook_data,
+            )
+        except (IndexError, KeyError, AttributeError) as e:
+            logger.error(f"Failed to normalize WhatsApp webhook data: {e}")
+            raise ValueError(f"Invalid webhook data structure: {e}")
+
+    @classmethod
+    def can_handle_webhook(
+        cls, webhook_data: Dict[str, Any], headers: Dict[str, str]
+    ) -> bool:
+        """Detect WhatsApp webhook payloads."""
+        if webhook_data.get("object") == "whatsapp_business_account":
+            return True
+
+        entry = webhook_data.get("entry") or []
+        return bool(entry and isinstance(entry, list))
+
+    @staticmethod
+    def parse_inbound_webhook(webhook_data: Dict[str, Any]) -> NormalizedInboundData:
+        """Parse WhatsApp webhook payload into the shared inbound shape."""
+        entry = webhook_data.get("entry", [{}])[0]
+        changes = entry.get("changes", [{}])[0]
+        value = changes.get("value", {})
+        call = value.get("call", {})
+        metadata = value.get("metadata", {})
+
+        call_id = call.get("id") or value.get("call_id") or ""
+        from_number = call.get("from") or ""
+        to_number = call.get("to") or metadata.get("display_phone_number") or ""
+        status = call.get("status") or value.get("status") or "unknown"
+        direction = call.get("direction") or value.get("direction") or "inbound"
+        account_id = metadata.get("phone_number_id") or metadata.get(
+            "display_phone_number"
+        )
+
+        return NormalizedInboundData(
+            provider=WhatsAppProvider.PROVIDER_NAME,
+            call_id=call_id,
+            from_number=(
+                normalize_telephony_address(from_number).canonical
+                if from_number
+                else ""
+            ),
+            to_number=(
+                normalize_telephony_address(to_number).canonical
+                if to_number
+                else ""
+            ),
+            direction=direction,
+            call_status=status,
+            account_id=account_id,
+            raw_data=webhook_data,
+        )
+
+    @staticmethod
+    def validate_account_id(config_data: dict, webhook_account_id: str) -> bool:
+        """Match inbound WhatsApp webhooks by phone_number_id."""
+        if not webhook_account_id:
+            return False
+        return config_data.get("phone_number_id") == webhook_account_id
+
+    def validate_config(self) -> bool:
+        """Return whether the WhatsApp credentials needed for WebRTC are present."""
+        return bool(
+            self.access_token
+            and self.phone_number_id
+            and self.webhook_verify_token
+            and self.app_secret
+        )
+
+    async def verify_webhook_signature(
+        self, url: str, params: Dict[str, Any], signature: str
+    ) -> bool:
+        """Verify a Meta webhook signature when the raw body is available."""
+        raw_body = ""
+        if isinstance(params, dict):
+            raw_body = (
+                params.get("_raw_body")
+                or params.get("raw_body")
+                or params.get("body")
+                or ""
+            )
+        if not raw_body or not signature or not self.app_secret:
+            return False
+
+        if signature.startswith("sha256="):
+            signature = signature[7:]
+
+        calculated_signature = hmac.new(
+            self.app_secret.encode("utf-8"),
+            str(raw_body).encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        return hmac.compare_digest(calculated_signature, signature)
+
+    def parse_status_callback(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize a WhatsApp webhook payload into shared callback fields."""
+        entry = data.get("entry", [{}])[0]
+        changes = entry.get("changes", [{}])[0]
+        value = changes.get("value", {})
+        call = value.get("call", {})
+        status = call.get("status") or value.get("status") or "unknown"
+
+        return {
+            "call_id": call.get("id") or value.get("call_id") or "",
+            "status": self._map_whatsapp_status_to_dograh(status),
+            "from_number": call.get("from") or "",
+            "to_number": call.get("to") or "",
+            "direction": call.get("direction") or value.get("direction"),
+            "duration": call.get("duration") or value.get("duration_seconds"),
+            "extra": data,
+        }
+
+    async def get_webhook_response(
+        self, workflow_id: int, organization_id: int, workflow_run_id: int
+    ) -> str:
+        """WhatsApp call-control is not XML-based; return an empty body."""
+        logger.warning(
+            "get_webhook_response called for WhatsApp - returning empty response. "
+            "WhatsApp inbound handling is implemented in the dedicated webhook routes."
+        )
+        return ""
+
+    async def handle_websocket(
+        self,
+        websocket: "WebSocket",
+        workflow_id: int,
+        organization_id: int,
+        workflow_run_id: int,
+    ) -> None:
+        """Run the shared telephony pipeline for a WhatsApp media websocket."""
+        from api.db import db_client
+        from api.services.pipecat.run_pipeline import run_pipeline_telephony
+
+        workflow_run = await db_client.get_workflow_run(
+            workflow_run_id, organization_id=organization_id
+        )
+        call_id = self.phone_number_id
+        if workflow_run and workflow_run.gathered_context:
+            call_id = (
+                workflow_run.gathered_context.get("call_id")
+                or workflow_run.gathered_context.get("call_uuid")
+                or call_id
+            )
+
+        logger.info(
+            f"[WhatsApp] Starting pipeline for workflow_run {workflow_run_id}, "
+            f"call_id={call_id}"
+        )
+        await run_pipeline_telephony(
+            websocket,
+            provider_name=self.PROVIDER_NAME,
+            workflow_id=workflow_id,
+            workflow_run_id=workflow_run_id,
+            organization_id=organization_id,
+            call_id=call_id,
+            transport_kwargs={"call_id": call_id},
+        )
+
+    async def start_inbound_stream(
+        self,
+        *,
+        websocket_url: str,
+        workflow_run_id: int,
+        normalized_data,
+        backend_endpoint: str,
+    ):
+        """Return a minimal response because WhatsApp handles media via websocket."""
+        from fastapi import Response
+
+        logger.info(
+            f"WhatsApp start_inbound_stream called for call_id={normalized_data.call_id}"
+        )
+        return Response(content="", status_code=204)
+
+    @staticmethod
+    def generate_error_response(error_type: str, message: str) -> tuple:
+        """Generate a simple JSON error response."""
+        from fastapi import Response
+
+        return Response(
+            content=json.dumps({"error": error_type, "message": message}),
+            media_type="application/json",
+        )
+
+    async def validate_phone_number(self, address: str) -> ProviderSyncResult:
+        """Check that Meta exposes this WhatsApp phone number on the connected WABA."""
+        try:
+            available_numbers = await self.get_available_phone_numbers()
+        except HTTPException as exc:
+            return ProviderSyncResult(ok=False, message=str(exc.detail))
+
+        normalized = normalize_telephony_address(address).canonical
+        if normalized in available_numbers:
+            return ProviderSyncResult(ok=True)
+
+        return ProviderSyncResult(
+            ok=False,
+            message=(
+                f"Phone number {normalized} is not owned by this WhatsApp "
+                "Business Account."
+            ),
+        )
+
+    async def transfer_call(
+        self,
+        destination: str,
+        transfer_id: str,
+        conference_name: str,
+        timeout: int = 30,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """WhatsApp Calling does not currently support transfers in Dograh."""
+        return {
+            "call_sid": transfer_id,
+            "status": "failed",
+            "provider": self.PROVIDER_NAME,
+            "message": "WhatsApp call transfer is not implemented",
+        }
+
+    def supports_transfers(self) -> bool:
+        """WhatsApp transfer support is not implemented yet."""
+        return False
+
+    async def get_available_phone_number_records(self) -> List[Dict[str, Any]]:
+        """Return WhatsApp Business number records with their Meta phone_number_id."""
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json",
+        }
+
+        records: List[Dict[str, Any]] = []
+        seen_addresses: set[str] = set()
+
+        # 1. Query the configured phone_number_id directly for display_phone_number
+        phone_number_endpoint = f"{self.GRAPH_API_BASE_URL}/{self.phone_number_id}"
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.get(
+                    phone_number_endpoint,
+                    headers=headers,
+                    params={"fields": "display_phone_number,verified_name,id"},
+                ) as response:
+                    if response.status == 200:
+                        payload = await response.json()
+                        direct_number = payload.get("display_phone_number")
+                        direct_id = payload.get("id") or self.phone_number_id
+                        if direct_number:
+                            try:
+                                canonical = normalize_telephony_address(
+                                    direct_number
+                                ).canonical
+                                if canonical not in seen_addresses:
+                                    seen_addresses.add(canonical)
+                                    records.append({
+                                        "address": canonical,
+                                        "extra_metadata": {
+                                            "meta_phone_number_id": str(direct_id),
+                                            "phone_number_id": str(direct_id),
+                                        },
+                                    })
+                            except ValueError:
+                                logger.warning(
+                                    "Skipping unparseable direct WhatsApp phone number "
+                                    f"{direct_number!r}"
+                                )
+                    else:
+                        error_text = await response.text()
+                        logger.warning(
+                            f"Direct query on phone_number_id={self.phone_number_id} "
+                            f"returned {response.status}: {error_text}"
+                        )
+            except Exception as e:
+                logger.warning(f"Error querying direct phone number endpoint: {e}")
+
+            # 2. If direct lookup did not resolve a number, try the /phone_numbers edge
+            # (useful when the configured ID is a WhatsApp Business Account / WABA ID)
+            if not records:
+                waba_endpoint = f"{self.GRAPH_API_BASE_URL}/{self.phone_number_id}/phone_numbers"
+                try:
+                    async with session.get(waba_endpoint, headers=headers) as response:
+                        if response.status == 200:
+                            payload = await response.json()
+                            for record in payload.get("data") or []:
+                                display_phone_number = record.get("display_phone_number")
+                                phone_id = record.get("id")
+                                if not display_phone_number:
+                                    continue
+                                try:
+                                    canonical = normalize_telephony_address(
+                                        display_phone_number
+                                    ).canonical
+                                    if canonical not in seen_addresses:
+                                        seen_addresses.add(canonical)
+                                        records.append({
+                                            "address": canonical,
+                                            "extra_metadata": {
+                                                "meta_phone_number_id": str(phone_id or self.phone_number_id),
+                                                "phone_number_id": str(phone_id or self.phone_number_id),
+                                            },
+                                        })
+                                except ValueError:
+                                    logger.warning(
+                                        "Skipping unparseable WhatsApp phone number "
+                                        f"{display_phone_number!r}"
+                                    )
+                        else:
+                            error_text = await response.text()
+                            logger.warning(
+                                f"Query on /phone_numbers edge for ID {self.phone_number_id} "
+                                f"returned {response.status}: {error_text}"
+                            )
+                except Exception as e:
+                    logger.warning(f"Error querying /phone_numbers edge: {e}")
+
+        # 3. Fallback to statically configured from_numbers if any
+        if not records and self.from_numbers:
+            for num in self.from_numbers:
+                try:
+                    canonical = normalize_telephony_address(num).canonical
+                    if canonical not in seen_addresses:
+                        seen_addresses.add(canonical)
+                        records.append({
+                            "address": canonical,
+                            "extra_metadata": {
+                                "meta_phone_number_id": str(self.phone_number_id),
+                                "phone_number_id": str(self.phone_number_id),
+                            },
+                        })
+                except ValueError:
+                    pass
+
+        if not records:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Failed to resolve WhatsApp phone number for ID {self.phone_number_id}. "
+                    "Please check your Phone Number ID and Access Token permissions."
+                ),
+            )
+
+        return records
+
+    async def get_available_phone_numbers(self) -> List[str]:
+        """Return the WhatsApp Business numbers exposed by Meta for this configuration."""
+        records = await self.get_available_phone_number_records()
+        return [r["address"] for r in records]
+
+    def _map_whatsapp_status_to_dograh(self, whatsapp_status: str) -> TelephonyCallStatus:
+        """Map WhatsApp call status to Dograh TelephonyCallStatus enum.
+        
+        Args:
+            whatsapp_status: Status string from WhatsApp Graph API
+            
+        Returns:
+            Corresponding TelephonyCallStatus enum value
+        """
+        status_mapping = {
+            "queued": TelephonyCallStatus.INITIATED,
+            "ringing": TelephonyCallStatus.RINGING,
+            "in-progress": TelephonyCallStatus.IN_PROGRESS,
+            "answered": TelephonyCallStatus.ANSWERED,
+            "completed": TelephonyCallStatus.COMPLETED,
+            "failed": TelephonyCallStatus.FAILED,
+            "busy": TelephonyCallStatus.BUSY,
+            "no-answer": TelephonyCallStatus.NO_ANSWER,
+            "canceled": TelephonyCallStatus.CANCELED,
+            "permission_requested": TelephonyCallStatus.INITIATED,
+            "permission_denied": TelephonyCallStatus.FAILED,
+        }
+
+        return status_mapping.get(whatsapp_status.lower(), TelephonyCallStatus.ERROR)
+
+    async def _request_call_permission(
+        self,
+        to_number: str,
+        workflow_run_id: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """Request call permission from WhatsApp user for business-initiated call.
+        
+        Args:
+            to_number: Destination phone number
+            workflow_run_id: Optional workflow run ID for tracking
+            
+        Returns:
+            Dict with permission request result from Graph API
+        """
+        endpoint = f"{self.GRAPH_API_BASE_URL}/{self.phone_number_id}/calls"
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json"
+        }
+
+        clean_to = to_number.lstrip("+")
+        payload: Dict[str, Any] = {
+            "messaging_product": "whatsapp",
+            "to": clean_to,
+        }
+        if workflow_run_id:
+            payload["biz_opaque_callback_data"] = str(workflow_run_id)
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(endpoint, headers=headers, json=payload) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    logger.error(f"Permission request failed: {error_text}")
+                    raise HTTPException(
+                        status_code=response.status,
+                        detail=f"Permission request failed: {error_text}"
+                    )
+
+                return await response.json()

--- a/api/services/telephony/providers/whatsapp/provider.py
+++ b/api/services/telephony/providers/whatsapp/provider.py
@@ -373,8 +373,24 @@ class WhatsAppProvider(TelephonyProvider):
         if webhook_data.get("object") == "whatsapp_business_account":
             return True
 
-        entry = webhook_data.get("entry") or []
-        return bool(entry and isinstance(entry, list))
+        entry = webhook_data.get("entry")
+        if isinstance(entry, list) and entry:
+            for item in entry:
+                if isinstance(item, dict):
+                    changes = item.get("changes")
+                    if isinstance(changes, list):
+                        for change in changes:
+                            if isinstance(change, dict):
+                                if change.get("field") in ("calls", "messages"):
+                                    return True
+                                value = change.get("value")
+                                if isinstance(value, dict) and (
+                                    value.get("messaging_product") == "whatsapp"
+                                    or "calls" in value
+                                    or "call" in value
+                                ):
+                                    return True
+        return False
 
     @staticmethod
     def parse_inbound_webhook(webhook_data: Dict[str, Any]) -> NormalizedInboundData:
@@ -382,11 +398,15 @@ class WhatsAppProvider(TelephonyProvider):
         entry = webhook_data.get("entry", [{}])[0]
         changes = entry.get("changes", [{}])[0]
         value = changes.get("value", {})
-        call = value.get("call", {})
+        calls = value.get("calls")
+        if isinstance(calls, list) and calls:
+            call = calls[0]
+        else:
+            call = value.get("call", {})
         metadata = value.get("metadata", {})
 
         call_id = call.get("id") or value.get("call_id") or ""
-        from_number = call.get("from") or ""
+        from_number = call.get("from") or value.get("from") or ""
         to_number = call.get("to") or metadata.get("display_phone_number") or ""
         status = call.get("status") or value.get("status") or "unknown"
         direction = call.get("direction") or value.get("direction") or "inbound"
@@ -541,6 +561,21 @@ class WhatsAppProvider(TelephonyProvider):
 
         return Response(
             content=json.dumps({"error": error_type, "message": message}),
+            media_type="application/json",
+        )
+
+    @staticmethod
+    def generate_validation_error_response(error_type) -> Any:
+        """Generate WhatsApp-specific error response for validation failures."""
+        from fastapi import Response
+
+        from api.errors.telephony_errors import TELEPHONY_ERROR_MESSAGES, TelephonyError
+
+        message = TELEPHONY_ERROR_MESSAGES.get(
+            error_type, TELEPHONY_ERROR_MESSAGES[TelephonyError.GENERAL_AUTH_FAILED]
+        )
+        return Response(
+            content=json.dumps({"error": str(error_type), "message": message}),
             media_type="application/json",
         )
 

--- a/api/services/telephony/providers/whatsapp/provider.py
+++ b/api/services/telephony/providers/whatsapp/provider.py
@@ -575,7 +575,7 @@ class WhatsAppProvider(TelephonyProvider):
             error_type, TELEPHONY_ERROR_MESSAGES[TelephonyError.GENERAL_AUTH_FAILED]
         )
         return Response(
-            content=json.dumps({"error": str(error_type), "message": message}),
+            content=json.dumps({"error": error_type.value if hasattr(error_type, "value") else str(error_type), "message": message}),
             media_type="application/json",
         )
 

--- a/api/services/telephony/providers/whatsapp/provider.py
+++ b/api/services/telephony/providers/whatsapp/provider.py
@@ -683,43 +683,55 @@ class WhatsAppProvider(TelephonyProvider):
             #   itself a WABA ID), query {self.phone_number_id}/phone_numbers.
             target_waba = waba_id or (self.phone_number_id if not records else None)
             if target_waba:
-                waba_endpoint = f"{self.GRAPH_API_BASE_URL}/{target_waba}/phone_numbers"
-                try:
-                    async with session.get(waba_endpoint, headers=headers) as response:
-                        if response.status == 200:
-                            self.is_full_inventory = True
-                            payload = await response.json()
-                            for record in payload.get("data") or []:
-                                display_phone_number = record.get("display_phone_number")
-                                phone_id = record.get("id")
-                                if not display_phone_number:
-                                    continue
-                                try:
-                                    canonical = normalize_telephony_address(
-                                        display_phone_number
-                                    ).canonical
-                                    if canonical not in seen_addresses:
-                                        seen_addresses.add(canonical)
-                                        records.append({
-                                            "address": canonical,
-                                            "extra_metadata": {
-                                                "meta_phone_number_id": str(phone_id or target_waba),
-                                                "phone_number_id": str(phone_id or target_waba),
-                                            },
-                                        })
-                                except ValueError:
-                                    logger.warning(
-                                        "Skipping unparseable WhatsApp phone number "
-                                        f"{display_phone_number!r}"
-                                    )
-                        else:
-                            error_text = await response.text()
-                            logger.warning(
-                                f"Query on /phone_numbers edge for ID {target_waba} "
-                                f"returned {response.status}: {error_text}"
-                            )
-                except Exception as e:
-                    logger.warning(f"Error querying /phone_numbers edge: {e}")
+                next_url: Optional[str] = f"{self.GRAPH_API_BASE_URL}/{target_waba}/phone_numbers"
+                all_pages_succeeded = True
+                had_successful_page = False
+                while next_url:
+                    try:
+                        async with session.get(next_url, headers=headers) as response:
+                            if response.status == 200:
+                                had_successful_page = True
+                                payload = await response.json()
+                                for record in payload.get("data") or []:
+                                    display_phone_number = record.get("display_phone_number")
+                                    phone_id = record.get("id")
+                                    if not display_phone_number:
+                                        continue
+                                    try:
+                                        canonical = normalize_telephony_address(
+                                            display_phone_number
+                                        ).canonical
+                                        if canonical not in seen_addresses:
+                                            seen_addresses.add(canonical)
+                                            records.append({
+                                                "address": canonical,
+                                                "extra_metadata": {
+                                                    "meta_phone_number_id": str(phone_id or target_waba),
+                                                    "phone_number_id": str(phone_id or target_waba),
+                                                },
+                                            })
+                                    except ValueError:
+                                        logger.warning(
+                                            "Skipping unparseable WhatsApp phone number "
+                                            f"{display_phone_number!r}"
+                                        )
+                                paging = payload.get("paging") or {}
+                                next_url = paging.get("next")
+                            else:
+                                error_text = await response.text()
+                                logger.warning(
+                                    f"Query on /phone_numbers edge for ID {target_waba} "
+                                    f"returned {response.status}: {error_text}"
+                                )
+                                all_pages_succeeded = False
+                                break
+                    except Exception as e:
+                        logger.warning(f"Error querying /phone_numbers edge: {e}")
+                        all_pages_succeeded = False
+                        break
+
+                if all_pages_succeeded and had_successful_page:
+                    self.is_full_inventory = True
 
         # 3. Fallback to statically configured from_numbers if any
         if not records and self.from_numbers:

--- a/api/services/telephony/providers/whatsapp/routes.py
+++ b/api/services/telephony/providers/whatsapp/routes.py
@@ -1,0 +1,654 @@
+"""WhatsApp webhook routes.
+
+This module handles incoming webhooks from Meta's WhatsApp Business Calling API,
+including call lifecycle events (connect, terminate), permission callbacks, and
+webhook verification, connecting incoming WhatsApp calls directly to Dograh's
+WebRTC AI voice pipeline.
+"""
+
+import asyncio
+import hashlib
+import hmac
+import json
+from typing import Any, Dict, Optional, Tuple
+
+import aiohttp
+from fastapi import APIRouter, HTTPException, Query, Request
+from loguru import logger
+from sqlalchemy import select
+from starlette.responses import PlainTextResponse
+
+from api.constants import (
+    ENABLE_COTURN,
+    FORCE_TURN_RELAY,
+    WHATSAPP_WEBHOOK_VERIFY_TOKEN,
+)
+from api.db import db_client
+from api.db.models import (
+    TelephonyConfigurationModel,
+    TelephonyPhoneNumberModel,
+    WorkflowRunModel,
+)
+from api.enums import CallType, TelephonyCallStatus, WorkflowRunState
+from api.routes.turn_credentials import (
+    TURN_HOST,
+    TURN_PORT,
+    TURN_SECRET,
+    generate_turn_credentials,
+)
+from api.services.call_concurrency import (
+    CallConcurrencyLimitError,
+    call_concurrency,
+)
+from api.services.pipecat.run_pipeline import run_pipeline_smallwebrtc
+from api.services.quota_service import authorize_workflow_run_start
+from api.services.workflow.run_creation import prepare_workflow_run_inputs
+from api.services.workflow_run_failure import mark_workflow_run_failed
+from api.utils.telephony_address import normalize_telephony_address
+from pipecat.transports.smallwebrtc.connection import IceServer, SmallWebRTCConnection
+from pipecat.transports.whatsapp.api import (
+    WhatsAppConnectCall,
+    WhatsAppWebhookRequest,
+)
+from pipecat.transports.whatsapp.client import WhatsAppClient
+
+router = APIRouter()
+
+# Active in-memory registry of ongoing WhatsApp WebRTC calls:
+# call_id -> (SmallWebRTCConnection, workflow_run_id, organization_id)
+_active_connections: Dict[str, Tuple[SmallWebRTCConnection, int, int]] = {}
+
+# Reusable aiohttp session and cached clients per phone_number_id
+_http_session: Optional[aiohttp.ClientSession] = None
+_clients: Dict[str, WhatsAppClient] = {}
+
+
+def _get_http_session() -> aiohttp.ClientSession:
+    """Return a shared aiohttp client session for Meta API requests."""
+    global _http_session
+    if _http_session is None or _http_session.closed:
+        _http_session = aiohttp.ClientSession()
+    return _http_session
+
+
+def _build_whatsapp_ice_servers() -> list[IceServer]:
+    """Configure STUN / TURN servers for WhatsApp WebRTC connection."""
+    servers: list[IceServer] = []
+    if not FORCE_TURN_RELAY:
+        servers.append(IceServer(urls="stun:stun.l.google.com:19302"))
+
+    if ENABLE_COTURN and TURN_HOST and TURN_SECRET:
+        creds = generate_turn_credentials("whatsapp", TURN_SECRET)
+        turn_udp = f"turn:{TURN_HOST}:{TURN_PORT}?transport=udp"
+        turn_tcp = f"turn:{TURN_HOST}:{TURN_PORT}?transport=tcp"
+        servers.append(
+            IceServer(
+                urls=[turn_udp, turn_tcp],
+                username=creds["username"],
+                credential=creds["password"],
+            )
+        )
+
+    return servers
+
+
+def _get_or_create_whatsapp_client(
+    phone_number_id: str,
+    access_token: str,
+    app_secret: Optional[str] = None,
+) -> WhatsAppClient:
+    """Get or instantiate a WhatsAppClient for the given business phone number."""
+    client = _clients.get(phone_number_id)
+    if not client:
+        session = _get_http_session()
+        ice_servers = _build_whatsapp_ice_servers()
+        client = WhatsAppClient(
+            whatsapp_token=access_token,
+            phone_number_id=phone_number_id,
+            session=session,
+            ice_servers=ice_servers,
+            whatsapp_secret=app_secret,
+        )
+        _clients[phone_number_id] = client
+    else:
+        client.update_whatsapp_token(access_token)
+        if app_secret:
+            client.update_whatsapp_secret(app_secret)
+
+    return client
+
+
+async def _reject_whatsapp_call(
+    phone_number_id: str,
+    call_id: str,
+    access_token: Optional[str],
+) -> None:
+    """Send a call rejection signal to Meta Graph API."""
+    if not access_token or not phone_number_id or not call_id:
+        return
+    try:
+        url = f"https://graph.facebook.com/v21.0/{phone_number_id}/calls"
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "messaging_product": "whatsapp",
+            "call_id": call_id,
+            "action": "reject",
+        }
+        session = _get_http_session()
+        async with session.post(url, headers=headers, json=payload) as resp:
+            logger.info(
+                f"[WhatsApp] Call {call_id} rejected via Graph API, status={resp.status}"
+            )
+    except Exception as e:
+        logger.error(f"[WhatsApp] Failed to send call reject to Meta: {e}")
+
+
+@router.get("/webhook")
+async def handle_webhook_verification(
+    hub_mode: str = Query(alias="hub.mode"),
+    hub_verify_token: str = Query(alias="hub.verify_token"),
+    hub_challenge: str = Query(alias="hub.challenge"),
+):
+    """Handle Meta's webhook verification handshake (hub.challenge)."""
+    if hub_mode != "subscribe":
+        raise HTTPException(status_code=400, detail="Invalid hub.mode")
+
+    # 1. Match against the global environment variable
+    if WHATSAPP_WEBHOOK_VERIFY_TOKEN and hub_verify_token == WHATSAPP_WEBHOOK_VERIFY_TOKEN:
+        logger.info("[WhatsApp] Webhook verification succeeded via environment verify token")
+        return PlainTextResponse(hub_challenge, status_code=200)
+
+    # 2. Fallback: Match against active WhatsApp telephony configurations in the DB
+    try:
+        async with db_client.async_session() as session:
+            stmt = select(TelephonyConfigurationModel).where(
+                TelephonyConfigurationModel.provider == "whatsapp",
+                TelephonyConfigurationModel.credentials.op("->>")(
+                    "webhook_verify_token"
+                )
+                == hub_verify_token,
+                TelephonyConfigurationModel.inactive.is_(False),
+            )
+            result = await session.execute(stmt)
+            matching_config = result.scalars().first()
+            if matching_config:
+                logger.info(
+                    f"[WhatsApp] Webhook verification succeeded for config {matching_config.id}"
+                )
+                return PlainTextResponse(hub_challenge, status_code=200)
+    except Exception as e:
+        logger.warning(f"[WhatsApp] Error during DB verify token lookup: {e}")
+
+    if not WHATSAPP_WEBHOOK_VERIFY_TOKEN:
+        logger.error("[WhatsApp] Webhook verification token is not configured")
+        raise HTTPException(
+            status_code=500,
+            detail="Webhook verification token is not configured",
+        )
+
+    logger.warning("[WhatsApp] Webhook verification failed: token mismatch")
+    raise HTTPException(status_code=403, detail="Invalid verification token")
+
+
+def _verify_whatsapp_signature(
+    app_secret: Optional[str],
+    raw_body: bytes,
+    signature_header: Optional[str],
+    phone_number_id: Optional[str] = None,
+) -> None:
+    """Validate Meta's X-Hub-Signature-256 HMAC for incoming webhook payloads.
+
+    Raises:
+        HTTPException: 403 if signature is missing, invalid format, app_secret is not configured, or signature mismatch.
+    """
+    if not app_secret:
+        logger.error(
+            f"[WhatsApp] Webhook signature verification failed: app_secret not configured "
+            f"for phone_number_id={phone_number_id}"
+        )
+        raise HTTPException(
+            status_code=403,
+            detail="Webhook signature verification failed: app_secret not configured",
+        )
+
+    if not signature_header:
+        logger.error(
+            f"[WhatsApp] Missing x-hub-signature-256 header for phone_number_id={phone_number_id}"
+        )
+        raise HTTPException(status_code=403, detail="Missing webhook signature")
+
+    if not signature_header.startswith("sha256="):
+        logger.error(f"[WhatsApp] Invalid signature header format: {signature_header}")
+        raise HTTPException(status_code=403, detail="Invalid webhook signature")
+
+    expected_sig = hmac.new(
+        key=app_secret.encode("utf-8"),
+        msg=raw_body,
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+    received_sig = signature_header[7:]
+
+    if not hmac.compare_digest(expected_sig, received_sig):
+        logger.error(
+            f"[WhatsApp] Webhook signature verification failed for phone_number_id={phone_number_id}"
+        )
+        raise HTTPException(status_code=403, detail="Invalid webhook signature")
+
+
+@router.post("/webhook")
+async def handle_whatsapp_webhook(request: Request):
+    """Handle incoming WhatsApp Cloud API webhooks (including calling events)."""
+    try:
+        raw_body = await request.body()
+        signature_header = request.headers.get("x-hub-signature-256")
+
+        try:
+            payload = json.loads(raw_body.decode("utf-8"))
+        except Exception as e:
+            logger.error(f"[WhatsApp] Webhook JSON parse error: {e}")
+            raise HTTPException(status_code=400, detail="Invalid JSON payload")
+
+        entry_list = payload.get("entry") or []
+        if not entry_list:
+            return {"status": "success"}
+
+        for entry in entry_list:
+            changes = entry.get("changes") or []
+            for change in changes:
+                field = change.get("field")
+                if field != "calls":
+                    logger.debug(f"[WhatsApp] Skipping non-calling webhook field: {field}")
+                    continue
+
+                value = change.get("value") or {}
+                metadata = value.get("metadata") or {}
+                phone_number_id = str(metadata.get("phone_number_id") or "")
+                calls = value.get("calls") or []
+                if not calls:
+                    continue
+
+                # Fallback to active connection if phone_number_id is omitted from metadata
+                if not phone_number_id:
+                    for c in calls:
+                        cid = c.get("id")
+                        if (
+                            cid
+                            and cid in _active_connections
+                            and len(_active_connections[cid]) > 3
+                        ):
+                            phone_number_id = str(_active_connections[cid][3])
+                            break
+
+                if not phone_number_id:
+                    logger.error("[WhatsApp] Webhook calling change missing phone_number_id")
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Missing phone_number_id in webhook metadata",
+                    )
+
+                # Look up active configuration for this phone_number_id
+                async with db_client.async_session() as session:
+                    stmt = select(TelephonyConfigurationModel).where(
+                        TelephonyConfigurationModel.provider == "whatsapp",
+                        TelephonyConfigurationModel.credentials.op("->>")(
+                            "phone_number_id"
+                        )
+                        == phone_number_id,
+                        TelephonyConfigurationModel.inactive.is_(False),
+                    )
+                    result = await session.execute(stmt)
+                    config = result.scalars().first()
+
+                if not config:
+                    logger.error(
+                        f"[WhatsApp] No active configuration found for phone_number_id {phone_number_id}"
+                    )
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"No active configuration for phone_number_id {phone_number_id}",
+                    )
+
+                # Require a valid HMAC-SHA256 signature BEFORE dispatching any calling event
+                app_secret = (config.credentials or {}).get("app_secret")
+                _verify_whatsapp_signature(
+                    app_secret=app_secret,
+                    raw_body=raw_body,
+                    signature_header=signature_header,
+                    phone_number_id=phone_number_id,
+                )
+
+                for call_data in calls:
+                    event = call_data.get("event")
+                    call_id = call_data.get("id")
+
+                    if event == "connect":
+                        await _handle_inbound_call_connect(
+                            call_data=call_data,
+                            metadata=metadata,
+                            phone_number_id=phone_number_id,
+                            raw_body=raw_body,
+                            signature_header=signature_header,
+                            payload=payload,
+                            config=config,
+                        )
+                    elif event == "terminate":
+                        await _handle_call_terminate(
+                            call_data=call_data,
+                            payload=payload,
+                        )
+                    else:
+                        logger.info(
+                            f"[WhatsApp] Received call event {event!r} for call {call_id}"
+                        )
+
+        return {"status": "success"}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"[WhatsApp] Error processing webhook: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"Webhook processing failed: {str(e)}"
+        )
+
+
+async def _handle_inbound_call_connect(
+    call_data: Dict[str, Any],
+    metadata: Dict[str, Any],
+    phone_number_id: str,
+    raw_body: bytes,
+    signature_header: Optional[str],
+    payload: Dict[str, Any],
+    config: Optional[TelephonyConfigurationModel] = None,
+) -> None:
+    """Process an incoming WhatsApp call connect event (SDP offer)."""
+    call_id = call_data.get("id") or ""
+    from_number = call_data.get("from") or ""
+    to_number = call_data.get("to") or metadata.get("display_phone_number") or ""
+    session_data = call_data.get("session") or {}
+    sdp_type = session_data.get("sdp_type")
+
+    logger.info(
+        f"[WhatsApp] Incoming call {call_id} from {from_number} to {to_number}, "
+        f"sdp_type={sdp_type}"
+    )
+
+    if sdp_type != "offer":
+        logger.warning(
+            f"[WhatsApp] Unexpected sdp_type {sdp_type!r} for inbound call {call_id}"
+        )
+        return
+
+    # 1. Lookup the TelephonyConfiguration for this phone_number_id if not supplied
+    if config is None:
+        async with db_client.async_session() as session:
+            stmt = select(TelephonyConfigurationModel).where(
+                TelephonyConfigurationModel.provider == "whatsapp",
+                TelephonyConfigurationModel.credentials.op("->>")(
+                    "phone_number_id"
+                )
+                == phone_number_id,
+                TelephonyConfigurationModel.inactive.is_(False),
+            )
+            result = await session.execute(stmt)
+            config = result.scalars().first()
+
+        if not config:
+            logger.error(
+                f"[WhatsApp] No active configuration found for phone_number_id {phone_number_id}"
+            )
+            return
+
+        app_secret = (config.credentials or {}).get("app_secret")
+        _verify_whatsapp_signature(
+            app_secret=app_secret,
+            raw_body=raw_body,
+            signature_header=signature_header,
+            phone_number_id=phone_number_id,
+        )
+
+    access_token = (config.credentials or {}).get("access_token")
+
+    # 3. Resolve destination phone number & assigned inbound workflow
+    normalized_to = (
+        normalize_telephony_address(to_number).canonical if to_number else ""
+    )
+    normalized_from = (
+        normalize_telephony_address(from_number).canonical if from_number else ""
+    )
+
+    async with db_client.async_session() as session:
+        stmt = select(TelephonyPhoneNumberModel).where(
+            TelephonyPhoneNumberModel.telephony_configuration_id == config.id,
+            TelephonyPhoneNumberModel.is_active.is_(True),
+        )
+        result = await session.execute(stmt)
+        phones = result.scalars().all()
+
+    phone_row: Optional[TelephonyPhoneNumberModel] = None
+    for p in phones:
+        if p.address_normalized == normalized_to:
+            phone_row = p
+            break
+    if not phone_row and phones:
+        # Fall back to the first active phone number row under this config
+        phone_row = phones[0]
+
+    if not phone_row or not phone_row.inbound_workflow_id:
+        logger.warning(
+            f"[WhatsApp] No inbound workflow assigned for number {to_number} "
+            f"(phone_number_id {phone_number_id}). Rejecting call."
+        )
+        await _reject_whatsapp_call(phone_number_id, call_id, access_token)
+        return
+
+    workflow_id = phone_row.inbound_workflow_id
+    workflow = await db_client.get_workflow(
+        workflow_id, organization_id=config.organization_id
+    )
+    if not workflow:
+        logger.error(
+            f"[WhatsApp] Inbound workflow {workflow_id} not found in org {config.organization_id}. Rejecting."
+        )
+        await _reject_whatsapp_call(phone_number_id, call_id, access_token)
+        return
+
+    # 4. Concurrency slot & workflow run creation
+    try:
+        concurrency_slot = await call_concurrency.acquire_org_slot(
+            config.organization_id,
+            source="inbound:whatsapp",
+            timeout=0,
+        )
+    except CallConcurrencyLimitError:
+        logger.warning(
+            f"[WhatsApp] Concurrency limit exceeded for org {config.organization_id}"
+        )
+        await _reject_whatsapp_call(phone_number_id, call_id, access_token)
+        return
+
+    try:
+        run_inputs = await prepare_workflow_run_inputs(db_client, workflow)
+        workflow_run_name = f"Inbound WhatsApp call from {normalized_from}"
+
+        workflow_run = await db_client.create_workflow_run(
+            workflow_run_name,
+            workflow_id,
+            "whatsapp",
+            user_id=workflow.user_id,
+            call_type=CallType.INBOUND,
+            initial_context={
+                "caller_number": normalized_from,
+                "called_number": normalized_to,
+                "direction": "inbound",
+                "provider": "whatsapp",
+                "telephony_configuration_id": config.id,
+            },
+            gathered_context={
+                "call_id": call_id,
+            },
+            logs={
+                "inbound_webhook": {
+                    "account_id": phone_number_id,
+                    "from_number": normalized_from,
+                    "to_number": normalized_to,
+                    "from_phone_number_id": phone_row.id,
+                },
+            },
+            organization_id=config.organization_id,
+            definition_id=run_inputs.definition_id,
+        )
+        await call_concurrency.bind_workflow_run(concurrency_slot, workflow_run.id)
+
+        quota_result = await authorize_workflow_run_start(
+            workflow_id=workflow_id,
+            organization_id=config.organization_id,
+            workflow_run_id=workflow_run.id,
+        )
+        if not quota_result.has_quota:
+            logger.warning(
+                f"[WhatsApp] Org {config.organization_id} has exceeded quota: "
+                f"{quota_result.error_message}"
+            )
+            await mark_workflow_run_failed(
+                workflow_run.id, quota_result.error_message or "Quota exceeded"
+            )
+            await call_concurrency.release_workflow_run_slot(workflow_run.id)
+            await _reject_whatsapp_call(phone_number_id, call_id, access_token)
+            return
+
+    except Exception as e:
+        logger.error(f"[WhatsApp] Failed to initialize workflow run: {e}")
+        await _reject_whatsapp_call(phone_number_id, call_id, access_token)
+        return
+
+    # 5. Connect WebRTC via Pipecat's WhatsAppClient
+    # Signature is already verified above in routes.py, so we pass app_secret=None
+    # to avoid redundant double-verification in WhatsAppClient.
+    client = _get_or_create_whatsapp_client(
+        phone_number_id=phone_number_id,
+        access_token=access_token,
+        app_secret=None,
+    )
+
+    async def on_call_connected(
+        connection: SmallWebRTCConnection, call: WhatsAppConnectCall
+    ) -> None:
+        logger.info(
+            f"[WhatsApp] Call {call.id} connected! Starting voice pipeline for "
+            f"workflow_run {workflow_run.id} in background"
+        )
+        _active_connections[call.id] = (
+            connection,
+            workflow_run.id,
+            config.organization_id,
+            phone_number_id,
+        )
+
+        # Launch the voice pipeline asynchronously so the webhook responds immediately
+        asyncio.create_task(
+            _run_whatsapp_pipeline(
+                connection=connection,
+                workflow_id=workflow_id,
+                workflow_run_id=workflow_run.id,
+                user_id=workflow.user_id,
+                organization_id=config.organization_id,
+                call_id=call.id,
+            )
+        )
+
+    try:
+        parsed_request = WhatsAppWebhookRequest.model_validate(payload)
+        await client.handle_webhook_request(
+            request=parsed_request,
+            connection_callback=on_call_connected,
+            raw_body=raw_body,
+            sha256_signature=signature_header,
+        )
+        logger.info(
+            f"[WhatsApp] Successfully accepted call {call_id} and dispatched pipeline"
+        )
+    except Exception as e:
+        logger.error(f"[WhatsApp] Failed to establish WebRTC connection for call {call_id}: {e}")
+        await mark_workflow_run_failed(
+            workflow_run.id, f"WebRTC connection failed: {e}"
+        )
+        await call_concurrency.release_workflow_run_slot(workflow_run.id)
+        await _reject_whatsapp_call(phone_number_id, call_id, access_token)
+
+
+async def _run_whatsapp_pipeline(
+    connection: SmallWebRTCConnection,
+    workflow_id: int,
+    workflow_run_id: int,
+    user_id: int,
+    organization_id: int,
+    call_id: str,
+) -> None:
+    """Execute Dograh's WebRTC AI pipeline over the active peer connection."""
+    try:
+        logger.info(
+            f"[WhatsApp] Pipeline started for workflow_run {workflow_run_id}, call_id={call_id}"
+        )
+        await run_pipeline_smallwebrtc(
+            webrtc_connection=connection,
+            workflow_id=workflow_id,
+            workflow_run_id=workflow_run_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        logger.info(
+            f"[WhatsApp] Pipeline finished cleanly for workflow_run {workflow_run_id}"
+        )
+    except Exception as e:
+        logger.error(
+            f"[WhatsApp] Pipeline error for workflow_run {workflow_run_id}: {e}",
+            exc_info=True,
+        )
+        await mark_workflow_run_failed(workflow_run_id, str(e))
+    finally:
+        _active_connections.pop(call_id, None)
+
+
+async def _handle_call_terminate(
+    call_data: Dict[str, Any], payload: Dict[str, Any]
+) -> None:
+    """Handle a WhatsApp call termination event from Meta."""
+    call_id = call_data.get("id") or ""
+    logger.info(f"[WhatsApp] Processing terminate event for call {call_id}")
+
+    entry = _active_connections.pop(call_id, None)
+    if entry:
+        connection, workflow_run_id, org_id = entry[:3]
+        try:
+            await connection.disconnect()
+            logger.info(f"[WhatsApp] Peer connection closed for call {call_id}")
+        except Exception as e:
+            logger.warning(f"[WhatsApp] Error during peer connection disconnect: {e}")
+
+        # Mark workflow run state if still running
+        try:
+            await db_client.update_workflow_run(
+                workflow_run_id,
+                is_completed=True,
+                state=WorkflowRunState.COMPLETED.value,
+            )
+        except Exception as e:
+            logger.warning(f"[WhatsApp] Failed to update workflow run on termination: {e}")
+
+
+@router.post("/permissions")
+async def handle_permission_callback(request: Request):
+    """Handle permission callback webhooks from Meta for business-initiated calls."""
+    try:
+        payload = await request.json()
+        logger.info(f"[WhatsApp] Received permission callback: {payload}")
+        return {"status": "success"}
+    except Exception as e:
+        logger.error(f"[WhatsApp] Error processing permission callback: {e}")
+        raise HTTPException(
+            status_code=500, detail=f"Permission callback processing failed: {str(e)}"
+        )

--- a/api/services/telephony/providers/whatsapp/routes.py
+++ b/api/services/telephony/providers/whatsapp/routes.py
@@ -91,6 +91,8 @@ def _ensure_redis_subscriber() -> None:
 async def _listen_for_remote_terminates() -> None:
     """Listen for cross-worker terminate events on Redis pub/sub and disconnect local peer."""
     while True:
+        redis = None
+        pubsub = None
         try:
             redis = aioredis.from_url(REDIS_URL, decode_responses=True)
             pubsub = redis.pubsub()
@@ -122,12 +124,29 @@ async def _listen_for_remote_terminates() -> None:
             logger.warning(
                 f"[WhatsApp] Redis terminate subscriber error: {e}, reconnecting in 5s..."
             )
+        finally:
+            if pubsub:
+                try:
+                    if hasattr(pubsub, "aclose"):
+                        await pubsub.aclose()
+                    else:
+                        await pubsub.close()
+                except Exception:
+                    pass
+            if redis:
+                try:
+                    await redis.aclose()
+                except Exception:
+                    pass
+        try:
             await asyncio.sleep(5)
+        except asyncio.CancelledError:
+            break
 
 
 def _get_http_session() -> aiohttp.ClientSession:
     """Return a shared aiohttp client session for Meta API requests."""
-    global _http_session
+    global _http_session, _clients
     loop = None
     try:
         loop = asyncio.get_running_loop()
@@ -140,6 +159,15 @@ def _get_http_session() -> aiohttp.ClientSession:
         or _http_session.closed
         or (loop and session_loop and session_loop != loop)
     ):
+        if _http_session and not _http_session.closed:
+            try:
+                if session_loop and session_loop.is_running():
+                    session_loop.create_task(_http_session.close())
+                elif loop and loop.is_running():
+                    loop.create_task(_http_session.close())
+            except Exception:
+                pass
+        _clients.clear()
         _http_session = aiohttp.ClientSession()
     return _http_session
 

--- a/api/services/telephony/providers/whatsapp/routes.py
+++ b/api/services/telephony/providers/whatsapp/routes.py
@@ -74,7 +74,7 @@ async def _get_redis() -> Optional[aioredis.Redis]:
     global _redis_client
     if _redis_client is None:
         try:
-            _redis_client = await aioredis.from_url(REDIS_URL, decode_responses=True)
+            _redis_client = aioredis.from_url(REDIS_URL, decode_responses=True)
         except Exception as e:
             logger.warning(f"[WhatsApp] Failed to connect to Redis: {e}")
             return None
@@ -90,7 +90,7 @@ def _ensure_redis_subscriber() -> None:
 async def _listen_for_remote_terminates() -> None:
     """Listen for cross-worker terminate events on Redis pub/sub and disconnect local peer."""
     try:
-        redis = await aioredis.from_url(REDIS_URL, decode_responses=True)
+        redis = aioredis.from_url(REDIS_URL, decode_responses=True)
         pubsub = redis.pubsub()
         await pubsub.subscribe(REDIS_TERMINATE_CHANNEL)
         async for message in pubsub.listen():
@@ -573,9 +573,10 @@ async def _handle_inbound_call_connect(
 
     except Exception as e:
         logger.error(f"[WhatsApp] Failed to initialize workflow run: {e}")
-        if slot_bound and workflow_run:
-            await call_concurrency.release_workflow_run_slot(workflow_run.id)
+        if workflow_run:
             await mark_workflow_run_failed(workflow_run.id, str(e))
+        if slot_bound:
+            await call_concurrency.release_workflow_run_slot(workflow_run.id)
         else:
             await call_concurrency.release_slot(concurrency_slot)
         await _reject_whatsapp_call(phone_number_id, call_id, access_token)
@@ -683,7 +684,13 @@ async def _run_whatsapp_pipeline(
             f"[WhatsApp] Pipeline error for workflow_run {workflow_run_id}: {e}",
             exc_info=True,
         )
-        await mark_workflow_run_failed(workflow_run_id, str(e))
+        # Only mark failed if terminate handler has not already finalized the run
+        try:
+            existing = await db_client.get_workflow_run_by_id(workflow_run_id)
+            if existing and not existing.is_completed:
+                await mark_workflow_run_failed(workflow_run_id, str(e))
+        except Exception:
+            await mark_workflow_run_failed(workflow_run_id, str(e))
     finally:
         _active_connections.pop(call_id, None)
         try:

--- a/api/services/telephony/providers/whatsapp/routes.py
+++ b/api/services/telephony/providers/whatsapp/routes.py
@@ -60,7 +60,8 @@ WHATSAPP_CALL_KEY_PREFIX = "whatsapp:call:"
 
 # Active in-memory registry of ongoing WhatsApp WebRTC calls on this worker:
 # call_id -> (SmallWebRTCConnection, workflow_run_id, organization_id, phone_number_id)
-_active_connections: Dict[str, Tuple[SmallWebRTCConnection, int, int]] = {}
+_active_connections: Dict[str, Tuple[SmallWebRTCConnection, int, int, str]] = {}
+_background_tasks: set[asyncio.Task] = set()
 
 # Reusable aiohttp session and cached clients per phone_number_id
 _http_session: Optional[aiohttp.ClientSession] = None
@@ -89,41 +90,56 @@ def _ensure_redis_subscriber() -> None:
 
 async def _listen_for_remote_terminates() -> None:
     """Listen for cross-worker terminate events on Redis pub/sub and disconnect local peer."""
-    try:
-        redis = aioredis.from_url(REDIS_URL, decode_responses=True)
-        pubsub = redis.pubsub()
-        await pubsub.subscribe(REDIS_TERMINATE_CHANNEL)
-        async for message in pubsub.listen():
-            if message.get("type") != "message":
-                continue
-            try:
-                data = json.loads(message["data"])
-                target_call_id = data.get("call_id")
-                if target_call_id and target_call_id in _active_connections:
-                    entry = _active_connections.pop(target_call_id, None)
-                    if entry:
-                        conn = entry[0]
-                        try:
-                            await conn.disconnect()
-                            logger.info(
-                                f"[WhatsApp] Peer connection closed via cross-worker terminate for {target_call_id}"
-                            )
-                        except Exception as e:
-                            logger.warning(
-                                f"[WhatsApp] Error during cross-worker peer disconnect: {e}"
-                            )
-            except Exception as e:
-                logger.warning(f"[WhatsApp] Error handling cross-worker terminate message: {e}")
-    except asyncio.CancelledError:
-        pass
-    except Exception as e:
-        logger.warning(f"[WhatsApp] Redis terminate subscriber stopped: {e}")
+    while True:
+        try:
+            redis = aioredis.from_url(REDIS_URL, decode_responses=True)
+            pubsub = redis.pubsub()
+            await pubsub.subscribe(REDIS_TERMINATE_CHANNEL)
+            async for message in pubsub.listen():
+                if message.get("type") != "message":
+                    continue
+                try:
+                    data = json.loads(message["data"])
+                    target_call_id = data.get("call_id")
+                    if target_call_id and target_call_id in _active_connections:
+                        entry = _active_connections.pop(target_call_id, None)
+                        if entry:
+                            conn = entry[0]
+                            try:
+                                await conn.disconnect()
+                                logger.info(
+                                    f"[WhatsApp] Peer connection closed via cross-worker terminate for {target_call_id}"
+                                )
+                            except Exception as e:
+                                logger.warning(
+                                    f"[WhatsApp] Error during cross-worker peer disconnect: {e}"
+                                )
+                except Exception as e:
+                    logger.warning(f"[WhatsApp] Error handling cross-worker terminate message: {e}")
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            logger.warning(
+                f"[WhatsApp] Redis terminate subscriber error: {e}, reconnecting in 5s..."
+            )
+            await asyncio.sleep(5)
 
 
 def _get_http_session() -> aiohttp.ClientSession:
     """Return a shared aiohttp client session for Meta API requests."""
     global _http_session
-    if _http_session is None or _http_session.closed:
+    loop = None
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+
+    session_loop = getattr(_http_session, "_loop", None) if _http_session else None
+    if (
+        _http_session is None
+        or _http_session.closed
+        or (loop and session_loop and session_loop != loop)
+    ):
         _http_session = aiohttp.ClientSession()
     return _http_session
 
@@ -230,13 +246,6 @@ async def handle_webhook_verification(
             return PlainTextResponse(hub_challenge, status_code=200)
     except Exception as e:
         logger.warning(f"[WhatsApp] Error during DB verify token lookup: {e}")
-
-    if not WHATSAPP_WEBHOOK_VERIFY_TOKEN:
-        logger.error("[WhatsApp] Webhook verification token is not configured")
-        raise HTTPException(
-            status_code=500,
-            detail="Webhook verification token is not configured",
-        )
 
     logger.warning("[WhatsApp] Webhook verification failed: token mismatch")
     raise HTTPException(status_code=403, detail="Invalid verification token")
@@ -477,10 +486,31 @@ async def _handle_inbound_call_connect(
             phone_row = p
             break
 
+    # Fallback: only when destination to_number was omitted/empty in the incoming webhook,
+    # resolve by matching phone_number_id in extra_metadata or single active phone row
+    if not phone_row and not normalized_to:
+        if phone_number_id:
+            for p in phones:
+                if not getattr(p, "is_active", True):
+                    continue
+                meta = getattr(p, "extra_metadata", {}) or {}
+                if str(meta.get("phone_number_id") or meta.get("meta_phone_number_id") or "") == str(phone_number_id):
+                    phone_row = p
+                    break
+
+        if not phone_row:
+            active_phones = [p for p in phones if getattr(p, "is_active", True)]
+            if len(active_phones) == 1:
+                phone_row = active_phones[0]
+
+        if phone_row:
+            normalized_to = phone_row.address_normalized
+
     if not phone_row:
         logger.warning(
             f"[WhatsApp] No active configured phone number found matching destination "
-            f"{normalized_to} for config {config.id}. Rejecting call {call_id}."
+            f"{normalized_to} (or phone_number_id {phone_number_id}) for config {config.id}. "
+            f"Rejecting call {call_id}."
         )
         await _reject_whatsapp_call(phone_number_id, call_id, access_token)
         return
@@ -625,7 +655,7 @@ async def _handle_inbound_call_connect(
         _ensure_redis_subscriber()
 
         # Launch the voice pipeline asynchronously so the webhook responds immediately
-        asyncio.create_task(
+        pipeline_task = asyncio.create_task(
             _run_whatsapp_pipeline(
                 connection=connection,
                 workflow_id=workflow_id,
@@ -635,6 +665,8 @@ async def _handle_inbound_call_connect(
                 call_id=call.id,
             )
         )
+        _background_tasks.add(pipeline_task)
+        pipeline_task.add_done_callback(_background_tasks.discard)
 
     try:
         parsed_request = WhatsAppWebhookRequest.model_validate(payload)
@@ -684,13 +716,14 @@ async def _run_whatsapp_pipeline(
             f"[WhatsApp] Pipeline error for workflow_run {workflow_run_id}: {e}",
             exc_info=True,
         )
-        # Only mark failed if terminate handler has not already finalized the run
         try:
-            existing = await db_client.get_workflow_run_by_id(workflow_run_id)
-            if existing and not existing.is_completed:
-                await mark_workflow_run_failed(workflow_run_id, str(e))
-        except Exception:
-            await mark_workflow_run_failed(workflow_run_id, str(e))
+            await mark_workflow_run_failed(
+                workflow_run_id, str(e), only_if_incomplete=True
+            )
+        except Exception as mark_err:
+            logger.warning(
+                f"[WhatsApp] Failed to mark workflow run {workflow_run_id} failed: {mark_err}"
+            )
     finally:
         _active_connections.pop(call_id, None)
         try:

--- a/api/services/telephony/providers/whatsapp/routes.py
+++ b/api/services/telephony/providers/whatsapp/routes.py
@@ -13,14 +13,15 @@ import json
 from typing import Any, Dict, Optional, Tuple
 
 import aiohttp
+import redis.asyncio as aioredis
 from fastapi import APIRouter, HTTPException, Query, Request
 from loguru import logger
-from sqlalchemy import select
 from starlette.responses import PlainTextResponse
 
 from api.constants import (
     ENABLE_COTURN,
     FORCE_TURN_RELAY,
+    REDIS_URL,
     WHATSAPP_WEBHOOK_VERIFY_TOKEN,
 )
 from api.db import db_client
@@ -52,15 +53,71 @@ from pipecat.transports.whatsapp.api import (
 )
 from pipecat.transports.whatsapp.client import WhatsAppClient
 
-router = APIRouter()
+router = APIRouter(prefix="/whatsapp")
 
-# Active in-memory registry of ongoing WhatsApp WebRTC calls:
-# call_id -> (SmallWebRTCConnection, workflow_run_id, organization_id)
+REDIS_TERMINATE_CHANNEL = "whatsapp:call:terminate"
+WHATSAPP_CALL_KEY_PREFIX = "whatsapp:call:"
+
+# Active in-memory registry of ongoing WhatsApp WebRTC calls on this worker:
+# call_id -> (SmallWebRTCConnection, workflow_run_id, organization_id, phone_number_id)
 _active_connections: Dict[str, Tuple[SmallWebRTCConnection, int, int]] = {}
 
 # Reusable aiohttp session and cached clients per phone_number_id
 _http_session: Optional[aiohttp.ClientSession] = None
 _clients: Dict[str, WhatsAppClient] = {}
+
+_redis_client: Optional[aioredis.Redis] = None
+_redis_subscriber_task: Optional[asyncio.Task] = None
+
+
+async def _get_redis() -> Optional[aioredis.Redis]:
+    global _redis_client
+    if _redis_client is None:
+        try:
+            _redis_client = await aioredis.from_url(REDIS_URL, decode_responses=True)
+        except Exception as e:
+            logger.warning(f"[WhatsApp] Failed to connect to Redis: {e}")
+            return None
+    return _redis_client
+
+
+def _ensure_redis_subscriber() -> None:
+    global _redis_subscriber_task
+    if _redis_subscriber_task is None or _redis_subscriber_task.done():
+        _redis_subscriber_task = asyncio.create_task(_listen_for_remote_terminates())
+
+
+async def _listen_for_remote_terminates() -> None:
+    """Listen for cross-worker terminate events on Redis pub/sub and disconnect local peer."""
+    try:
+        redis = await aioredis.from_url(REDIS_URL, decode_responses=True)
+        pubsub = redis.pubsub()
+        await pubsub.subscribe(REDIS_TERMINATE_CHANNEL)
+        async for message in pubsub.listen():
+            if message.get("type") != "message":
+                continue
+            try:
+                data = json.loads(message["data"])
+                target_call_id = data.get("call_id")
+                if target_call_id and target_call_id in _active_connections:
+                    entry = _active_connections.pop(target_call_id, None)
+                    if entry:
+                        conn = entry[0]
+                        try:
+                            await conn.disconnect()
+                            logger.info(
+                                f"[WhatsApp] Peer connection closed via cross-worker terminate for {target_call_id}"
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"[WhatsApp] Error during cross-worker peer disconnect: {e}"
+                            )
+            except Exception as e:
+                logger.warning(f"[WhatsApp] Error handling cross-worker terminate message: {e}")
+    except asyncio.CancelledError:
+        pass
+    except Exception as e:
+        logger.warning(f"[WhatsApp] Redis terminate subscriber stopped: {e}")
 
 
 def _get_http_session() -> aiohttp.ClientSession:
@@ -163,22 +220,14 @@ async def handle_webhook_verification(
 
     # 2. Fallback: Match against active WhatsApp telephony configurations in the DB
     try:
-        async with db_client.async_session() as session:
-            stmt = select(TelephonyConfigurationModel).where(
-                TelephonyConfigurationModel.provider == "whatsapp",
-                TelephonyConfigurationModel.credentials.op("->>")(
-                    "webhook_verify_token"
-                )
-                == hub_verify_token,
-                TelephonyConfigurationModel.inactive.is_(False),
+        matching_config = await db_client.get_whatsapp_configuration_by_verify_token(
+            hub_verify_token
+        )
+        if matching_config:
+            logger.info(
+                f"[WhatsApp] Webhook verification succeeded for config {matching_config.id}"
             )
-            result = await session.execute(stmt)
-            matching_config = result.scalars().first()
-            if matching_config:
-                logger.info(
-                    f"[WhatsApp] Webhook verification succeeded for config {matching_config.id}"
-                )
-                return PlainTextResponse(hub_challenge, status_code=200)
+            return PlainTextResponse(hub_challenge, status_code=200)
     except Exception as e:
         logger.warning(f"[WhatsApp] Error during DB verify token lookup: {e}")
 
@@ -290,17 +339,9 @@ async def handle_whatsapp_webhook(request: Request):
                     )
 
                 # Look up active configuration for this phone_number_id
-                async with db_client.async_session() as session:
-                    stmt = select(TelephonyConfigurationModel).where(
-                        TelephonyConfigurationModel.provider == "whatsapp",
-                        TelephonyConfigurationModel.credentials.op("->>")(
-                            "phone_number_id"
-                        )
-                        == phone_number_id,
-                        TelephonyConfigurationModel.inactive.is_(False),
-                    )
-                    result = await session.execute(stmt)
-                    config = result.scalars().first()
+                config = await db_client.get_whatsapp_configuration_by_phone_number_id(
+                    phone_number_id
+                )
 
                 if not config:
                     logger.error(
@@ -382,20 +423,29 @@ async def _handle_inbound_call_connect(
         )
         return
 
-    # 1. Lookup the TelephonyConfiguration for this phone_number_id if not supplied
-    if config is None:
-        async with db_client.async_session() as session:
-            stmt = select(TelephonyConfigurationModel).where(
-                TelephonyConfigurationModel.provider == "whatsapp",
-                TelephonyConfigurationModel.credentials.op("->>")(
-                    "phone_number_id"
-                )
-                == phone_number_id,
-                TelephonyConfigurationModel.inactive.is_(False),
-            )
-            result = await session.execute(stmt)
-            config = result.scalars().first()
+    # 1. Check for duplicate or active call
+    if not call_id:
+        logger.warning("[WhatsApp] Missing call_id in connect event")
+        return
 
+    if call_id in _active_connections:
+        logger.warning(
+            f"[WhatsApp] Call {call_id} already active in-memory, ignoring duplicate connect"
+        )
+        return
+
+    existing_run = await db_client.get_workflow_run_by_call_id(call_id)
+    if existing_run:
+        logger.warning(
+            f"[WhatsApp] Call {call_id} already has workflow_run {existing_run.id}, ignoring duplicate connect"
+        )
+        return
+
+    # 2. Lookup the TelephonyConfiguration for this phone_number_id if not supplied
+    if config is None:
+        config = await db_client.get_whatsapp_configuration_by_phone_number_id(
+            phone_number_id
+        )
         if not config:
             logger.error(
                 f"[WhatsApp] No active configuration found for phone_number_id {phone_number_id}"
@@ -420,24 +470,22 @@ async def _handle_inbound_call_connect(
         normalize_telephony_address(from_number).canonical if from_number else ""
     )
 
-    async with db_client.async_session() as session:
-        stmt = select(TelephonyPhoneNumberModel).where(
-            TelephonyPhoneNumberModel.telephony_configuration_id == config.id,
-            TelephonyPhoneNumberModel.is_active.is_(True),
-        )
-        result = await session.execute(stmt)
-        phones = result.scalars().all()
-
+    phones = await db_client.list_phone_numbers_for_config(config.id)
     phone_row: Optional[TelephonyPhoneNumberModel] = None
     for p in phones:
-        if p.address_normalized == normalized_to:
+        if p.is_active and p.address_normalized == normalized_to:
             phone_row = p
             break
-    if not phone_row and phones:
-        # Fall back to the first active phone number row under this config
-        phone_row = phones[0]
 
-    if not phone_row or not phone_row.inbound_workflow_id:
+    if not phone_row:
+        logger.warning(
+            f"[WhatsApp] No active configured phone number found matching destination "
+            f"{normalized_to} for config {config.id}. Rejecting call {call_id}."
+        )
+        await _reject_whatsapp_call(phone_number_id, call_id, access_token)
+        return
+
+    if not phone_row.inbound_workflow_id:
         logger.warning(
             f"[WhatsApp] No inbound workflow assigned for number {to_number} "
             f"(phone_number_id {phone_number_id}). Rejecting call."
@@ -470,6 +518,8 @@ async def _handle_inbound_call_connect(
         await _reject_whatsapp_call(phone_number_id, call_id, access_token)
         return
 
+    workflow_run = None
+    slot_bound = False
     try:
         run_inputs = await prepare_workflow_run_inputs(db_client, workflow)
         workflow_run_name = f"Inbound WhatsApp call from {normalized_from}"
@@ -502,6 +552,7 @@ async def _handle_inbound_call_connect(
             definition_id=run_inputs.definition_id,
         )
         await call_concurrency.bind_workflow_run(concurrency_slot, workflow_run.id)
+        slot_bound = True
 
         quota_result = await authorize_workflow_run_start(
             workflow_id=workflow_id,
@@ -522,6 +573,11 @@ async def _handle_inbound_call_connect(
 
     except Exception as e:
         logger.error(f"[WhatsApp] Failed to initialize workflow run: {e}")
+        if slot_bound and workflow_run:
+            await call_concurrency.release_workflow_run_slot(workflow_run.id)
+            await mark_workflow_run_failed(workflow_run.id, str(e))
+        else:
+            await call_concurrency.release_slot(concurrency_slot)
         await _reject_whatsapp_call(phone_number_id, call_id, access_token)
         return
 
@@ -547,6 +603,25 @@ async def _handle_inbound_call_connect(
             config.organization_id,
             phone_number_id,
         )
+
+        # Store call lifecycle state in shared Redis
+        try:
+            redis = await _get_redis()
+            if redis:
+                await redis.setex(
+                    f"{WHATSAPP_CALL_KEY_PREFIX}{call.id}",
+                    3600,
+                    json.dumps({
+                        "workflow_run_id": workflow_run.id,
+                        "organization_id": config.organization_id,
+                        "phone_number_id": phone_number_id,
+                    }),
+                )
+        except Exception as e:
+            logger.warning(f"[WhatsApp] Failed to store call state in Redis: {e}")
+
+        # Ensure this worker is subscribed to cross-worker shutdown events
+        _ensure_redis_subscriber()
 
         # Launch the voice pipeline asynchronously so the webhook responds immediately
         asyncio.create_task(
@@ -611,6 +686,18 @@ async def _run_whatsapp_pipeline(
         await mark_workflow_run_failed(workflow_run_id, str(e))
     finally:
         _active_connections.pop(call_id, None)
+        try:
+            redis = await _get_redis()
+            if redis:
+                await redis.delete(f"{WHATSAPP_CALL_KEY_PREFIX}{call_id}")
+        except Exception:
+            pass
+        try:
+            await call_concurrency.release_workflow_run_slot(workflow_run_id)
+        except Exception as e:
+            logger.warning(
+                f"[WhatsApp] Failed to release concurrency slot for workflow_run {workflow_run_id}: {e}"
+            )
 
 
 async def _handle_call_terminate(
@@ -618,7 +705,21 @@ async def _handle_call_terminate(
 ) -> None:
     """Handle a WhatsApp call termination event from Meta."""
     call_id = call_data.get("id") or ""
+    if not call_id:
+        return
     logger.info(f"[WhatsApp] Processing terminate event for call {call_id}")
+
+    # Broadcast terminate to owning worker via Redis pub/sub and delete call key
+    try:
+        redis = await _get_redis()
+        if redis:
+            await redis.delete(f"{WHATSAPP_CALL_KEY_PREFIX}{call_id}")
+            await redis.publish(
+                REDIS_TERMINATE_CHANNEL,
+                json.dumps({"call_id": call_id}),
+            )
+    except Exception as e:
+        logger.warning(f"[WhatsApp] Failed to publish terminate to Redis: {e}")
 
     entry = _active_connections.pop(call_id, None)
     if entry:
@@ -638,6 +739,31 @@ async def _handle_call_terminate(
             )
         except Exception as e:
             logger.warning(f"[WhatsApp] Failed to update workflow run on termination: {e}")
+
+        try:
+            await call_concurrency.release_workflow_run_slot(workflow_run_id)
+        except Exception as e:
+            logger.warning(
+                f"[WhatsApp] Failed to release concurrency slot on terminate for {workflow_run_id}: {e}"
+            )
+    else:
+        # Cross-worker termination cleanup: when webhook hits a different worker instance
+        try:
+            run = await db_client.get_workflow_run_by_call_id(call_id)
+            if run and not run.is_completed:
+                logger.info(
+                    f"[WhatsApp] Cleaning up cross-worker workflow run {run.id} for terminated call {call_id}"
+                )
+                await db_client.update_workflow_run(
+                    run.id,
+                    is_completed=True,
+                    state=WorkflowRunState.COMPLETED.value,
+                )
+                await call_concurrency.release_workflow_run_slot(run.id)
+        except Exception as e:
+            logger.warning(
+                f"[WhatsApp] Failed cross-worker terminate cleanup for call {call_id}: {e}"
+            )
 
 
 @router.post("/permissions")

--- a/api/services/telephony/providers/whatsapp/serializers.py
+++ b/api/services/telephony/providers/whatsapp/serializers.py
@@ -12,7 +12,9 @@ class WhatsAppFrameSerializer(FrameSerializer):
     """Frame serializer for WhatsApp WebRTC connections.
 
     Handles serialization/deserialization of audio frames for WhatsApp's
-    WebRTC media transport with OPUS codec at 48kHz.
+    WebRTC media transport. The `sample_rate` passed at construction time
+    must match the transport's `audio_in_sample_rate` so that downstream
+    processors receive frames labelled at the correct wire rate.
     """
 
     def __init__(

--- a/api/services/telephony/providers/whatsapp/serializers.py
+++ b/api/services/telephony/providers/whatsapp/serializers.py
@@ -22,6 +22,7 @@ class WhatsAppFrameSerializer(FrameSerializer):
         access_token: str,
         transfer_strategy=None,
         hangup_strategy=None,
+        sample_rate: int = 16000,
     ):
         """Initialize WhatsApp frame serializer.
 
@@ -31,19 +32,19 @@ class WhatsAppFrameSerializer(FrameSerializer):
             access_token: WhatsApp API access token
             transfer_strategy: Strategy for handling call transfers
             hangup_strategy: Strategy for handling call hangups
+            sample_rate: Sample rate for deserialized audio frames (default 16000)
         """
         self.call_id = call_id
         self.phone_number_id = phone_number_id
         self.access_token = access_token
         self.transfer_strategy = transfer_strategy
         self.hangup_strategy = hangup_strategy
+        self.sample_rate = sample_rate
 
     async def serialize(self, frame: AudioRawFrame) -> bytes:
         """Serialize audio frame to bytes for transmission."""
-        # WhatsApp transports raw audio bytes through the WebRTC layer.
         return frame.audio
 
     async def deserialize(self, data: bytes) -> InputAudioRawFrame:
         """Deserialize bytes to an input audio frame."""
-        # WhatsApp audio is transported as mono PCM at 48 kHz.
-        return InputAudioRawFrame(audio=data, sample_rate=48000, num_channels=1)
+        return InputAudioRawFrame(audio=data, sample_rate=self.sample_rate, num_channels=1)

--- a/api/services/telephony/providers/whatsapp/serializers.py
+++ b/api/services/telephony/providers/whatsapp/serializers.py
@@ -1,0 +1,49 @@
+"""WhatsApp frame serializer for WebRTC media transport.
+
+This module implements frame serialization for WhatsApp WebRTC connections,
+following the pattern from other telephony providers.
+"""
+
+from pipecat.frames.frames import AudioRawFrame, EndFrame, InputAudioRawFrame
+from pipecat.serializers.base_serializer import FrameSerializer
+
+
+class WhatsAppFrameSerializer(FrameSerializer):
+    """Frame serializer for WhatsApp WebRTC connections.
+
+    Handles serialization/deserialization of audio frames for WhatsApp's
+    WebRTC media transport with OPUS codec at 48kHz.
+    """
+
+    def __init__(
+        self,
+        call_id: str,
+        phone_number_id: str,
+        access_token: str,
+        transfer_strategy=None,
+        hangup_strategy=None,
+    ):
+        """Initialize WhatsApp frame serializer.
+
+        Args:
+            call_id: WhatsApp call ID from Graph API
+            phone_number_id: Business phone number ID
+            access_token: WhatsApp API access token
+            transfer_strategy: Strategy for handling call transfers
+            hangup_strategy: Strategy for handling call hangups
+        """
+        self.call_id = call_id
+        self.phone_number_id = phone_number_id
+        self.access_token = access_token
+        self.transfer_strategy = transfer_strategy
+        self.hangup_strategy = hangup_strategy
+
+    async def serialize(self, frame: AudioRawFrame) -> bytes:
+        """Serialize audio frame to bytes for transmission."""
+        # WhatsApp transports raw audio bytes through the WebRTC layer.
+        return frame.audio
+
+    async def deserialize(self, data: bytes) -> InputAudioRawFrame:
+        """Deserialize bytes to an input audio frame."""
+        # WhatsApp audio is transported as mono PCM at 48 kHz.
+        return InputAudioRawFrame(audio=data, sample_rate=48000, num_channels=1)

--- a/api/services/telephony/providers/whatsapp/strategies.py
+++ b/api/services/telephony/providers/whatsapp/strategies.py
@@ -1,51 +1,28 @@
 """WhatsApp transfer and hangup strategies.
 
 This module implements strategies for handling call transfers and hangups
-in WhatsApp WebRTC connections, following the pattern from other providers.
+in WhatsApp connections, following the pattern from other telephony providers.
 """
 
-from pipecat.frames.frames import EndFrame
+from typing import Any, Dict
+
+from loguru import logger
+from pipecat.serializers.call_strategies import HangupStrategy, TransferStrategy
 
 
-class WhatsAppTransferStrategy:
-    """Strategy for handling call transfers in WhatsApp."""
+class WhatsAppTransferStrategy(TransferStrategy):
+    """WhatsApp transfer strategy (transfers not supported in this release)."""
 
-    def can_transfer(self, frame: EndFrame) -> bool:
-        """Check if the frame represents a transfer request.
-        
-        Args:
-            frame: End frame to check
-            
-        Returns:
-            True if this is a transfer request
-        """
-        # TODO: Implement WhatsApp transfer detection
+    async def execute_transfer(self, context: Dict[str, Any]) -> bool:
+        """Execute transfer for WhatsApp call (unsupported)."""
+        logger.warning("[WhatsApp] Call transfer is not supported in this release")
         return False
 
-    def get_transfer_target(self, frame: EndFrame) -> str:
-        """Extract transfer target from frame.
-        
-        Args:
-            frame: End frame with transfer information
-            
-        Returns:
-            Target phone number for transfer
-        """
-        # TODO: Implement transfer target extraction
-        return ""
 
+class WhatsAppHangupStrategy(HangupStrategy):
+    """WhatsApp hangup strategy."""
 
-class WhatsAppHangupStrategy:
-    """Strategy for handling call hangups in WhatsApp."""
-
-    def should_hangup(self, frame: EndFrame) -> bool:
-        """Check if the frame represents a hangup request.
-        
-        Args:
-            frame: End frame to check
-            
-        Returns:
-            True if this is a hangup request
-        """
-        # TODO: Implement WhatsApp hangup detection
+    async def execute_hangup(self, context: Dict[str, Any]) -> bool:
+        """Execute hangup for WhatsApp call."""
+        logger.info("[WhatsApp] Call hangup strategy invoked")
         return True

--- a/api/services/telephony/providers/whatsapp/strategies.py
+++ b/api/services/telephony/providers/whatsapp/strategies.py
@@ -1,0 +1,51 @@
+"""WhatsApp transfer and hangup strategies.
+
+This module implements strategies for handling call transfers and hangups
+in WhatsApp WebRTC connections, following the pattern from other providers.
+"""
+
+from pipecat.frames.frames import EndFrame
+
+
+class WhatsAppTransferStrategy:
+    """Strategy for handling call transfers in WhatsApp."""
+
+    def can_transfer(self, frame: EndFrame) -> bool:
+        """Check if the frame represents a transfer request.
+        
+        Args:
+            frame: End frame to check
+            
+        Returns:
+            True if this is a transfer request
+        """
+        # TODO: Implement WhatsApp transfer detection
+        return False
+
+    def get_transfer_target(self, frame: EndFrame) -> str:
+        """Extract transfer target from frame.
+        
+        Args:
+            frame: End frame with transfer information
+            
+        Returns:
+            Target phone number for transfer
+        """
+        # TODO: Implement transfer target extraction
+        return ""
+
+
+class WhatsAppHangupStrategy:
+    """Strategy for handling call hangups in WhatsApp."""
+
+    def should_hangup(self, frame: EndFrame) -> bool:
+        """Check if the frame represents a hangup request.
+        
+        Args:
+            frame: End frame to check
+            
+        Returns:
+            True if this is a hangup request
+        """
+        # TODO: Implement WhatsApp hangup detection
+        return True

--- a/api/services/telephony/providers/whatsapp/transport.py
+++ b/api/services/telephony/providers/whatsapp/transport.py
@@ -1,11 +1,7 @@
-"""WhatsApp WebRTC transport factory.
-
-This module creates WebRTC transports for WhatsApp voice calls using
-Pipecat's WhatsApp transport or custom implementation for OPUS codec
-at 48kHz with DTLS/SRTP encryption.
-"""
+"""WhatsApp transport factory."""
 
 from fastapi import WebSocket
+from loguru import logger
 from pipecat.transports.websocket.fastapi import (
     FastAPIWebsocketParams,
     FastAPIWebsocketTransport,
@@ -17,7 +13,7 @@ from api.services.pipecat.transport_params import realtime_param_overrides
 from api.services.telephony.factory import load_credentials_for_transport
 
 from .serializers import WhatsAppFrameSerializer
-from .strategies import WhatsAppTransferStrategy, WhatsAppHangupStrategy
+from .strategies import WhatsAppHangupStrategy, WhatsAppTransferStrategy
 
 
 async def create_transport(
@@ -31,33 +27,7 @@ async def create_transport(
     is_realtime: bool = False,
     call_id: str,
 ):
-    """
-    Create a WebRTC transport for WhatsApp voice calls.
-
-    This factory creates a Pipecat transport configured for WhatsApp's
-    WebRTC requirements: OPUS codec at 48kHz with DTLS/SRTP encryption.
-
-    Args:
-        websocket: FastAPI WebSocket connection
-        workflow_run_id: Workflow run identifier
-        audio_config: Audio configuration for the call
-        organization_id: Organization ID for credential lookup
-        ambient_noise_config: Optional ambient noise configuration
-        telephony_configuration_id: Telephony configuration ID
-        is_realtime: Whether to use realtime mode
-        call_id: WhatsApp call ID from Graph API
-
-    Returns:
-        Configured FastAPIWebsocketTransport for WhatsApp WebRTC
-
-    Raises:
-        ValueError: If required credentials are missing
-
-    Note:
-        WhatsApp uses 48kHz OPUS codec with WebRTC. The transport must
-        handle SDP offer/answer exchange with Meta's servers and support
-        ICE candidate negotiation for NAT traversal.
-    """
+    """Create a transport for WhatsApp connections."""
     config = await load_credentials_for_transport(
         organization_id, telephony_configuration_id, expected_provider="whatsapp"
     )
@@ -70,42 +40,33 @@ async def create_transport(
             f"Incomplete WhatsApp configuration for organization {organization_id}"
         )
 
-    # Create frame serializer with WhatsApp-specific strategies
     serializer = WhatsAppFrameSerializer(
         call_id=call_id,
         phone_number_id=phone_number_id,
         access_token=access_token,
         transfer_strategy=WhatsAppTransferStrategy(),
         hangup_strategy=WhatsAppHangupStrategy(),
+        sample_rate=audio_config.transport_in_sample_rate,
     )
 
-    # Build audio output mixer
-    audio_out_mixer = build_audio_out_mixer(audio_config)
-
-    # Apply realtime parameter overrides if needed
-    params = realtime_param_overrides(
-        audio_config=audio_config,
-        ambient_noise_config=ambient_noise_config,
-        is_realtime=is_realtime,
-    )
-
-    # Create WebRTC transport with WhatsApp configuration
-    transport = FastAPIWebsocketTransport(
-        websocket=websocket,
-        params=FastAPIWebsocketParams(
-            audio_in_sample_rate=audio_config.input_sample_rate,
-            audio_out_sample_rate=audio_config.output_sample_rate,
-            # WhatsApp-specific WebRTC parameters
-            # Add any additional WhatsApp-specific parameters here
-        ),
-        serializer=serializer,
-        audio_out_mixer=audio_out_mixer,
-        **params,
+    mixer = await build_audio_out_mixer(
+        audio_config.transport_out_sample_rate, ambient_noise_config
     )
 
     logger.info(
-        f"Created WhatsApp WebRTC transport for call_id={call_id}, "
+        f"Created WhatsApp transport for call_id={call_id}, "
         f"workflow_run_id={workflow_run_id}"
     )
 
-    return transport
+    return FastAPIWebsocketTransport(
+        websocket=websocket,
+        params=FastAPIWebsocketParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+            audio_in_sample_rate=audio_config.transport_in_sample_rate,
+            audio_out_sample_rate=audio_config.transport_out_sample_rate,
+            audio_out_mixer=mixer,
+            serializer=serializer,
+            **realtime_param_overrides(is_realtime),
+        ),
+    )

--- a/api/services/telephony/providers/whatsapp/transport.py
+++ b/api/services/telephony/providers/whatsapp/transport.py
@@ -1,0 +1,111 @@
+"""WhatsApp WebRTC transport factory.
+
+This module creates WebRTC transports for WhatsApp voice calls using
+Pipecat's WhatsApp transport or custom implementation for OPUS codec
+at 48kHz with DTLS/SRTP encryption.
+"""
+
+from fastapi import WebSocket
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
+
+from api.services.pipecat.audio_config import AudioConfig
+from api.services.pipecat.audio_mixer import build_audio_out_mixer
+from api.services.pipecat.transport_params import realtime_param_overrides
+from api.services.telephony.factory import load_credentials_for_transport
+
+from .serializers import WhatsAppFrameSerializer
+from .strategies import WhatsAppTransferStrategy, WhatsAppHangupStrategy
+
+
+async def create_transport(
+    websocket: WebSocket,
+    workflow_run_id: int,
+    audio_config: AudioConfig,
+    organization_id: int,
+    *,
+    ambient_noise_config: dict | None = None,
+    telephony_configuration_id: int | None = None,
+    is_realtime: bool = False,
+    call_id: str,
+):
+    """
+    Create a WebRTC transport for WhatsApp voice calls.
+
+    This factory creates a Pipecat transport configured for WhatsApp's
+    WebRTC requirements: OPUS codec at 48kHz with DTLS/SRTP encryption.
+
+    Args:
+        websocket: FastAPI WebSocket connection
+        workflow_run_id: Workflow run identifier
+        audio_config: Audio configuration for the call
+        organization_id: Organization ID for credential lookup
+        ambient_noise_config: Optional ambient noise configuration
+        telephony_configuration_id: Telephony configuration ID
+        is_realtime: Whether to use realtime mode
+        call_id: WhatsApp call ID from Graph API
+
+    Returns:
+        Configured FastAPIWebsocketTransport for WhatsApp WebRTC
+
+    Raises:
+        ValueError: If required credentials are missing
+
+    Note:
+        WhatsApp uses 48kHz OPUS codec with WebRTC. The transport must
+        handle SDP offer/answer exchange with Meta's servers and support
+        ICE candidate negotiation for NAT traversal.
+    """
+    config = await load_credentials_for_transport(
+        organization_id, telephony_configuration_id, expected_provider="whatsapp"
+    )
+
+    access_token = config.get("access_token")
+    phone_number_id = config.get("phone_number_id")
+
+    if not access_token or not phone_number_id:
+        raise ValueError(
+            f"Incomplete WhatsApp configuration for organization {organization_id}"
+        )
+
+    # Create frame serializer with WhatsApp-specific strategies
+    serializer = WhatsAppFrameSerializer(
+        call_id=call_id,
+        phone_number_id=phone_number_id,
+        access_token=access_token,
+        transfer_strategy=WhatsAppTransferStrategy(),
+        hangup_strategy=WhatsAppHangupStrategy(),
+    )
+
+    # Build audio output mixer
+    audio_out_mixer = build_audio_out_mixer(audio_config)
+
+    # Apply realtime parameter overrides if needed
+    params = realtime_param_overrides(
+        audio_config=audio_config,
+        ambient_noise_config=ambient_noise_config,
+        is_realtime=is_realtime,
+    )
+
+    # Create WebRTC transport with WhatsApp configuration
+    transport = FastAPIWebsocketTransport(
+        websocket=websocket,
+        params=FastAPIWebsocketParams(
+            audio_in_sample_rate=audio_config.input_sample_rate,
+            audio_out_sample_rate=audio_config.output_sample_rate,
+            # WhatsApp-specific WebRTC parameters
+            # Add any additional WhatsApp-specific parameters here
+        ),
+        serializer=serializer,
+        audio_out_mixer=audio_out_mixer,
+        **params,
+    )
+
+    logger.info(
+        f"Created WhatsApp WebRTC transport for call_id={call_id}, "
+        f"workflow_run_id={workflow_run_id}"
+    )
+
+    return transport

--- a/api/services/telephony/registry.py
+++ b/api/services/telephony/registry.py
@@ -303,7 +303,6 @@ class ProviderSpec:
     transport_factory: TransportFactory
     transport_sample_rate: int
     config_request_cls: Type[BaseModel]
-    config_response_cls: Optional[Type[BaseModel]] = None
     ui_metadata: Optional[ProviderUIMetadata] = None
     # Credential field that uniquely identifies the provider account. Used to
     # (a) match an inbound webhook to the right org config when multiple configs

--- a/api/services/telephony/registry.py
+++ b/api/services/telephony/registry.py
@@ -261,6 +261,7 @@ class ProviderSpec:
             uses (e.g. 8000 for Twilio/Plivo, 16000 for Vonage). The pipecat
             layer derives the full ``AudioConfig`` from this.
         config_request_cls: Pydantic model for incoming save requests.
+        config_response_cls: Optional Pydantic model for outgoing (masked) responses.
         ui_metadata: Optional form metadata used by the telephony-config
             UI to render a provider-specific form. Surfaced via
             ``GET /api/v1/telephony/providers/metadata``.
@@ -303,6 +304,7 @@ class ProviderSpec:
     transport_factory: TransportFactory
     transport_sample_rate: int
     config_request_cls: Type[BaseModel]
+    config_response_cls: Optional[Type[BaseModel]] = None
     ui_metadata: Optional[ProviderUIMetadata] = None
     # Credential field that uniquely identifies the provider account. Used to
     # (a) match an inbound webhook to the right org config when multiple configs

--- a/api/services/telephony/registry.py
+++ b/api/services/telephony/registry.py
@@ -303,6 +303,7 @@ class ProviderSpec:
     transport_factory: TransportFactory
     transport_sample_rate: int
     config_request_cls: Type[BaseModel]
+    config_response_cls: Optional[Type[BaseModel]] = None
     ui_metadata: Optional[ProviderUIMetadata] = None
     # Credential field that uniquely identifies the provider account. Used to
     # (a) match an inbound webhook to the right org config when multiple configs

--- a/api/services/workflow_run_failure.py
+++ b/api/services/workflow_run_failure.py
@@ -23,7 +23,12 @@ from api.services.workflow.disposition_mapping import map_disposition
 from api.tasks.function_names import FunctionNames
 
 
-async def mark_workflow_run_failed(workflow_run_id: int, error_message: str) -> None:
+async def mark_workflow_run_failed(
+    workflow_run_id: int,
+    error_message: str,
+    *,
+    only_if_incomplete: bool = False,
+) -> None:
     """Complete the run with a user-visible error and notify integrations.
 
     Best-effort: callers invoke this while rejecting a call, so a bookkeeping
@@ -62,6 +67,7 @@ async def mark_workflow_run_failed(workflow_run_id: int, error_message: str) -> 
                 "call_status": error_disposition,
             },
             logs={"realtime_feedback_events": [failure_event]},
+            only_if_incomplete=only_if_incomplete,
         )
     except Exception as e:  # noqa: BLE001 - bookkeeping must remain best-effort
         logger.error(f"Failed to record failure on workflow run {workflow_run_id}: {e}")

--- a/api/services/workflow_run_failure.py
+++ b/api/services/workflow_run_failure.py
@@ -53,7 +53,7 @@ async def mark_workflow_run_failed(
             await db_client.get_organization_id_by_workflow_run_id(workflow_run_id),
             error_disposition,
         )
-        await db_client.update_workflow_run(
+        updated_run = await db_client.update_workflow_run(
             run_id=workflow_run_id,
             is_completed=True,
             state=WorkflowRunState.COMPLETED.value,
@@ -69,6 +69,11 @@ async def mark_workflow_run_failed(
             logs={"realtime_feedback_events": [failure_event]},
             only_if_incomplete=only_if_incomplete,
         )
+        if only_if_incomplete and updated_run is None:
+            logger.info(
+                f"Workflow run {workflow_run_id} was already completed; skipping failure enqueue"
+            )
+            return
     except Exception as e:  # noqa: BLE001 - bookkeeping must remain best-effort
         logger.error(f"Failed to record failure on workflow run {workflow_run_id}: {e}")
         return

--- a/api/tests/telephony/test_external_pbx_configuration.py
+++ b/api/tests/telephony/test_external_pbx_configuration.py
@@ -1,4 +1,9 @@
 from api.routes import organization
+from api.services.configuration.masking import (
+    build_sensitive_tree,
+    mask_key,
+    restore_masked_fields,
+)
 
 
 def _credentials(password: str = "agent-secret") -> dict:
@@ -17,6 +22,31 @@ def _credentials(password: str = "agent-secret") -> dict:
     }
 
 
+def _credentials_with_non_agent_api(
+    agent_password: str = "agent-secret",
+    non_agent_password: str = "non-agent-secret",
+) -> dict:
+    """Full credentials including optional non_agent_api section."""
+    return {
+        "ari_endpoint": "https://asterisk.example.com",
+        "app_name": "dograh",
+        "app_password": "ari-secret",
+        "external_pbx": {
+            "type": "vicidial",
+            "agent_api": {
+                "url": "https://vici.example.com/agc/api.php",
+                "username": "agent-user",
+                "password": agent_password,
+            },
+            "non_agent_api": {
+                "url": "https://vici.example.com/vicidial/non_agent_api.php",
+                "username": "lead-api-user",
+                "password": non_agent_password,
+            },
+        },
+    }
+
+
 def test_nested_external_pbx_secrets_are_masked_without_mutating_source():
     credentials = _credentials()
 
@@ -30,8 +60,260 @@ def test_nested_external_pbx_secrets_are_masked_without_mutating_source():
 def test_nested_masked_external_pbx_secrets_are_restored_on_update():
     existing = _credentials()
     request = organization._credentials_for_display("ari", existing)
+    fields_set = {
+        "ari_endpoint", "app_name", "app_password",
+        "external_pbx", "external_pbx.type",
+        "external_pbx.agent_api", "external_pbx.agent_api.url",
+        "external_pbx.agent_api.username", "external_pbx.agent_api.password",
+    }
 
-    organization.preserve_masked_fields("ari", request, existing)
+    organization.preserve_masked_fields("ari", request, existing, fields_set=fields_set)
 
     assert request["app_password"] == "ari-secret"
     assert request["external_pbx"]["agent_api"]["password"] == "agent-secret"
+
+
+def test_nested_secrets_not_restored_when_external_pbx_explicitly_none():
+    """When external_pbx is explicitly set to None (in fields_set), nested secrets should NOT be restored."""
+    existing = _credentials_with_non_agent_api()
+    request = {
+        "ari_endpoint": "https://asterisk.example.com",
+        "app_name": "dograh",
+        "app_password": "ari-secret",
+        "external_pbx": None,  # Explicitly cleared
+    }
+
+    # external_pbx is in fields_set AND its value is None → explicit clear
+    fields_set = {"external_pbx"}
+    organization.preserve_masked_fields("ari", request, existing, fields_set=fields_set)
+
+    # external_pbx should remain None, not be recreated with secrets
+    assert request["external_pbx"] is None
+
+
+def test_nested_secrets_preserved_when_external_pbx_omitted():
+    """When external_pbx is omitted entirely, nested secrets and non-sensitive fields should be preserved."""
+    existing = _credentials_with_non_agent_api()
+    request = {
+        "ari_endpoint": "https://asterisk.example.com",
+        "app_name": "dograh",
+        "app_password": "ari-secret",
+        # external_pbx is omitted entirely
+    }
+
+    fields_set = {"ari_endpoint", "app_name", "app_password"}
+    organization.preserve_masked_fields("ari", request, existing, fields_set=fields_set)
+
+    # external_pbx should be preserved since it was omitted (original behavior)
+    assert request["external_pbx"]["type"] == "vicidial"
+    assert request["external_pbx"]["agent_api"]["url"] == "https://vici.example.com/agc/api.php"
+    assert request["external_pbx"]["agent_api"]["username"] == "agent-user"
+    assert request["external_pbx"]["agent_api"]["password"] == "agent-secret"
+    assert request["external_pbx"]["non_agent_api"]["url"] == "https://vici.example.com/vicidial/non_agent_api.php"
+    assert request["external_pbx"]["non_agent_api"]["username"] == "lead-api-user"
+    assert request["external_pbx"]["non_agent_api"]["password"] == "non-agent-secret"
+
+
+def test_nested_secrets_not_restored_when_non_agent_api_explicitly_none():
+    """When external_pbx.non_agent_api is explicitly set to None (in fields_set), its secrets should NOT be restored."""
+    existing = _credentials_with_non_agent_api()
+    request = {
+        "ari_endpoint": "https://asterisk.example.com",
+        "app_name": "dograh",
+        "app_password": "ari-secret",
+        "external_pbx": {
+            "type": "vicidial",
+            "agent_api": {
+                "url": "https://vici.example.com/agc/api.php",
+                "username": "agent-user",
+                "password": mask_key("agent-secret"),
+            },
+            "non_agent_api": None,  # Explicitly cleared
+        },
+    }
+
+    # non_agent_api is in fields_set AND its dict value is None → explicit clear
+    fields_set = {"external_pbx", "external_pbx.type", "external_pbx.agent_api", "external_pbx.agent_api.url", "external_pbx.agent_api.username", "external_pbx.agent_api.password", "external_pbx.non_agent_api"}
+    organization.preserve_masked_fields("ari", request, existing, fields_set=fields_set)
+
+    # non_agent_api should remain None
+    assert request["external_pbx"]["non_agent_api"] is None
+    # agent_api secrets should still be preserved since that section is present
+    assert request["external_pbx"]["agent_api"]["password"] == "agent-secret"
+
+
+def test_non_agent_api_secrets_preserved_when_sibling_section_omitted_with_fields_set():
+    """Production path: external_pbx submitted with agent_api only, non_agent_api omitted.
+
+    This is the scenario that occurs on the real update endpoint when
+    model_dump() materialises the omitted non_agent_api as None.  The stored
+    non_agent_api credentials must be preserved — ``external_pbx`` being in
+    fields_set only means the user submitted the section, NOT that they
+    cleared every child.
+    """
+    existing = _credentials_with_non_agent_api()
+    request = {
+        "ari_endpoint": "https://asterisk.example.com",
+        "app_name": "dograh",
+        "app_password": "ari-secret",
+        "external_pbx": {
+            "type": "vicidial",
+            "agent_api": {
+                "url": "https://vici.example.com/agc/api.php",
+                "username": "agent-user",
+                "password": mask_key("agent-secret"),
+            },
+            "non_agent_api": None,  # materialised by model_dump(), NOT explicitly sent
+        },
+    }
+
+    # non_agent_api is NOT in fields_set — it was omitted by the client
+    fields_set = {
+        "external_pbx", "external_pbx.type",
+        "external_pbx.agent_api", "external_pbx.agent_api.url",
+        "external_pbx.agent_api.username", "external_pbx.agent_api.password",
+    }
+    organization.preserve_masked_fields("ari", request, existing, fields_set=fields_set)
+
+    # non_agent_api secrets and non-sensitive siblings must be restored (omitted ≠ cleared)
+    assert request["external_pbx"]["non_agent_api"]["url"] == "https://vici.example.com/vicidial/non_agent_api.php"
+    assert request["external_pbx"]["non_agent_api"]["username"] == "lead-api-user"
+    assert request["external_pbx"]["non_agent_api"]["password"] == "non-agent-secret"
+    # agent_api secrets should still be restored from mask
+    assert request["external_pbx"]["agent_api"]["password"] == "agent-secret"
+
+
+def test_nested_secrets_preserved_when_non_agent_api_omitted():
+    """When external_pbx.non_agent_api is omitted from request, its secrets should be preserved (original behavior)."""
+    existing = _credentials_with_non_agent_api()
+    request = {
+        "ari_endpoint": "https://asterisk.example.com",
+        "app_name": "dograh",
+        "app_password": "ari-secret",
+        "external_pbx": {
+            "type": "vicidial",
+            "agent_api": {
+                "url": "https://vici.example.com/agc/api.php",
+                "username": "agent-user",
+                "password": mask_key("agent-secret"),
+            },
+            # non_agent_api is omitted entirely
+        },
+    }
+
+    fields_set = {
+        "ari_endpoint", "app_name", "app_password",
+        "external_pbx", "external_pbx.type",
+        "external_pbx.agent_api", "external_pbx.agent_api.url",
+        "external_pbx.agent_api.username", "external_pbx.agent_api.password",
+    }
+    organization.preserve_masked_fields("ari", request, existing, fields_set=fields_set)
+
+    # non_agent_api secrets and non-sensitive siblings should be preserved since parent is present and not None
+    assert request["external_pbx"]["non_agent_api"]["url"] == "https://vici.example.com/vicidial/non_agent_api.php"
+    assert request["external_pbx"]["non_agent_api"]["username"] == "lead-api-user"
+    assert request["external_pbx"]["non_agent_api"]["password"] == "non-agent-secret"
+    # agent_api secrets should still be preserved since that section is present
+    assert request["external_pbx"]["agent_api"]["password"] == "agent-secret"
+
+
+def test_nested_secrets_preserved_when_parent_present_and_not_none():
+    """When external_pbx is present and not None, nested secrets ARE preserved as expected."""
+    existing = _credentials_with_non_agent_api()
+    request = organization._credentials_for_display("ari", existing)
+    fields_set = {
+        "ari_endpoint", "app_name", "app_password",
+        "external_pbx", "external_pbx.type",
+        "external_pbx.agent_api", "external_pbx.agent_api.url",
+        "external_pbx.agent_api.username", "external_pbx.agent_api.password",
+        "external_pbx.non_agent_api", "external_pbx.non_agent_api.url",
+        "external_pbx.non_agent_api.username", "external_pbx.non_agent_api.password",
+    }
+
+    organization.preserve_masked_fields("ari", request, existing, fields_set=fields_set)
+
+    # All nested secrets should be restored
+    assert request["app_password"] == "ari-secret"
+    assert request["external_pbx"]["agent_api"]["password"] == "agent-secret"
+    assert request["external_pbx"]["non_agent_api"]["password"] == "non-agent-secret"
+
+
+def test_non_agent_api_secrets_preserved_when_parent_present():
+    """When external_pbx.non_agent_api is present, its secrets are preserved even if masked."""
+    existing = _credentials_with_non_agent_api()
+    request = {
+        "ari_endpoint": "https://asterisk.example.com",
+        "app_name": "dograh",
+        "app_password": "ari-secret",
+        "external_pbx": {
+            "type": "vicidial",
+            "agent_api": {
+                "url": "https://vici.example.com/agc/api.php",
+                "username": "agent-user",
+                "password": mask_key("agent-secret"),
+            },
+            "non_agent_api": {
+                "url": "https://vici.example.com/vicidial/non_agent_api.php",
+                "username": "lead-api-user",
+                "password": mask_key("non-agent-secret"),
+            },
+        },
+    }
+
+    fields_set = {
+        "ari_endpoint", "app_name", "app_password",
+        "external_pbx", "external_pbx.type",
+        "external_pbx.agent_api", "external_pbx.agent_api.url",
+        "external_pbx.agent_api.username", "external_pbx.agent_api.password",
+        "external_pbx.non_agent_api", "external_pbx.non_agent_api.url",
+        "external_pbx.non_agent_api.username", "external_pbx.non_agent_api.password",
+    }
+    organization.preserve_masked_fields("ari", request, existing, fields_set=fields_set)
+
+    # Both nested secrets should be restored
+    assert request["external_pbx"]["agent_api"]["password"] == "agent-secret"
+    assert request["external_pbx"]["non_agent_api"]["password"] == "non-agent-secret"
+
+
+def test_nested_secrets_not_restored_when_parent_explicitly_none():
+    """When parent is explicitly None, nested secrets should NOT be restored."""
+    existing = _credentials_with_non_agent_api()
+    request = {
+        "ari_endpoint": "https://asterisk.example.com",
+        "app_name": "dograh",
+        "app_password": "ari-secret",
+        "external_pbx": None,  # Explicitly cleared
+    }
+
+    fields_set = {"ari_endpoint", "app_name", "app_password", "external_pbx"}
+    organization.preserve_masked_fields("ari", request, existing, fields_set=fields_set)
+
+    # external_pbx should remain None
+    assert request["external_pbx"] is None
+
+
+def test_secret_that_is_also_a_section_gets_both_roles():
+    """A sensitive path may also be an ancestor of another sensitive path.
+
+    No provider declares that today, but ``sensitive=True`` on a section field
+    is a one-line registry change. Both roles have to survive: the path is
+    unmasked when the stored value is a scalar, and recursed into when it is a
+    section — a tree that kept only one role would write the mask back to the
+    database.
+    """
+    tree = build_sensitive_tree(["a", "a.b"])
+
+    assert tree["a"].secret, "'a' is a secret in its own right"
+    assert "b" in tree["a"].children, "'a' is also an ancestor of secret 'a.b'"
+
+    # Stored scalar: 'a' acts as a secret, so the resubmitted mask is replaced.
+    request = {"a": mask_key("top-secret")}
+    restore_masked_fields(request, {"a": "top-secret"}, {"a"}, ["a", "a.b"])
+    assert request["a"] == "top-secret"
+
+    # Stored section: 'a' acts as a section, so the walk descends to 'a.b'.
+    request = {"a": {"b": mask_key("nested-secret")}}
+    restore_masked_fields(
+        request, {"a": {"b": "nested-secret"}}, {"a", "a.b"}, ["a", "a.b"]
+    )
+    assert request["a"]["b"] == "nested-secret"

--- a/api/tests/telephony/test_setup_checklists.py
+++ b/api/tests/telephony/test_setup_checklists.py
@@ -79,3 +79,39 @@ def test_provider_that_can_dial_without_a_number_has_no_checklist():
         )
         is None
     )
+
+
+def test_sensitive_fields_match_config_request_schema():
+    """Ensure every sensitive field defined in ui_metadata resolves to a valid field on config_request_cls."""
+    import typing
+
+    def _unwrap_model(annotation):
+        if hasattr(annotation, "model_fields"):
+            return annotation
+        args = typing.get_args(annotation)
+        for arg in args:
+            m = _unwrap_model(arg)
+            if m is not None:
+                return m
+        return None
+
+    for spec in registry.all_specs():
+        if not spec.ui_metadata or not spec.config_request_cls:
+            continue
+        req_cls = spec.config_request_cls
+        for field in spec.ui_metadata.fields:
+            if not field.sensitive:
+                continue
+            current_cls = req_cls
+            parts = field.name.split(".")
+            for idx, part in enumerate(parts):
+                assert current_cls is not None and hasattr(current_cls, "model_fields"), (
+                    f"Provider '{spec.name}' sensitive field '{field.name}' references non-model at '{part}'"
+                )
+                assert part in current_cls.model_fields, (
+                    f"Provider '{spec.name}' sensitive field '{field.name}' segment '{part}' not found in {current_cls}"
+                )
+                if idx < len(parts) - 1:
+                    field_info = current_cls.model_fields[part]
+                    current_cls = _unwrap_model(field_info.annotation)
+

--- a/api/tests/telephony/whatsapp/__init__.py
+++ b/api/tests/telephony/whatsapp/__init__.py
@@ -1,0 +1,1 @@
+"""WhatsApp telephony provider tests."""

--- a/api/tests/telephony/whatsapp/test_inbound_call.py
+++ b/api/tests/telephony/whatsapp/test_inbound_call.py
@@ -403,6 +403,9 @@ class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
         ), patch(
             "api.services.call_concurrency.call_concurrency.release_workflow_run_slot",
             AsyncMock(),
+        ), patch(
+            "api.services.telephony.providers.whatsapp.routes._get_redis",
+            AsyncMock(return_value=None),
         ):
             response = await handle_whatsapp_webhook(request)
 
@@ -440,7 +443,10 @@ class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
         ) as mock_update, patch(
             "api.services.call_concurrency.call_concurrency.release_workflow_run_slot",
             AsyncMock(),
-        ) as mock_release:
+        ) as mock_release, patch(
+            "api.services.telephony.providers.whatsapp.routes._get_redis",
+            AsyncMock(return_value=None),
+        ):
             response = await handle_whatsapp_webhook(request)
 
             self.assertEqual(response, {"status": "success"})

--- a/api/tests/telephony/whatsapp/test_inbound_call.py
+++ b/api/tests/telephony/whatsapp/test_inbound_call.py
@@ -1,0 +1,501 @@
+"""Unit tests for WhatsApp inbound calling webhook and WebRTC integration."""
+
+import hashlib
+import hmac
+import json
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import HTTPException
+from fastapi.responses import PlainTextResponse
+from starlette.requests import Request
+
+from api.db import db_client
+from api.services.telephony.providers.whatsapp.routes import (
+    _active_connections,
+    handle_webhook_verification,
+    handle_whatsapp_webhook,
+)
+
+
+class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
+    def setUp(self):
+        _active_connections.clear()
+
+    async def test_webhook_verification_via_db_fallback(self):
+        """Verify GET /webhook falls back to DB telephony configuration if env var not set."""
+        mock_config = MagicMock()
+        mock_config.id = 42
+
+        with patch(
+            "api.services.telephony.providers.whatsapp.routes.WHATSAPP_WEBHOOK_VERIFY_TOKEN",
+            None,
+        ):
+            with patch.object(db_client, "async_session") as mock_session_ctx:
+                mock_session = AsyncMock()
+                mock_session_ctx.return_value.__aenter__.return_value = mock_session
+                mock_result = MagicMock()
+                mock_result.scalars.return_value.first.return_value = mock_config
+                mock_session.execute.return_value = mock_result
+
+                response = await handle_webhook_verification(
+                    hub_mode="subscribe",
+                    hub_verify_token="custom_org_token",
+                    hub_challenge="challenge_777",
+                )
+
+                self.assertIsInstance(response, PlainTextResponse)
+                self.assertEqual(response.body, b"challenge_777")
+
+    async def test_webhook_connect_creates_workflow_run_and_answers_call(self):
+        """Verify POST /webhook handles connect event, creates workflow_run, and answers call."""
+        phone_number_id = "106540352242922"
+        call_id = "call_abc123"
+        app_secret = "test_app_secret"
+
+        payload = {
+            "object": "whatsapp_business_account",
+            "entry": [
+                {
+                    "id": "waba_123",
+                    "changes": [
+                        {
+                            "field": "calls",
+                            "value": {
+                                "messaging_product": "whatsapp",
+                                "metadata": {
+                                    "display_phone_number": "+15551234567",
+                                    "phone_number_id": phone_number_id,
+                                },
+                                "calls": [
+                                    {
+                                        "id": call_id,
+                                        "from": "+15559876543",
+                                        "to": "+15551234567",
+                                        "event": "connect",
+                                        "timestamp": "1725619200",
+                                        "direction": "inbound",
+                                        "session": {
+                                            "sdp_type": "offer",
+                                            "sdp": "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 50000 UDP/TLS/RTP/SAVPF 111\r\n",
+                                        },
+                                    }
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+
+        body_bytes = json.dumps(payload).encode("utf-8")
+        signature = hmac.new(
+            app_secret.encode("utf-8"), body_bytes, hashlib.sha256
+        ).hexdigest()
+
+        # Mock DB records
+        mock_config = MagicMock()
+        mock_config.id = 1
+        mock_config.organization_id = 10
+        mock_config.credentials = {
+            "phone_number_id": phone_number_id,
+            "access_token": "valid_token",
+            "app_secret": app_secret,
+        }
+
+        mock_phone = MagicMock()
+        mock_phone.id = 2
+        mock_phone.address_normalized = "+15551234567"
+        mock_phone.inbound_workflow_id = 99
+
+        mock_workflow = MagicMock()
+        mock_workflow.id = 99
+        mock_workflow.user_id = 5
+        mock_workflow.organization_id = 10
+
+        mock_workflow_run = MagicMock()
+        mock_workflow_run.id = 101
+
+        mock_client = AsyncMock()
+
+        # Build mock request
+        async def mock_receive():
+            return {"type": "http.request", "body": body_bytes}
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"x-hub-signature-256", f"sha256={signature}".encode("utf-8")),
+            ],
+        }
+        request = Request(scope, receive=mock_receive)
+
+        with patch.object(db_client, "async_session") as mock_session_ctx, \
+             patch.object(db_client, "get_workflow", AsyncMock(return_value=mock_workflow)), \
+             patch.object(db_client, "create_workflow_run", AsyncMock(return_value=mock_workflow_run)), \
+             patch("api.services.call_concurrency.call_concurrency.acquire_org_slot", AsyncMock(return_value="slot1")), \
+             patch("api.services.call_concurrency.call_concurrency.bind_workflow_run", AsyncMock()), \
+             patch("api.services.telephony.providers.whatsapp.routes.prepare_workflow_run_inputs", AsyncMock(return_value=MagicMock(definition_id=1))), \
+             patch("api.services.telephony.providers.whatsapp.routes.authorize_workflow_run_start", AsyncMock(return_value=MagicMock(has_quota=True))), \
+             patch("api.services.telephony.providers.whatsapp.routes._get_or_create_whatsapp_client", return_value=mock_client), \
+             patch("api.services.telephony.providers.whatsapp.routes._run_whatsapp_pipeline", AsyncMock()):
+
+            mock_session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+
+            # First query: TelephonyConfigurationModel
+            # Second query: TelephonyPhoneNumberModel
+            config_result = MagicMock()
+            config_result.scalars.return_value.first.return_value = mock_config
+
+            phone_result = MagicMock()
+            phone_result.scalars.return_value.all.return_value = [mock_phone]
+
+            mock_session.execute.side_effect = [config_result, phone_result]
+
+            response = await handle_whatsapp_webhook(request)
+
+            self.assertEqual(response, {"status": "success"})
+            mock_client.handle_webhook_request.assert_called_once()
+
+    async def test_webhook_connect_rejects_invalid_signature(self):
+        """Verify POST /webhook raises 403 when signature does not match app_secret."""
+        phone_number_id = "106540352242922"
+        app_secret = "secret123"
+
+        payload = {
+            "object": "whatsapp_business_account",
+            "entry": [
+                {
+                    "changes": [
+                        {
+                            "field": "calls",
+                            "value": {
+                                "metadata": {"phone_number_id": phone_number_id},
+                                "calls": [{"id": "c1", "event": "connect", "session": {"sdp_type": "offer"}}],
+                            },
+                        }
+                    ]
+                }
+            ],
+        }
+
+        body_bytes = json.dumps(payload).encode("utf-8")
+
+        mock_config = MagicMock()
+        mock_config.credentials = {
+            "phone_number_id": phone_number_id,
+            "app_secret": app_secret,
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body_bytes}
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"x-hub-signature-256", b"sha256=wrong_signature"),
+            ],
+        }
+        request = Request(scope, receive=mock_receive)
+
+        with patch.object(db_client, "async_session") as mock_session_ctx:
+            mock_session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+            config_result = MagicMock()
+            config_result.scalars.return_value.first.return_value = mock_config
+            mock_session.execute.return_value = config_result
+
+            with self.assertRaises(HTTPException) as ctx:
+                await handle_whatsapp_webhook(request)
+
+            self.assertEqual(ctx.exception.status_code, 403)
+            self.assertEqual(ctx.exception.detail, "Invalid webhook signature")
+
+    async def test_webhook_connect_rejects_missing_signature(self):
+        """Verify POST /webhook raises 403 when x-hub-signature-256 is omitted on connect."""
+        phone_number_id = "106540352242922"
+        payload = {
+            "object": "whatsapp_business_account",
+            "entry": [
+                {
+                    "changes": [
+                        {
+                            "field": "calls",
+                            "value": {
+                                "metadata": {"phone_number_id": phone_number_id},
+                                "calls": [{"id": "c1", "event": "connect", "session": {"sdp_type": "offer"}}],
+                            },
+                        }
+                    ]
+                }
+            ],
+        }
+
+        body_bytes = json.dumps(payload).encode("utf-8")
+        mock_config = MagicMock()
+        mock_config.credentials = {
+            "phone_number_id": phone_number_id,
+            "app_secret": "secret123",
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body_bytes}
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "headers": [(b"content-type", b"application/json")],
+        }
+        request = Request(scope, receive=mock_receive)
+
+        with patch.object(db_client, "async_session") as mock_session_ctx:
+            mock_session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+            config_result = MagicMock()
+            config_result.scalars.return_value.first.return_value = mock_config
+            mock_session.execute.return_value = config_result
+
+            with self.assertRaises(HTTPException) as ctx:
+                await handle_whatsapp_webhook(request)
+
+            self.assertEqual(ctx.exception.status_code, 403)
+            self.assertEqual(ctx.exception.detail, "Missing webhook signature")
+
+    async def test_webhook_calling_rejects_missing_app_secret(self):
+        """Verify POST /webhook raises 403 when app_secret is not configured."""
+        phone_number_id = "106540352242922"
+        payload = {
+            "object": "whatsapp_business_account",
+            "entry": [
+                {
+                    "changes": [
+                        {
+                            "field": "calls",
+                            "value": {
+                                "metadata": {"phone_number_id": phone_number_id},
+                                "calls": [{"id": "c1", "event": "connect", "session": {"sdp_type": "offer"}}],
+                            },
+                        }
+                    ]
+                }
+            ],
+        }
+
+        body_bytes = json.dumps(payload).encode("utf-8")
+        mock_config = MagicMock()
+        mock_config.credentials = {
+            "phone_number_id": phone_number_id,
+            "app_secret": None,
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body_bytes}
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"x-hub-signature-256", b"sha256=some_sig"),
+            ],
+        }
+        request = Request(scope, receive=mock_receive)
+
+        with patch.object(db_client, "async_session") as mock_session_ctx:
+            mock_session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+            config_result = MagicMock()
+            config_result.scalars.return_value.first.return_value = mock_config
+            mock_session.execute.return_value = config_result
+
+            with self.assertRaises(HTTPException) as ctx:
+                await handle_whatsapp_webhook(request)
+
+            self.assertEqual(ctx.exception.status_code, 403)
+            self.assertEqual(
+                ctx.exception.detail,
+                "Webhook signature verification failed: app_secret not configured",
+            )
+
+    async def test_webhook_terminate_disconnects_peer_connection(self):
+        """Verify POST /webhook with valid signature handles terminate event and disconnects."""
+        call_id = "call_to_terminate"
+        phone_number_id = "123"
+        app_secret = "test_app_secret"
+        mock_connection = AsyncMock()
+        _active_connections[call_id] = (mock_connection, 101, 10, phone_number_id)
+
+        payload = {
+            "object": "whatsapp_business_account",
+            "entry": [
+                {
+                    "changes": [
+                        {
+                            "field": "calls",
+                            "value": {
+                                "metadata": {"phone_number_id": phone_number_id},
+                                "calls": [{"id": call_id, "event": "terminate"}],
+                            },
+                        }
+                    ]
+                }
+            ],
+        }
+
+        body_bytes = json.dumps(payload).encode("utf-8")
+        signature = hmac.new(
+            app_secret.encode("utf-8"), body_bytes, hashlib.sha256
+        ).hexdigest()
+
+        mock_config = MagicMock()
+        mock_config.credentials = {
+            "phone_number_id": phone_number_id,
+            "app_secret": app_secret,
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body_bytes}
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"x-hub-signature-256", f"sha256={signature}".encode("utf-8")),
+            ],
+        }
+        request = Request(scope, receive=mock_receive)
+
+        with patch.object(db_client, "async_session") as mock_session_ctx, \
+             patch.object(db_client, "update_workflow_run", AsyncMock()):
+            mock_session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+            config_result = MagicMock()
+            config_result.scalars.return_value.first.return_value = mock_config
+            mock_session.execute.return_value = config_result
+
+            response = await handle_whatsapp_webhook(request)
+
+            self.assertEqual(response, {"status": "success"})
+            mock_connection.disconnect.assert_called_once()
+            self.assertNotIn(call_id, _active_connections)
+
+    async def test_webhook_terminate_rejects_missing_signature(self):
+        """Verify POST /webhook raises 403 and does NOT disconnect when signature is omitted on terminate."""
+        call_id = "call_to_terminate"
+        phone_number_id = "123"
+        mock_connection = AsyncMock()
+        _active_connections[call_id] = (mock_connection, 101, 10, phone_number_id)
+
+        payload = {
+            "object": "whatsapp_business_account",
+            "entry": [
+                {
+                    "changes": [
+                        {
+                            "field": "calls",
+                            "value": {
+                                "metadata": {"phone_number_id": phone_number_id},
+                                "calls": [{"id": call_id, "event": "terminate"}],
+                            },
+                        }
+                    ]
+                }
+            ],
+        }
+
+        body_bytes = json.dumps(payload).encode("utf-8")
+        mock_config = MagicMock()
+        mock_config.credentials = {
+            "phone_number_id": phone_number_id,
+            "app_secret": "test_app_secret",
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body_bytes}
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "headers": [(b"content-type", b"application/json")],
+        }
+        request = Request(scope, receive=mock_receive)
+
+        with patch.object(db_client, "async_session") as mock_session_ctx:
+            mock_session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+            config_result = MagicMock()
+            config_result.scalars.return_value.first.return_value = mock_config
+            mock_session.execute.return_value = config_result
+
+            with self.assertRaises(HTTPException) as ctx:
+                await handle_whatsapp_webhook(request)
+
+            self.assertEqual(ctx.exception.status_code, 403)
+            self.assertEqual(ctx.exception.detail, "Missing webhook signature")
+            mock_connection.disconnect.assert_not_called()
+            self.assertIn(call_id, _active_connections)
+
+    async def test_webhook_terminate_rejects_invalid_signature(self):
+        """Verify POST /webhook raises 403 and does NOT disconnect when signature is forged on terminate."""
+        call_id = "call_to_terminate"
+        phone_number_id = "123"
+        mock_connection = AsyncMock()
+        _active_connections[call_id] = (mock_connection, 101, 10, phone_number_id)
+
+        payload = {
+            "object": "whatsapp_business_account",
+            "entry": [
+                {
+                    "changes": [
+                        {
+                            "field": "calls",
+                            "value": {
+                                "metadata": {"phone_number_id": phone_number_id},
+                                "calls": [{"id": call_id, "event": "terminate"}],
+                            },
+                        }
+                    ]
+                }
+            ],
+        }
+
+        body_bytes = json.dumps(payload).encode("utf-8")
+        mock_config = MagicMock()
+        mock_config.credentials = {
+            "phone_number_id": phone_number_id,
+            "app_secret": "test_app_secret",
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": body_bytes}
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"x-hub-signature-256", b"sha256=forged_signature_digest"),
+            ],
+        }
+        request = Request(scope, receive=mock_receive)
+
+        with patch.object(db_client, "async_session") as mock_session_ctx:
+            mock_session = AsyncMock()
+            mock_session_ctx.return_value.__aenter__.return_value = mock_session
+            config_result = MagicMock()
+            config_result.scalars.return_value.first.return_value = mock_config
+            mock_session.execute.return_value = config_result
+
+            with self.assertRaises(HTTPException) as ctx:
+                await handle_whatsapp_webhook(request)
+
+            self.assertEqual(ctx.exception.status_code, 403)
+            self.assertEqual(ctx.exception.detail, "Invalid webhook signature")
+            mock_connection.disconnect.assert_not_called()
+            self.assertIn(call_id, _active_connections)

--- a/api/tests/telephony/whatsapp/test_inbound_call.py
+++ b/api/tests/telephony/whatsapp/test_inbound_call.py
@@ -3,6 +3,7 @@
 import hashlib
 import hmac
 import json
+from typing import Any, Dict, List, Optional
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,6 +19,102 @@ from api.services.telephony.providers.whatsapp.routes import (
 )
 
 
+def _build_webhook_payload(
+    calls: List[Dict[str, Any]],
+    phone_number_id: str = "106540352242922",
+    display_phone_number: str = "+15551234567",
+) -> Dict[str, Any]:
+    """Helper to construct a Meta WhatsApp Business webhook payload."""
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "waba_123",
+                "changes": [
+                    {
+                        "field": "calls",
+                        "value": {
+                            "messaging_product": "whatsapp",
+                            "metadata": {
+                                "display_phone_number": display_phone_number,
+                                "phone_number_id": phone_number_id,
+                            },
+                            "calls": calls,
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _build_request(
+    payload: Dict[str, Any],
+    signature: Optional[str] = None,
+    app_secret: Optional[str] = None,
+    custom_headers: Optional[Dict[str, str]] = None,
+) -> Request:
+    """Helper to construct a Starlette Request with appropriate HMAC headers."""
+    body_bytes = json.dumps(payload).encode("utf-8")
+    headers: List[tuple[bytes, bytes]] = [(b"content-type", b"application/json")]
+
+    if signature is not None:
+        headers.append((b"x-hub-signature-256", signature.encode("utf-8")))
+    elif app_secret is not None:
+        sig = hmac.new(
+            app_secret.encode("utf-8"), body_bytes, hashlib.sha256
+        ).hexdigest()
+        headers.append((b"x-hub-signature-256", f"sha256={sig}".encode("utf-8")))
+
+    if custom_headers:
+        for k, v in custom_headers.items():
+            headers.append((k.encode("utf-8"), v.encode("utf-8")))
+
+    async def mock_receive():
+        return {"type": "http.request", "body": body_bytes}
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": headers,
+    }
+    return Request(scope, receive=mock_receive)
+
+
+def _build_mock_config(
+    phone_number_id: str = "106540352242922",
+    app_secret: Optional[str] = "test_app_secret",
+    access_token: str = "valid_token",
+    org_id: int = 10,
+    config_id: int = 1,
+) -> MagicMock:
+    """Helper to construct a mock TelephonyConfigurationModel."""
+    config = MagicMock()
+    config.id = config_id
+    config.organization_id = org_id
+    config.credentials = {
+        "phone_number_id": phone_number_id,
+        "access_token": access_token,
+        "app_secret": app_secret,
+    }
+    return config
+
+
+def _build_mock_phone(
+    phone_id: int = 2,
+    address: str = "+15551234567",
+    workflow_id: int = 99,
+    is_active: bool = True,
+) -> MagicMock:
+    """Helper to construct a mock TelephonyPhoneNumberModel."""
+    phone = MagicMock()
+    phone.id = phone_id
+    phone.address_normalized = address
+    phone.is_active = is_active
+    phone.inbound_workflow_id = workflow_id
+    return phone
+
+
 class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
     def setUp(self):
         _active_connections.clear()
@@ -30,22 +127,19 @@ class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
         with patch(
             "api.services.telephony.providers.whatsapp.routes.WHATSAPP_WEBHOOK_VERIFY_TOKEN",
             None,
+        ), patch.object(
+            db_client,
+            "get_whatsapp_configuration_by_verify_token",
+            AsyncMock(return_value=mock_config),
         ):
-            with patch.object(db_client, "async_session") as mock_session_ctx:
-                mock_session = AsyncMock()
-                mock_session_ctx.return_value.__aenter__.return_value = mock_session
-                mock_result = MagicMock()
-                mock_result.scalars.return_value.first.return_value = mock_config
-                mock_session.execute.return_value = mock_result
+            response = await handle_webhook_verification(
+                hub_mode="subscribe",
+                hub_verify_token="custom_org_token",
+                hub_challenge="challenge_777",
+            )
 
-                response = await handle_webhook_verification(
-                    hub_mode="subscribe",
-                    hub_verify_token="custom_org_token",
-                    hub_challenge="challenge_777",
-                )
-
-                self.assertIsInstance(response, PlainTextResponse)
-                self.assertEqual(response.body, b"challenge_777")
+            self.assertIsInstance(response, PlainTextResponse)
+            self.assertEqual(response.body, b"challenge_777")
 
     async def test_webhook_connect_creates_workflow_run_and_answers_call(self):
         """Verify POST /webhook handles connect event, creates workflow_run, and answers call."""
@@ -53,60 +147,26 @@ class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
         call_id = "call_abc123"
         app_secret = "test_app_secret"
 
-        payload = {
-            "object": "whatsapp_business_account",
-            "entry": [
+        payload = _build_webhook_payload(
+            calls=[
                 {
-                    "id": "waba_123",
-                    "changes": [
-                        {
-                            "field": "calls",
-                            "value": {
-                                "messaging_product": "whatsapp",
-                                "metadata": {
-                                    "display_phone_number": "+15551234567",
-                                    "phone_number_id": phone_number_id,
-                                },
-                                "calls": [
-                                    {
-                                        "id": call_id,
-                                        "from": "+15559876543",
-                                        "to": "+15551234567",
-                                        "event": "connect",
-                                        "timestamp": "1725619200",
-                                        "direction": "inbound",
-                                        "session": {
-                                            "sdp_type": "offer",
-                                            "sdp": "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 50000 UDP/TLS/RTP/SAVPF 111\r\n",
-                                        },
-                                    }
-                                ],
-                            },
-                        }
-                    ],
+                    "id": call_id,
+                    "from": "+15559876543",
+                    "to": "+15551234567",
+                    "event": "connect",
+                    "timestamp": "1725619200",
+                    "direction": "inbound",
+                    "session": {
+                        "sdp_type": "offer",
+                        "sdp": "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 50000 UDP/TLS/RTP/SAVPF 111\r\n",
+                    },
                 }
             ],
-        }
-
-        body_bytes = json.dumps(payload).encode("utf-8")
-        signature = hmac.new(
-            app_secret.encode("utf-8"), body_bytes, hashlib.sha256
-        ).hexdigest()
-
-        # Mock DB records
-        mock_config = MagicMock()
-        mock_config.id = 1
-        mock_config.organization_id = 10
-        mock_config.credentials = {
-            "phone_number_id": phone_number_id,
-            "access_token": "valid_token",
-            "app_secret": app_secret,
-        }
-
-        mock_phone = MagicMock()
-        mock_phone.id = 2
-        mock_phone.address_normalized = "+15551234567"
-        mock_phone.inbound_workflow_id = 99
+            phone_number_id=phone_number_id,
+        )
+        request = _build_request(payload, app_secret=app_secret)
+        mock_config = _build_mock_config(phone_number_id=phone_number_id, app_secret=app_secret)
+        mock_phone = _build_mock_phone()
 
         mock_workflow = MagicMock()
         mock_workflow.id = 99
@@ -118,21 +178,17 @@ class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
 
         mock_client = AsyncMock()
 
-        # Build mock request
-        async def mock_receive():
-            return {"type": "http.request", "body": body_bytes}
+        async def fake_handle_webhook_request(request, connection_callback, **kwargs):
+            mock_connection = MagicMock()
+            mock_call = MagicMock()
+            mock_call.id = call_id
+            await connection_callback(mock_connection, mock_call)
 
-        scope = {
-            "type": "http",
-            "method": "POST",
-            "headers": [
-                (b"content-type", b"application/json"),
-                (b"x-hub-signature-256", f"sha256={signature}".encode("utf-8")),
-            ],
-        }
-        request = Request(scope, receive=mock_receive)
+        mock_client.handle_webhook_request = AsyncMock(side_effect=fake_handle_webhook_request)
 
-        with patch.object(db_client, "async_session") as mock_session_ctx, \
+        with patch.object(db_client, "get_whatsapp_configuration_by_phone_number_id", AsyncMock(return_value=mock_config)), \
+             patch.object(db_client, "get_workflow_run_by_call_id", AsyncMock(return_value=None)), \
+             patch.object(db_client, "list_phone_numbers_for_config", AsyncMock(return_value=[mock_phone])), \
              patch.object(db_client, "get_workflow", AsyncMock(return_value=mock_workflow)), \
              patch.object(db_client, "create_workflow_run", AsyncMock(return_value=mock_workflow_run)), \
              patch("api.services.call_concurrency.call_concurrency.acquire_org_slot", AsyncMock(return_value="slot1")), \
@@ -140,76 +196,135 @@ class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
              patch("api.services.telephony.providers.whatsapp.routes.prepare_workflow_run_inputs", AsyncMock(return_value=MagicMock(definition_id=1))), \
              patch("api.services.telephony.providers.whatsapp.routes.authorize_workflow_run_start", AsyncMock(return_value=MagicMock(has_quota=True))), \
              patch("api.services.telephony.providers.whatsapp.routes._get_or_create_whatsapp_client", return_value=mock_client), \
+             patch("api.services.telephony.providers.whatsapp.routes._get_redis", AsyncMock(return_value=None)), \
              patch("api.services.telephony.providers.whatsapp.routes._run_whatsapp_pipeline", AsyncMock()):
-
-            mock_session = AsyncMock()
-            mock_session_ctx.return_value.__aenter__.return_value = mock_session
-
-            # First query: TelephonyConfigurationModel
-            # Second query: TelephonyPhoneNumberModel
-            config_result = MagicMock()
-            config_result.scalars.return_value.first.return_value = mock_config
-
-            phone_result = MagicMock()
-            phone_result.scalars.return_value.all.return_value = [mock_phone]
-
-            mock_session.execute.side_effect = [config_result, phone_result]
 
             response = await handle_whatsapp_webhook(request)
 
             self.assertEqual(response, {"status": "success"})
             mock_client.handle_webhook_request.assert_called_once()
+            self.assertIn(call_id, _active_connections)
+            self.assertEqual(_active_connections[call_id][1], mock_workflow_run.id)
+            self.assertEqual(_active_connections[call_id][2], mock_workflow.organization_id)
+
+    async def test_webhook_connect_rejects_unmatched_destination(self):
+        """Verify POST /webhook rejects call when destination does not match active configured numbers."""
+        phone_number_id = "106540352242922"
+        call_id = "call_unmatched"
+        app_secret = "test_app_secret"
+
+        payload = _build_webhook_payload(
+            calls=[
+                {
+                    "id": call_id,
+                    "from": "+15559876543",
+                    "to": "+15559999999",
+                    "event": "connect",
+                    "session": {"sdp_type": "offer"},
+                }
+            ],
+            phone_number_id=phone_number_id,
+            display_phone_number="+15559999999",
+        )
+        request = _build_request(payload, app_secret=app_secret)
+        mock_config = _build_mock_config(phone_number_id=phone_number_id, app_secret=app_secret)
+        mock_phone = _build_mock_phone()
+
+        with patch.object(db_client, "get_whatsapp_configuration_by_phone_number_id", AsyncMock(return_value=mock_config)), \
+             patch.object(db_client, "get_workflow_run_by_call_id", AsyncMock(return_value=None)), \
+             patch.object(db_client, "list_phone_numbers_for_config", AsyncMock(return_value=[mock_phone])), \
+             patch("api.services.telephony.providers.whatsapp.routes._reject_whatsapp_call", AsyncMock()) as mock_reject:
+
+            response = await handle_whatsapp_webhook(request)
+            self.assertEqual(response, {"status": "success"})
+            mock_reject.assert_awaited_once_with(phone_number_id, call_id, "valid_token")
+
+    async def test_webhook_connect_idempotent_on_duplicate_call_id(self):
+        """Verify POST /webhook ignores retried connect event if call is already registered."""
+        phone_number_id = "106540352242922"
+        call_id = "call_dup_123"
+        app_secret = "test_app_secret"
+
+        payload = _build_webhook_payload(
+            calls=[
+                {
+                    "id": call_id,
+                    "event": "connect",
+                    "session": {"sdp_type": "offer"},
+                }
+            ],
+            phone_number_id=phone_number_id,
+        )
+        request = _build_request(payload, app_secret=app_secret)
+        mock_config = _build_mock_config(phone_number_id=phone_number_id, app_secret=app_secret)
+
+        # Put call_id in active connections
+        _active_connections[call_id] = (AsyncMock(), 101, 10, phone_number_id)
+
+        with patch.object(db_client, "get_whatsapp_configuration_by_phone_number_id", AsyncMock(return_value=mock_config)), \
+             patch("api.services.call_concurrency.call_concurrency.acquire_org_slot", AsyncMock()) as mock_acquire:
+
+            response = await handle_whatsapp_webhook(request)
+            self.assertEqual(response, {"status": "success"})
+            mock_acquire.assert_not_called()
+
+    async def test_webhook_connect_releases_slot_on_run_creation_failure(self):
+        """Verify concurrency slot is cleanly released if workflow run creation fails."""
+        phone_number_id = "106540352242922"
+        call_id = "call_fail_init"
+        app_secret = "test_app_secret"
+
+        payload = _build_webhook_payload(
+            calls=[
+                {
+                    "id": call_id,
+                    "from": "+15559876543",
+                    "to": "+15551234567",
+                    "event": "connect",
+                    "session": {"sdp_type": "offer"},
+                }
+            ],
+            phone_number_id=phone_number_id,
+        )
+        request = _build_request(payload, app_secret=app_secret)
+        mock_config = _build_mock_config(phone_number_id=phone_number_id, app_secret=app_secret)
+        mock_phone = _build_mock_phone()
+
+        mock_workflow = MagicMock()
+        mock_workflow.id = 99
+        mock_workflow.organization_id = 10
+
+        with patch.object(db_client, "get_whatsapp_configuration_by_phone_number_id", AsyncMock(return_value=mock_config)), \
+             patch.object(db_client, "get_workflow_run_by_call_id", AsyncMock(return_value=None)), \
+             patch.object(db_client, "list_phone_numbers_for_config", AsyncMock(return_value=[mock_phone])), \
+             patch.object(db_client, "get_workflow", AsyncMock(return_value=mock_workflow)), \
+             patch("api.services.call_concurrency.call_concurrency.acquire_org_slot", AsyncMock(return_value="slot1")), \
+             patch("api.services.telephony.providers.whatsapp.routes.prepare_workflow_run_inputs", AsyncMock(side_effect=RuntimeError("inputs failed"))), \
+             patch("api.services.call_concurrency.call_concurrency.release_slot", AsyncMock()) as mock_release_slot, \
+             patch("api.services.telephony.providers.whatsapp.routes._reject_whatsapp_call", AsyncMock()) as mock_reject:
+
+            response = await handle_whatsapp_webhook(request)
+            self.assertEqual(response, {"status": "success"})
+            mock_release_slot.assert_awaited_once_with("slot1")
+            mock_reject.assert_awaited_once_with(phone_number_id, call_id, "valid_token")
 
     async def test_webhook_connect_rejects_invalid_signature(self):
         """Verify POST /webhook raises 403 when signature does not match app_secret."""
         phone_number_id = "106540352242922"
         app_secret = "secret123"
 
-        payload = {
-            "object": "whatsapp_business_account",
-            "entry": [
-                {
-                    "changes": [
-                        {
-                            "field": "calls",
-                            "value": {
-                                "metadata": {"phone_number_id": phone_number_id},
-                                "calls": [{"id": "c1", "event": "connect", "session": {"sdp_type": "offer"}}],
-                            },
-                        }
-                    ]
-                }
-            ],
-        }
+        payload = _build_webhook_payload(
+            calls=[{"id": "c1", "event": "connect", "session": {"sdp_type": "offer"}}],
+            phone_number_id=phone_number_id,
+        )
+        request = _build_request(payload, signature="sha256=wrong_signature")
+        mock_config = _build_mock_config(phone_number_id=phone_number_id, app_secret=app_secret)
 
-        body_bytes = json.dumps(payload).encode("utf-8")
-
-        mock_config = MagicMock()
-        mock_config.credentials = {
-            "phone_number_id": phone_number_id,
-            "app_secret": app_secret,
-        }
-
-        async def mock_receive():
-            return {"type": "http.request", "body": body_bytes}
-
-        scope = {
-            "type": "http",
-            "method": "POST",
-            "headers": [
-                (b"content-type", b"application/json"),
-                (b"x-hub-signature-256", b"sha256=wrong_signature"),
-            ],
-        }
-        request = Request(scope, receive=mock_receive)
-
-        with patch.object(db_client, "async_session") as mock_session_ctx:
-            mock_session = AsyncMock()
-            mock_session_ctx.return_value.__aenter__.return_value = mock_session
-            config_result = MagicMock()
-            config_result.scalars.return_value.first.return_value = mock_config
-            mock_session.execute.return_value = config_result
-
+        with patch.object(
+            db_client,
+            "get_whatsapp_configuration_by_phone_number_id",
+            AsyncMock(return_value=mock_config),
+        ):
             with self.assertRaises(HTTPException) as ctx:
                 await handle_whatsapp_webhook(request)
 
@@ -219,47 +334,20 @@ class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
     async def test_webhook_connect_rejects_missing_signature(self):
         """Verify POST /webhook raises 403 when x-hub-signature-256 is omitted on connect."""
         phone_number_id = "106540352242922"
-        payload = {
-            "object": "whatsapp_business_account",
-            "entry": [
-                {
-                    "changes": [
-                        {
-                            "field": "calls",
-                            "value": {
-                                "metadata": {"phone_number_id": phone_number_id},
-                                "calls": [{"id": "c1", "event": "connect", "session": {"sdp_type": "offer"}}],
-                            },
-                        }
-                    ]
-                }
-            ],
-        }
+        app_secret = "secret123"
 
-        body_bytes = json.dumps(payload).encode("utf-8")
-        mock_config = MagicMock()
-        mock_config.credentials = {
-            "phone_number_id": phone_number_id,
-            "app_secret": "secret123",
-        }
+        payload = _build_webhook_payload(
+            calls=[{"id": "c1", "event": "connect", "session": {"sdp_type": "offer"}}],
+            phone_number_id=phone_number_id,
+        )
+        request = _build_request(payload)  # No signature or secret provided
+        mock_config = _build_mock_config(phone_number_id=phone_number_id, app_secret=app_secret)
 
-        async def mock_receive():
-            return {"type": "http.request", "body": body_bytes}
-
-        scope = {
-            "type": "http",
-            "method": "POST",
-            "headers": [(b"content-type", b"application/json")],
-        }
-        request = Request(scope, receive=mock_receive)
-
-        with patch.object(db_client, "async_session") as mock_session_ctx:
-            mock_session = AsyncMock()
-            mock_session_ctx.return_value.__aenter__.return_value = mock_session
-            config_result = MagicMock()
-            config_result.scalars.return_value.first.return_value = mock_config
-            mock_session.execute.return_value = config_result
-
+        with patch.object(
+            db_client,
+            "get_whatsapp_configuration_by_phone_number_id",
+            AsyncMock(return_value=mock_config),
+        ):
             with self.assertRaises(HTTPException) as ctx:
                 await handle_whatsapp_webhook(request)
 
@@ -269,50 +357,19 @@ class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
     async def test_webhook_calling_rejects_missing_app_secret(self):
         """Verify POST /webhook raises 403 when app_secret is not configured."""
         phone_number_id = "106540352242922"
-        payload = {
-            "object": "whatsapp_business_account",
-            "entry": [
-                {
-                    "changes": [
-                        {
-                            "field": "calls",
-                            "value": {
-                                "metadata": {"phone_number_id": phone_number_id},
-                                "calls": [{"id": "c1", "event": "connect", "session": {"sdp_type": "offer"}}],
-                            },
-                        }
-                    ]
-                }
-            ],
-        }
 
-        body_bytes = json.dumps(payload).encode("utf-8")
-        mock_config = MagicMock()
-        mock_config.credentials = {
-            "phone_number_id": phone_number_id,
-            "app_secret": None,
-        }
+        payload = _build_webhook_payload(
+            calls=[{"id": "c1", "event": "connect", "session": {"sdp_type": "offer"}}],
+            phone_number_id=phone_number_id,
+        )
+        request = _build_request(payload, signature="sha256=some_sig")
+        mock_config = _build_mock_config(phone_number_id=phone_number_id, app_secret=None)
 
-        async def mock_receive():
-            return {"type": "http.request", "body": body_bytes}
-
-        scope = {
-            "type": "http",
-            "method": "POST",
-            "headers": [
-                (b"content-type", b"application/json"),
-                (b"x-hub-signature-256", b"sha256=some_sig"),
-            ],
-        }
-        request = Request(scope, receive=mock_receive)
-
-        with patch.object(db_client, "async_session") as mock_session_ctx:
-            mock_session = AsyncMock()
-            mock_session_ctx.return_value.__aenter__.return_value = mock_session
-            config_result = MagicMock()
-            config_result.scalars.return_value.first.return_value = mock_config
-            mock_session.execute.return_value = config_result
-
+        with patch.object(
+            db_client,
+            "get_whatsapp_configuration_by_phone_number_id",
+            AsyncMock(return_value=mock_config),
+        ):
             with self.assertRaises(HTTPException) as ctx:
                 await handle_whatsapp_webhook(request)
 
@@ -330,60 +387,67 @@ class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
         mock_connection = AsyncMock()
         _active_connections[call_id] = (mock_connection, 101, 10, phone_number_id)
 
-        payload = {
-            "object": "whatsapp_business_account",
-            "entry": [
-                {
-                    "changes": [
-                        {
-                            "field": "calls",
-                            "value": {
-                                "metadata": {"phone_number_id": phone_number_id},
-                                "calls": [{"id": call_id, "event": "terminate"}],
-                            },
-                        }
-                    ]
-                }
-            ],
-        }
+        payload = _build_webhook_payload(
+            calls=[{"id": call_id, "event": "terminate"}],
+            phone_number_id=phone_number_id,
+        )
+        request = _build_request(payload, app_secret=app_secret)
+        mock_config = _build_mock_config(phone_number_id=phone_number_id, app_secret=app_secret)
 
-        body_bytes = json.dumps(payload).encode("utf-8")
-        signature = hmac.new(
-            app_secret.encode("utf-8"), body_bytes, hashlib.sha256
-        ).hexdigest()
-
-        mock_config = MagicMock()
-        mock_config.credentials = {
-            "phone_number_id": phone_number_id,
-            "app_secret": app_secret,
-        }
-
-        async def mock_receive():
-            return {"type": "http.request", "body": body_bytes}
-
-        scope = {
-            "type": "http",
-            "method": "POST",
-            "headers": [
-                (b"content-type", b"application/json"),
-                (b"x-hub-signature-256", f"sha256={signature}".encode("utf-8")),
-            ],
-        }
-        request = Request(scope, receive=mock_receive)
-
-        with patch.object(db_client, "async_session") as mock_session_ctx, \
-             patch.object(db_client, "update_workflow_run", AsyncMock()):
-            mock_session = AsyncMock()
-            mock_session_ctx.return_value.__aenter__.return_value = mock_session
-            config_result = MagicMock()
-            config_result.scalars.return_value.first.return_value = mock_config
-            mock_session.execute.return_value = config_result
-
+        with patch.object(
+            db_client,
+            "get_whatsapp_configuration_by_phone_number_id",
+            AsyncMock(return_value=mock_config),
+        ), patch.object(
+            db_client, "update_workflow_run", AsyncMock()
+        ), patch(
+            "api.services.call_concurrency.call_concurrency.release_workflow_run_slot",
+            AsyncMock(),
+        ):
             response = await handle_whatsapp_webhook(request)
 
             self.assertEqual(response, {"status": "success"})
             mock_connection.disconnect.assert_called_once()
             self.assertNotIn(call_id, _active_connections)
+
+    async def test_webhook_terminate_cross_worker_cleanup(self):
+        """Verify terminate event for call on another worker cleans up workflow_run and releases slot."""
+        call_id = "call_cross_worker"
+        phone_number_id = "123"
+        app_secret = "test_app_secret"
+
+        payload = _build_webhook_payload(
+            calls=[{"id": call_id, "event": "terminate"}],
+            phone_number_id=phone_number_id,
+        )
+        request = _build_request(payload, app_secret=app_secret)
+        mock_config = _build_mock_config(phone_number_id=phone_number_id, app_secret=app_secret)
+
+        mock_run = MagicMock()
+        mock_run.id = 555
+        mock_run.is_completed = False
+
+        with patch.object(
+            db_client,
+            "get_whatsapp_configuration_by_phone_number_id",
+            AsyncMock(return_value=mock_config),
+        ), patch.object(
+            db_client,
+            "get_workflow_run_by_call_id",
+            AsyncMock(return_value=mock_run),
+        ), patch.object(
+            db_client, "update_workflow_run", AsyncMock()
+        ) as mock_update, patch(
+            "api.services.call_concurrency.call_concurrency.release_workflow_run_slot",
+            AsyncMock(),
+        ) as mock_release:
+            response = await handle_whatsapp_webhook(request)
+
+            self.assertEqual(response, {"status": "success"})
+            mock_update.assert_awaited_once_with(
+                555, is_completed=True, state="completed"
+            )
+            mock_release.assert_awaited_once_with(555)
 
     async def test_webhook_terminate_rejects_missing_signature(self):
         """Verify POST /webhook raises 403 and does NOT disconnect when signature is omitted on terminate."""
@@ -392,47 +456,18 @@ class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
         mock_connection = AsyncMock()
         _active_connections[call_id] = (mock_connection, 101, 10, phone_number_id)
 
-        payload = {
-            "object": "whatsapp_business_account",
-            "entry": [
-                {
-                    "changes": [
-                        {
-                            "field": "calls",
-                            "value": {
-                                "metadata": {"phone_number_id": phone_number_id},
-                                "calls": [{"id": call_id, "event": "terminate"}],
-                            },
-                        }
-                    ]
-                }
-            ],
-        }
+        payload = _build_webhook_payload(
+            calls=[{"id": call_id, "event": "terminate"}],
+            phone_number_id=phone_number_id,
+        )
+        request = _build_request(payload)  # No signature or secret
+        mock_config = _build_mock_config(phone_number_id=phone_number_id, app_secret="test_app_secret")
 
-        body_bytes = json.dumps(payload).encode("utf-8")
-        mock_config = MagicMock()
-        mock_config.credentials = {
-            "phone_number_id": phone_number_id,
-            "app_secret": "test_app_secret",
-        }
-
-        async def mock_receive():
-            return {"type": "http.request", "body": body_bytes}
-
-        scope = {
-            "type": "http",
-            "method": "POST",
-            "headers": [(b"content-type", b"application/json")],
-        }
-        request = Request(scope, receive=mock_receive)
-
-        with patch.object(db_client, "async_session") as mock_session_ctx:
-            mock_session = AsyncMock()
-            mock_session_ctx.return_value.__aenter__.return_value = mock_session
-            config_result = MagicMock()
-            config_result.scalars.return_value.first.return_value = mock_config
-            mock_session.execute.return_value = config_result
-
+        with patch.object(
+            db_client,
+            "get_whatsapp_configuration_by_phone_number_id",
+            AsyncMock(return_value=mock_config),
+        ):
             with self.assertRaises(HTTPException) as ctx:
                 await handle_whatsapp_webhook(request)
 
@@ -448,50 +483,18 @@ class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
         mock_connection = AsyncMock()
         _active_connections[call_id] = (mock_connection, 101, 10, phone_number_id)
 
-        payload = {
-            "object": "whatsapp_business_account",
-            "entry": [
-                {
-                    "changes": [
-                        {
-                            "field": "calls",
-                            "value": {
-                                "metadata": {"phone_number_id": phone_number_id},
-                                "calls": [{"id": call_id, "event": "terminate"}],
-                            },
-                        }
-                    ]
-                }
-            ],
-        }
+        payload = _build_webhook_payload(
+            calls=[{"id": call_id, "event": "terminate"}],
+            phone_number_id=phone_number_id,
+        )
+        request = _build_request(payload, signature="sha256=forged_signature_digest")
+        mock_config = _build_mock_config(phone_number_id=phone_number_id, app_secret="test_app_secret")
 
-        body_bytes = json.dumps(payload).encode("utf-8")
-        mock_config = MagicMock()
-        mock_config.credentials = {
-            "phone_number_id": phone_number_id,
-            "app_secret": "test_app_secret",
-        }
-
-        async def mock_receive():
-            return {"type": "http.request", "body": body_bytes}
-
-        scope = {
-            "type": "http",
-            "method": "POST",
-            "headers": [
-                (b"content-type", b"application/json"),
-                (b"x-hub-signature-256", b"sha256=forged_signature_digest"),
-            ],
-        }
-        request = Request(scope, receive=mock_receive)
-
-        with patch.object(db_client, "async_session") as mock_session_ctx:
-            mock_session = AsyncMock()
-            mock_session_ctx.return_value.__aenter__.return_value = mock_session
-            config_result = MagicMock()
-            config_result.scalars.return_value.first.return_value = mock_config
-            mock_session.execute.return_value = config_result
-
+        with patch.object(
+            db_client,
+            "get_whatsapp_configuration_by_phone_number_id",
+            AsyncMock(return_value=mock_config),
+        ):
             with self.assertRaises(HTTPException) as ctx:
                 await handle_whatsapp_webhook(request)
 
@@ -499,3 +502,35 @@ class TestWhatsAppInboundCalling(IsolatedAsyncioTestCase):
             self.assertEqual(ctx.exception.detail, "Invalid webhook signature")
             mock_connection.disconnect.assert_not_called()
             self.assertIn(call_id, _active_connections)
+
+    async def test_webhook_terminate_publishes_to_redis(self):
+        """Verify POST /webhook publishes terminate event to Redis pub/sub."""
+        call_id = "call_redis_pub"
+        phone_number_id = "123"
+        app_secret = "test_app_secret"
+
+        payload = _build_webhook_payload(
+            calls=[{"id": call_id, "event": "terminate"}],
+            phone_number_id=phone_number_id,
+        )
+        request = _build_request(payload, app_secret=app_secret)
+        mock_config = _build_mock_config(phone_number_id=phone_number_id, app_secret=app_secret)
+        mock_redis = AsyncMock()
+
+        with patch.object(
+            db_client,
+            "get_whatsapp_configuration_by_phone_number_id",
+            AsyncMock(return_value=mock_config),
+        ), patch(
+            "api.services.telephony.providers.whatsapp.routes._get_redis",
+            AsyncMock(return_value=mock_redis),
+        ), patch.object(
+            db_client,
+            "get_workflow_run_by_call_id",
+            AsyncMock(return_value=None),
+        ):
+            response = await handle_whatsapp_webhook(request)
+            self.assertEqual(response, {"status": "success"})
+            mock_redis.publish.assert_awaited_once()
+            mock_redis.delete.assert_awaited_once_with(f"whatsapp:call:{call_id}")
+

--- a/api/tests/telephony/whatsapp/test_provider.py
+++ b/api/tests/telephony/whatsapp/test_provider.py
@@ -564,6 +564,13 @@ class TestWhatsAppConfigurationDisplayAndMerge(IsolatedAsyncioTestCase):
         self.assertEqual(request_dict["app_secret"], "secret_app_secret_value")
         self.assertEqual(request_dict["webhook_verify_token"], "secret_verify_token_value")
 
+        # The round-trip has to carry the non-sensitive settings too. The save
+        # path replaces credentials wholesale, so a flag that GET drops (or that
+        # the response schema stops declaring) would come back as the request
+        # schema's default and silently overwrite what is stored.
+        self.assertIs(request_dict["business_initiated_calls_enabled"], True)
+        self.assertEqual(request_dict["call_icon_visibility"], "business_hours")
+
     def test_preserve_masked_fields_accepts_new_secrets_when_updated(self):
         """When user provides a new real secret, it is not overwritten by existing value."""
         from api.routes.organization import _get_model_fields_set_paths

--- a/api/tests/telephony/whatsapp/test_provider.py
+++ b/api/tests/telephony/whatsapp/test_provider.py
@@ -163,7 +163,16 @@ class TestWhatsAppProvider(IsolatedAsyncioTestCase):
             {"object": "whatsapp_business_account"}, {}
         ))
         self.assertTrue(WhatsAppProvider.can_handle_webhook(
+            {"entry": [{"changes": [{"field": "calls"}]}]}, {}
+        ))
+        self.assertTrue(WhatsAppProvider.can_handle_webhook(
+            {"entry": [{"changes": [{"value": {"messaging_product": "whatsapp"}}]}]}, {}
+        ))
+        self.assertFalse(WhatsAppProvider.can_handle_webhook(
             {"entry": [{"changes": []}]}, {}
+        ))
+        self.assertFalse(WhatsAppProvider.can_handle_webhook(
+            {"entry": [{"changes": [{"field": "feed"}]}]}, {}
         ))
         self.assertFalse(WhatsAppProvider.can_handle_webhook(
             {"something_else": True}, {}
@@ -206,6 +215,31 @@ class TestWhatsAppProvider(IsolatedAsyncioTestCase):
         self.assertEqual(res.direction, "inbound")
         self.assertEqual(res.call_status, "ringing")
         self.assertEqual(res.account_id, "test_phone_id")
+
+        # Also test with 'calls' array format
+        calls_array_webhook = {
+            "entry": [{
+                "changes": [{
+                    "field": "calls",
+                    "value": {
+                        "metadata": {
+                            "display_phone_number": "+15551234567",
+                            "phone_number_id": "test_phone_id",
+                        },
+                        "calls": [{
+                            "id": "call_id_999",
+                            "direction": "inbound",
+                            "from": "+15559876543",
+                            "to": "+15551234567",
+                            "status": "ringing",
+                        }],
+                    },
+                }],
+            }],
+        }
+        res_arr = WhatsAppProvider.parse_inbound_webhook(calls_array_webhook)
+        self.assertEqual(res_arr.provider, "whatsapp")
+        self.assertEqual(res_arr.call_id, "call_id_999")
 
     async def test_normalize_inbound_data_converts_whatsapp_webhook_to_standard_format(self):
         """Test WhatsApp webhook payloads convert to NormalizedInboundData."""
@@ -309,10 +343,12 @@ class TestWhatsAppProvider(IsolatedAsyncioTestCase):
             ("queued", TelephonyCallStatus.INITIATED),
             ("ringing", TelephonyCallStatus.RINGING),
             ("in-progress", TelephonyCallStatus.IN_PROGRESS),
+            ("answered", TelephonyCallStatus.ANSWERED),
             ("completed", TelephonyCallStatus.COMPLETED),
             ("failed", TelephonyCallStatus.FAILED),
             ("busy", TelephonyCallStatus.BUSY),
             ("no-answer", TelephonyCallStatus.NO_ANSWER),
+            ("canceled", TelephonyCallStatus.CANCELED),
             ("permission_requested", TelephonyCallStatus.INITIATED),
             ("permission_denied", TelephonyCallStatus.FAILED),
         ]
@@ -331,6 +367,15 @@ class TestWhatsAppProvider(IsolatedAsyncioTestCase):
         res = WhatsAppProvider.generate_error_response("ERR", "Something failed")
         self.assertIsInstance(res, Response)
         self.assertEqual(res.media_type, "application/json")
+
+    def test_generate_validation_error_response(self):
+        """Test generating validation error response."""
+        res = WhatsAppProvider.generate_validation_error_response("AUTH_FAILED")
+        self.assertIsInstance(res, Response)
+        self.assertEqual(res.media_type, "application/json")
+        body = json.loads(res.body.decode())
+        self.assertEqual(body["error"], "AUTH_FAILED")
+        self.assertIn("message", body)
 
     async def test_get_available_phone_numbers_direct(self):
         """Test fetching available phone numbers via direct phone number query."""
@@ -432,4 +477,39 @@ class TestWhatsAppProvider(IsolatedAsyncioTestCase):
         ):
             res = await provider.validate_phone_number("+15559999999")
             self.assertFalse(res.ok)
+
+    async def test_create_whatsapp_transport_success(self):
+        """Test create_transport constructs a valid FastAPIWebsocketTransport with 48 kHz audio config."""
+        from api.services.pipecat.audio_config import AudioConfig
+        from api.services.telephony.providers.whatsapp.transport import create_transport
+
+        mock_websocket = MagicMock()
+        audio_config = AudioConfig(
+            transport_in_sample_rate=48000,
+            transport_out_sample_rate=48000,
+            pipeline_in_sample_rate=16000,
+            pipeline_out_sample_rate=24000,
+        )
+        mock_credentials = {
+            "access_token": "valid_token",
+            "phone_number_id": "12345",
+        }
+
+        with patch(
+            "api.services.telephony.providers.whatsapp.transport.load_credentials_for_transport",
+            AsyncMock(return_value=mock_credentials),
+        ), patch(
+            "api.services.telephony.providers.whatsapp.transport.build_audio_out_mixer",
+            AsyncMock(return_value=None),
+        ):
+            transport = await create_transport(
+                websocket=mock_websocket,
+                workflow_run_id=101,
+                audio_config=audio_config,
+                organization_id=10,
+                call_id="call_test_123",
+            )
+            self.assertIsNotNone(transport)
+            self.assertEqual(transport._params.audio_in_sample_rate, 48000)
+            self.assertEqual(transport._params.audio_out_sample_rate, 48000)
 

--- a/api/tests/telephony/whatsapp/test_provider.py
+++ b/api/tests/telephony/whatsapp/test_provider.py
@@ -550,10 +550,15 @@ class TestWhatsAppConfigurationDisplayAndMerge(IsolatedAsyncioTestCase):
 
     def test_preserve_masked_fields_restores_stored_secrets_when_masked(self):
         """When UI submits masked secrets back, stored unmasked values are restored."""
-        displayed = self._credentials_for_display("whatsapp", self.stored)
-        request_dict = dict(displayed)
+        from api.routes.organization import _get_model_fields_set_paths
+        from api.services.telephony.providers.whatsapp.config import WhatsAppConfigurationRequest
 
-        self.preserve_masked_fields("whatsapp", request_dict, self.stored)
+        displayed = self._credentials_for_display("whatsapp", self.stored)
+        req = WhatsAppConfigurationRequest.model_validate(displayed)
+        request_dict = req.model_dump()
+        fields_set = _get_model_fields_set_paths(req)
+
+        self.preserve_masked_fields("whatsapp", request_dict, self.stored, fields_set=fields_set)
 
         self.assertEqual(request_dict["access_token"], "secret_access_token_value")
         self.assertEqual(request_dict["app_secret"], "secret_app_secret_value")
@@ -561,15 +566,19 @@ class TestWhatsAppConfigurationDisplayAndMerge(IsolatedAsyncioTestCase):
 
     def test_preserve_masked_fields_accepts_new_secrets_when_updated(self):
         """When user provides a new real secret, it is not overwritten by existing value."""
-        request_dict = {
-            "provider": "whatsapp",
+        from api.routes.organization import _get_model_fields_set_paths
+        from api.services.telephony.providers.whatsapp.config import WhatsAppConfigurationRequest
+
+        req = WhatsAppConfigurationRequest.model_validate({
             "phone_number_id": "106540352242922",
             "access_token": "new_rotated_access_token",
             "app_secret": "new_rotated_app_secret",
             "webhook_verify_token": "new_rotated_verify_token",
-        }
+        })
+        request_dict = req.model_dump()
+        fields_set = _get_model_fields_set_paths(req)
 
-        self.preserve_masked_fields("whatsapp", request_dict, self.stored)
+        self.preserve_masked_fields("whatsapp", request_dict, self.stored, fields_set=fields_set)
 
         self.assertEqual(request_dict["access_token"], "new_rotated_access_token")
         self.assertEqual(request_dict["app_secret"], "new_rotated_app_secret")
@@ -577,6 +586,10 @@ class TestWhatsAppConfigurationDisplayAndMerge(IsolatedAsyncioTestCase):
 
     def test_preserve_masked_fields_allows_clearing_optional_secrets(self):
         """When an optional sensitive credential is set to None or empty, it is not restored."""
+        from api.routes.organization import _get_model_fields_set_paths
+        from api.services.configuration.masking import mask_key
+        from api.services.telephony.providers.vonage.config import VonageConfigurationRequest
+
         stored_vonage = {
             "api_key": "k1",
             "api_secret": "secret_key_12345",
@@ -584,10 +597,16 @@ class TestWhatsAppConfigurationDisplayAndMerge(IsolatedAsyncioTestCase):
             "private_key": "private_key_data_here",
             "signature_secret": "existing_sig_secret",
         }
-        displayed = self._credentials_for_display("vonage", stored_vonage)
-        request_dict = dict(displayed)
-        request_dict["signature_secret"] = None  # user explicitly cleared
-        self.preserve_masked_fields("vonage", request_dict, stored_vonage)
+        req = VonageConfigurationRequest.model_validate({
+            "api_key": "k1",
+            "api_secret": mask_key(stored_vonage["api_secret"]),
+            "application_id": "app1",
+            "private_key": mask_key(stored_vonage["private_key"]),
+            "signature_secret": None,  # user explicitly cleared
+        })
+        request_dict = req.model_dump()
+        fields_set = _get_model_fields_set_paths(req)
+        self.preserve_masked_fields("vonage", request_dict, stored_vonage, fields_set=fields_set)
         self.assertEqual(request_dict["api_secret"], "secret_key_12345")
         self.assertEqual(request_dict["private_key"], "private_key_data_here")
         self.assertIsNone(request_dict["signature_secret"])
@@ -606,6 +625,7 @@ class TestWhatsAppConfigurationDisplayAndMerge(IsolatedAsyncioTestCase):
 
     def test_whatsapp_configuration_request_accepts_masked_values_for_update(self):
         """WhatsAppConfigurationRequest accepts masked values populated by edit dialog."""
+        from api.routes.organization import _get_model_fields_set_paths
         from api.services.telephony.providers.whatsapp.config import WhatsAppConfigurationRequest
 
         displayed = self._credentials_for_display("whatsapp", self.stored)
@@ -613,7 +633,8 @@ class TestWhatsAppConfigurationDisplayAndMerge(IsolatedAsyncioTestCase):
         self.assertTrue(req.access_token.startswith("****"))
 
         req_dict = req.model_dump()
-        self.preserve_masked_fields("whatsapp", req_dict, self.stored)
+        fields_set = _get_model_fields_set_paths(req)
+        self.preserve_masked_fields("whatsapp", req_dict, self.stored, fields_set=fields_set)
         self.assertEqual(req_dict["access_token"], "secret_access_token_value")
         self.assertEqual(req_dict["app_secret"], "secret_app_secret_value")
 

--- a/api/tests/telephony/whatsapp/test_provider.py
+++ b/api/tests/telephony/whatsapp/test_provider.py
@@ -617,4 +617,61 @@ class TestWhatsAppConfigurationDisplayAndMerge(IsolatedAsyncioTestCase):
         self.assertEqual(req_dict["access_token"], "secret_access_token_value")
         self.assertEqual(req_dict["app_secret"], "secret_app_secret_value")
 
+    def test_preserve_masked_fields_preserves_omitted_secrets_on_partial_update(self):
+        """When an update omits an optional sensitive field, stored value is preserved."""
+        from api.routes.organization import _get_model_fields_set_paths
+        from api.services.configuration.masking import mask_key
+        from api.services.telephony.providers.vonage.config import VonageConfigurationRequest
+
+        stored_vonage = {
+            "api_key": "k1",
+            "api_secret": "secret_key_12345",
+            "application_id": "app1",
+            "private_key": "private_key_data_here",
+            "signature_secret": "existing_sig_secret",
+        }
+        # Update payload omits signature_secret
+        req = VonageConfigurationRequest.model_validate({
+            "api_key": "k1",
+            "api_secret": mask_key(stored_vonage["api_secret"]),
+            "application_id": "app1",
+            "private_key": mask_key(stored_vonage["private_key"]),
+        })
+        fields_set = _get_model_fields_set_paths(req)
+        request_dict = req.model_dump()
+        self.assertNotIn("signature_secret", fields_set)
+        self.assertIsNone(request_dict["signature_secret"])
+
+        self.preserve_masked_fields("vonage", request_dict, stored_vonage, fields_set=fields_set)
+        self.assertEqual(request_dict["signature_secret"], "existing_sig_secret")
+        self.assertEqual(request_dict["api_secret"], "secret_key_12345")
+
+    def test_preserve_masked_fields_allows_explicit_null_clearing_with_fields_set(self):
+        """When signature_secret is explicitly set to None, it is not restored."""
+        from api.routes.organization import _get_model_fields_set_paths
+        from api.services.configuration.masking import mask_key
+        from api.services.telephony.providers.vonage.config import VonageConfigurationRequest
+
+        stored_vonage = {
+            "api_key": "k1",
+            "api_secret": "secret_key_12345",
+            "application_id": "app1",
+            "private_key": "private_key_data_here",
+            "signature_secret": "existing_sig_secret",
+        }
+        req = VonageConfigurationRequest.model_validate({
+            "api_key": "k1",
+            "api_secret": mask_key(stored_vonage["api_secret"]),
+            "application_id": "app1",
+            "private_key": mask_key(stored_vonage["private_key"]),
+            "signature_secret": None,
+        })
+        fields_set = _get_model_fields_set_paths(req)
+        request_dict = req.model_dump()
+        self.assertIn("signature_secret", fields_set)
+
+        self.preserve_masked_fields("vonage", request_dict, stored_vonage, fields_set=fields_set)
+        self.assertIsNone(request_dict["signature_secret"])
+        self.assertEqual(request_dict["api_secret"], "secret_key_12345")
+
 

--- a/api/tests/telephony/whatsapp/test_provider.py
+++ b/api/tests/telephony/whatsapp/test_provider.py
@@ -1,0 +1,435 @@
+"""WhatsApp provider tests."""
+
+import hashlib
+import hmac
+import json
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import HTTPException
+from fastapi.responses import Response
+
+from api.enums import TelephonyCallStatus
+from api.services.telephony.base import NormalizedInboundData
+from api.services.telephony.providers.whatsapp.provider import WhatsAppProvider
+
+
+def _provider(**kwargs) -> WhatsAppProvider:
+    """Create a test WhatsApp provider with minimal configuration."""
+    default_config = {
+        "access_token": "test_token",
+        "phone_number_id": "test_phone_id",
+        "webhook_verify_token": "test_verify_token",
+        "app_secret": "test_secret",
+        "from_numbers": ["+15551234567"],
+    }
+    default_config.update(kwargs)
+    return WhatsAppProvider(default_config)
+
+
+class TestWhatsAppProvider(IsolatedAsyncioTestCase):
+    """Test suite for WhatsAppProvider implementation."""
+
+    async def test_initialization_with_valid_config(self):
+        """Test provider initializes correctly with valid configuration."""
+        provider = _provider(
+            access_token="test_token",
+            phone_number_id="test_phone_id",
+            webhook_verify_token="test_verify_token",
+            app_secret="test_secret",
+        )
+        self.assertEqual(provider.access_token, "test_token")
+        self.assertEqual(provider.phone_number_id, "test_phone_id")
+        self.assertEqual(provider.PROVIDER_NAME, "whatsapp")
+        self.assertTrue(provider.validate_config())
+
+    async def test_initialization_with_missing_required_fields(self):
+        """Test provider fails initialization with missing required fields."""
+        with self.assertRaises(ValueError):
+            WhatsAppProvider({
+                "access_token": "test_token"
+                # Missing phone_number_id, webhook_verify_token, app_secret
+            })
+
+    async def test_initialization_with_missing_phone_number_id(self):
+        """Test provider fails initialization with missing phone_number_id."""
+        with self.assertRaisesRegex(ValueError, "phone_number_id"):
+            _provider(phone_number_id="")
+
+    async def test_initialization_with_missing_app_secret(self):
+        """Test provider fails initialization with missing app_secret."""
+        with self.assertRaisesRegex(ValueError, "app_secret"):
+            _provider(app_secret="")
+
+    async def test_initialization_with_missing_webhook_verify_token(self):
+        """Test provider fails initialization with missing webhook_verify_token."""
+        with self.assertRaisesRegex(ValueError, "webhook_verify_token"):
+            _provider(webhook_verify_token="")
+
+    async def test_initiate_call_raises_under_development(self):
+        """Test initiate_call raises HTTPException indicating outbound is under development."""
+        provider = _provider()
+        with self.assertRaises(HTTPException) as ctx:
+            await provider.initiate_call(
+                to_number="+15551234567",
+                webhook_url="https://example.test/webhook",
+                workflow_run_id=123,
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("under development", ctx.exception.detail)
+
+    def test_whatsapp_setup_checklist_blocks_outbound(self):
+        """Test WhatsApp setup checklist resolver explicitly reports outbound is blocked/under development."""
+        from api.services.telephony.providers.whatsapp import _whatsapp_setup_checklist
+        from api.services.telephony.registry import ConfigurationSetupState
+
+        checklist = _whatsapp_setup_checklist(
+            {},
+            ConfigurationSetupState(
+                active_phone_number_count=1,
+                inbound_routed_phone_number_count=1,
+                enabled_trunk_count=0,
+                unassigned_active_phone_number_count=0,
+            ),
+        )
+        self.assertFalse(checklist.ready_for_outbound)
+        self.assertIn("under development", checklist.outbound_blocked_reason)
+
+    async def test_request_call_permission_payload(self):
+        """Test _request_call_permission constructs correct payload with messaging_product."""
+        provider = _provider(business_initiated_calls_enabled=True)
+        captured_payload = {}
+
+        class DummyResponse:
+            status = 200
+            async def json(self):
+                return {"id": "call_999", "status": "permission_requested"}
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+
+        class DummySession:
+            def post(self, url, headers=None, json=None):
+                nonlocal captured_payload
+                captured_payload = json
+                return DummyResponse()
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+
+        with patch("aiohttp.ClientSession", return_value=DummySession()):
+            res = await provider._request_call_permission(
+                to_number="+15551234567",
+                workflow_run_id=789,
+            )
+            self.assertEqual(res["id"], "call_999")
+            self.assertEqual(captured_payload.get("messaging_product"), "whatsapp")
+            self.assertEqual(captured_payload.get("to"), "15551234567")
+            self.assertEqual(captured_payload.get("biz_opaque_callback_data"), "789")
+
+    async def test_supports_transfers_is_false(self):
+        """Test WhatsApp provider indicates it does not support transfers."""
+        provider = _provider()
+        self.assertFalse(provider.supports_transfers())
+
+    async def test_transfer_call_returns_failure(self):
+        """Test transfer_call returns failed status."""
+        provider = _provider()
+        res = await provider.transfer_call(
+            destination="+15551234567",
+            transfer_id="transfer_123",
+            conference_name="conf_123",
+        )
+        self.assertEqual(res["status"], "failed")
+        self.assertEqual(res["provider"], "whatsapp")
+
+    async def test_get_call_cost_returns_default(self):
+        """Test get_call_cost returns default 0 cost."""
+        provider = _provider()
+        cost = await provider.get_call_cost("call_123")
+        self.assertEqual(cost["cost_usd"], 0.0)
+
+    async def test_configure_inbound(self):
+        """Test configure_inbound returns ok status."""
+        provider = _provider()
+        result = await provider.configure_inbound("+15551234567", "https://example.com/webhook")
+        self.assertTrue(result.ok)
+
+    async def test_can_handle_webhook(self):
+        """Test webhook detection for whatsapp."""
+        self.assertTrue(WhatsAppProvider.can_handle_webhook(
+            {"object": "whatsapp_business_account"}, {}
+        ))
+        self.assertTrue(WhatsAppProvider.can_handle_webhook(
+            {"entry": [{"changes": []}]}, {}
+        ))
+        self.assertFalse(WhatsAppProvider.can_handle_webhook(
+            {"something_else": True}, {}
+        ))
+
+    async def test_validate_account_id(self):
+        """Test matching inbound webhook by phone_number_id."""
+        config = {"phone_number_id": "phone_123"}
+        self.assertTrue(WhatsAppProvider.validate_account_id(config, "phone_123"))
+        self.assertFalse(WhatsAppProvider.validate_account_id(config, "other_id"))
+        self.assertFalse(WhatsAppProvider.validate_account_id(config, ""))
+
+    async def test_parse_inbound_webhook(self):
+        """Test parsing inbound webhook payload into NormalizedInboundData."""
+        whatsapp_webhook = {
+            "entry": [{
+                "changes": [{
+                    "field": "calls",
+                    "value": {
+                        "metadata": {
+                            "display_phone_number": "+15551234567",
+                            "phone_number_id": "test_phone_id",
+                        },
+                        "call": {
+                            "id": "call_id_123",
+                            "direction": "inbound",
+                            "from": "+15559876543",
+                            "to": "+15551234567",
+                            "status": "ringing",
+                        },
+                    },
+                }],
+            }],
+        }
+        res = WhatsAppProvider.parse_inbound_webhook(whatsapp_webhook)
+        self.assertEqual(res.provider, "whatsapp")
+        self.assertEqual(res.call_id, "call_id_123")
+        self.assertEqual(res.from_number, "+15559876543")
+        self.assertEqual(res.to_number, "+15551234567")
+        self.assertEqual(res.direction, "inbound")
+        self.assertEqual(res.call_status, "ringing")
+        self.assertEqual(res.account_id, "test_phone_id")
+
+    async def test_normalize_inbound_data_converts_whatsapp_webhook_to_standard_format(self):
+        """Test WhatsApp webhook payloads convert to NormalizedInboundData."""
+        provider = _provider()
+        whatsapp_webhook = {
+            "entry": [{
+                "changes": [{
+                    "field": "calls",
+                    "value": {
+                        "display_phone_number": "+15551234567",
+                        "call": {
+                            "id": "call_id_123",
+                            "direction": "inbound",
+                            "from": "+15559876543",
+                            "to": "+15551234567",
+                            "status": "ringing",
+                        },
+                    },
+                }],
+            }],
+        }
+        result = provider.normalize_inbound_data(whatsapp_webhook)
+        self.assertEqual(result.provider, "whatsapp")
+        self.assertEqual(result.call_id, "call_id_123")
+        self.assertEqual(result.from_number, "+15559876543")
+        self.assertEqual(result.to_number, "+15551234567")
+        self.assertEqual(result.direction, "inbound")
+        self.assertEqual(result.call_status, "ringing")
+
+    async def test_normalize_inbound_data_handles_missing_call_id(self):
+        """Test normalization fails when call_id is missing."""
+        provider = _provider()
+        whatsapp_webhook = {
+            "entry": [{
+                "changes": [{
+                    "field": "calls",
+                    "value": {
+                        "call": {
+                            "direction": "inbound",
+                            "from": "+15559876543",
+                        },
+                    },
+                }],
+            }],
+        }
+        with self.assertRaisesRegex(ValueError, "Missing call_id"):
+            provider.normalize_inbound_data(whatsapp_webhook)
+
+    async def test_normalize_inbound_data_handles_invalid_structure(self):
+        """Test normalization fails with invalid webhook structure."""
+        provider = _provider()
+        invalid_webhook = {"invalid": "structure"}
+        with self.assertRaisesRegex(ValueError, "Invalid webhook data structure"):
+            provider.normalize_inbound_data(invalid_webhook)
+
+    async def test_verify_inbound_signature(self):
+        """Test inbound signature verification with HMAC-SHA256."""
+        secret = "my_app_secret"
+        provider = _provider(app_secret=secret)
+        body = '{"entry": []}'
+        expected_sig = hmac.new(
+            secret.encode("utf-8"), body.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+
+        # Valid signature
+        headers = {"x-hub-signature-256": f"sha256={expected_sig}"}
+        self.assertTrue(
+            await provider.verify_inbound_signature(
+                url="https://example.com/webhook",
+                webhook_data={},
+                headers=headers,
+                body=body,
+            )
+        )
+
+        # Invalid signature
+        bad_headers = {"x-hub-signature-256": "sha256=invalid_digest"}
+        self.assertFalse(
+            await provider.verify_inbound_signature(
+                url="https://example.com/webhook",
+                webhook_data={},
+                headers=bad_headers,
+                body=body,
+            )
+        )
+
+        # Missing header
+        self.assertFalse(
+            await provider.verify_inbound_signature(
+                url="https://example.com/webhook",
+                webhook_data={},
+                headers={},
+                body=body,
+            )
+        )
+
+    def test_map_whatsapp_status_to_dograh(self):
+        """Test WhatsApp call statuses map correctly to Dograh TelephonyCallStatus."""
+        provider = _provider()
+        status_mappings = [
+            ("queued", TelephonyCallStatus.INITIATED),
+            ("ringing", TelephonyCallStatus.RINGING),
+            ("in-progress", TelephonyCallStatus.IN_PROGRESS),
+            ("completed", TelephonyCallStatus.COMPLETED),
+            ("failed", TelephonyCallStatus.FAILED),
+            ("busy", TelephonyCallStatus.BUSY),
+            ("no-answer", TelephonyCallStatus.NO_ANSWER),
+            ("permission_requested", TelephonyCallStatus.INITIATED),
+            ("permission_denied", TelephonyCallStatus.FAILED),
+        ]
+        for whatsapp_status, expected_dograh_status in status_mappings:
+            result = provider._map_whatsapp_status_to_dograh(whatsapp_status)
+            self.assertEqual(result, expected_dograh_status, f"Failed for {whatsapp_status}")
+
+    def test_map_whatsapp_status_unknown_maps_to_error(self):
+        """Test unknown WhatsApp status maps to ERROR."""
+        provider = _provider()
+        result = provider._map_whatsapp_status_to_dograh("unknown_status")
+        self.assertEqual(result, TelephonyCallStatus.ERROR)
+
+    def test_generate_error_response(self):
+        """Test generating error response."""
+        res = WhatsAppProvider.generate_error_response("ERR", "Something failed")
+        self.assertIsInstance(res, Response)
+        self.assertEqual(res.media_type, "application/json")
+
+    async def test_get_available_phone_numbers_direct(self):
+        """Test fetching available phone numbers via direct phone number query."""
+        provider = _provider()
+
+        class DummyResponse:
+            def __init__(self, status, payload):
+                self.status = status
+                self._payload = payload
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+            async def json(self):
+                return self._payload
+
+            async def text(self):
+                return json.dumps(self._payload)
+
+        class DummySession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+            def get(self, url, **kwargs):
+                if url.endswith("/test_phone_id"):
+                    return DummyResponse(200, {
+                        "display_phone_number": "+1 555-123-4567",
+                        "verified_name": "Test Business",
+                    })
+                return DummyResponse(404, {})
+
+        with patch("aiohttp.ClientSession", return_value=DummySession()):
+            numbers = await provider.get_available_phone_numbers()
+            self.assertEqual(numbers, ["+15551234567"])
+
+    async def test_get_available_phone_numbers_fallback_edge(self):
+        """Test fetching numbers from /phone_numbers edge when direct query has no number."""
+        provider = _provider()
+
+        class DummyResponse:
+            def __init__(self, status, payload):
+                self.status = status
+                self._payload = payload
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+            async def json(self):
+                return self._payload
+
+            async def text(self):
+                return json.dumps(self._payload)
+
+        class DummySession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+            def get(self, url, **kwargs):
+                if url.endswith("/test_phone_id"):
+                    return DummyResponse(400, {"error": "Not a phone number ID"})
+                elif "test_phone_id/phone_numbers" in url:
+                    return DummyResponse(200, {
+                        "data": [
+                            {"display_phone_number": "+1 555-987-6543"},
+                        ]
+                    })
+                return DummyResponse(404, {})
+
+        with patch("aiohttp.ClientSession", return_value=DummySession()):
+            numbers = await provider.get_available_phone_numbers()
+            self.assertEqual(numbers, ["+15559876543"])
+
+    async def test_validate_phone_number_success(self):
+        """Test validate_phone_number returns ok when number is owned."""
+        provider = _provider()
+        with patch.object(
+            provider, "get_available_phone_numbers", AsyncMock(return_value=["+15551234567"])
+        ):
+            res = await provider.validate_phone_number("+1 (555) 123-4567")
+            self.assertTrue(res.ok)
+
+    async def test_validate_phone_number_not_owned(self):
+        """Test validate_phone_number returns ok=False when number is not owned."""
+        provider = _provider()
+        with patch.object(
+            provider, "get_available_phone_numbers", AsyncMock(return_value=["+15551234567"])
+        ):
+            res = await provider.validate_phone_number("+15559999999")
+            self.assertFalse(res.ok)
+

--- a/api/tests/telephony/whatsapp/test_provider.py
+++ b/api/tests/telephony/whatsapp/test_provider.py
@@ -479,16 +479,15 @@ class TestWhatsAppProvider(IsolatedAsyncioTestCase):
             self.assertFalse(res.ok)
 
     async def test_create_whatsapp_transport_success(self):
-        """Test create_transport constructs a valid FastAPIWebsocketTransport with 48 kHz audio config."""
+        """Test create_transport constructs a valid FastAPIWebsocketTransport with 16 kHz audio config."""
         from api.services.pipecat.audio_config import AudioConfig
         from api.services.telephony.providers.whatsapp.transport import create_transport
 
         mock_websocket = MagicMock()
         audio_config = AudioConfig(
-            transport_in_sample_rate=48000,
-            transport_out_sample_rate=48000,
-            pipeline_in_sample_rate=16000,
-            pipeline_out_sample_rate=24000,
+            transport_in_sample_rate=16000,
+            transport_out_sample_rate=16000,
+            pipeline_sample_rate=16000,
         )
         mock_credentials = {
             "access_token": "valid_token",
@@ -510,6 +509,6 @@ class TestWhatsAppProvider(IsolatedAsyncioTestCase):
                 call_id="call_test_123",
             )
             self.assertIsNotNone(transport)
-            self.assertEqual(transport._params.audio_in_sample_rate, 48000)
-            self.assertEqual(transport._params.audio_out_sample_rate, 48000)
+            self.assertEqual(transport._params.audio_in_sample_rate, 16000)
+            self.assertEqual(transport._params.audio_out_sample_rate, 16000)
 

--- a/api/tests/telephony/whatsapp/test_provider.py
+++ b/api/tests/telephony/whatsapp/test_provider.py
@@ -559,22 +559,6 @@ class TestWhatsAppConfigurationDisplayAndMerge(IsolatedAsyncioTestCase):
         self.assertEqual(request_dict["app_secret"], "secret_app_secret_value")
         self.assertEqual(request_dict["webhook_verify_token"], "secret_verify_token_value")
 
-    def test_preserve_masked_fields_restores_stored_secrets_when_omitted_or_empty(self):
-        """When UI or client omits secrets or submits empty string on update, stored values are preserved."""
-        request_dict = {
-            "provider": "whatsapp",
-            "phone_number_id": "106540352242922",
-            "access_token": None,
-            "app_secret": "",
-            "webhook_verify_token": None,
-        }
-
-        self.preserve_masked_fields("whatsapp", request_dict, self.stored)
-
-        self.assertEqual(request_dict["access_token"], "secret_access_token_value")
-        self.assertEqual(request_dict["app_secret"], "secret_app_secret_value")
-        self.assertEqual(request_dict["webhook_verify_token"], "secret_verify_token_value")
-
     def test_preserve_masked_fields_accepts_new_secrets_when_updated(self):
         """When user provides a new real secret, it is not overwritten by existing value."""
         request_dict = {
@@ -590,5 +574,47 @@ class TestWhatsAppConfigurationDisplayAndMerge(IsolatedAsyncioTestCase):
         self.assertEqual(request_dict["access_token"], "new_rotated_access_token")
         self.assertEqual(request_dict["app_secret"], "new_rotated_app_secret")
         self.assertEqual(request_dict["webhook_verify_token"], "new_rotated_verify_token")
+
+    def test_preserve_masked_fields_allows_clearing_optional_secrets(self):
+        """When an optional sensitive credential is set to None or empty, it is not restored."""
+        stored_vonage = {
+            "api_key": "k1",
+            "api_secret": "secret_key_12345",
+            "application_id": "app1",
+            "private_key": "private_key_data_here",
+            "signature_secret": "existing_sig_secret",
+        }
+        displayed = self._credentials_for_display("vonage", stored_vonage)
+        request_dict = dict(displayed)
+        request_dict["signature_secret"] = None  # user explicitly cleared
+        self.preserve_masked_fields("vonage", request_dict, stored_vonage)
+        self.assertEqual(request_dict["api_secret"], "secret_key_12345")
+        self.assertEqual(request_dict["private_key"], "private_key_data_here")
+        self.assertIsNone(request_dict["signature_secret"])
+
+    def test_whatsapp_configuration_request_requires_fields(self):
+        """WhatsAppConfigurationRequest enforces all required credential fields directly."""
+        from api.services.telephony.providers.whatsapp.config import WhatsAppConfigurationRequest
+        from pydantic import ValidationError
+
+        with self.assertRaises(ValidationError) as ctx:
+            WhatsAppConfigurationRequest(phone_number_id="12345")
+        errors = {e["loc"][0] for e in ctx.exception.errors()}
+        self.assertIn("access_token", errors)
+        self.assertIn("app_secret", errors)
+        self.assertIn("webhook_verify_token", errors)
+
+    def test_whatsapp_configuration_request_accepts_masked_values_for_update(self):
+        """WhatsAppConfigurationRequest accepts masked values populated by edit dialog."""
+        from api.services.telephony.providers.whatsapp.config import WhatsAppConfigurationRequest
+
+        displayed = self._credentials_for_display("whatsapp", self.stored)
+        req = WhatsAppConfigurationRequest(**displayed)
+        self.assertTrue(req.access_token.startswith("****"))
+
+        req_dict = req.model_dump()
+        self.preserve_masked_fields("whatsapp", req_dict, self.stored)
+        self.assertEqual(req_dict["access_token"], "secret_access_token_value")
+        self.assertEqual(req_dict["app_secret"], "secret_app_secret_value")
 
 

--- a/api/tests/telephony/whatsapp/test_provider.py
+++ b/api/tests/telephony/whatsapp/test_provider.py
@@ -512,3 +512,83 @@ class TestWhatsAppProvider(IsolatedAsyncioTestCase):
             self.assertEqual(transport._params.audio_in_sample_rate, 16000)
             self.assertEqual(transport._params.audio_out_sample_rate, 16000)
 
+
+class TestWhatsAppConfigurationDisplayAndMerge(IsolatedAsyncioTestCase):
+    """Test credential masking and edit-merge preservation for WhatsApp configurations."""
+
+    def setUp(self):
+        from api.routes.organization import _credentials_for_display, preserve_masked_fields
+        self._credentials_for_display = _credentials_for_display
+        self.preserve_masked_fields = preserve_masked_fields
+
+        self.stored = {
+            "provider": "whatsapp",
+            "phone_number_id": "106540352242922",
+            "access_token": "secret_access_token_value",
+            "app_secret": "secret_app_secret_value",
+            "webhook_verify_token": "secret_verify_token_value",
+            "business_initiated_calls_enabled": True,
+            "call_icon_visibility": "business_hours",
+        }
+
+    def test_credentials_for_display_masks_secrets_without_dropping_them(self):
+        """Display credentials must include access_token and app_secret in masked form."""
+        displayed = self._credentials_for_display("whatsapp", self.stored)
+
+        self.assertEqual(displayed["provider"], "whatsapp")
+        self.assertEqual(displayed["phone_number_id"], "106540352242922")
+        self.assertTrue(displayed["business_initiated_calls_enabled"])
+        self.assertEqual(displayed["call_icon_visibility"], "business_hours")
+
+        # Secrets must be present and masked (not equal to original secret)
+        self.assertIn("access_token", displayed)
+        self.assertIn("app_secret", displayed)
+        self.assertIn("webhook_verify_token", displayed)
+        self.assertNotEqual(displayed["access_token"], "secret_access_token_value")
+        self.assertNotEqual(displayed["app_secret"], "secret_app_secret_value")
+        self.assertNotEqual(displayed["webhook_verify_token"], "secret_verify_token_value")
+
+    def test_preserve_masked_fields_restores_stored_secrets_when_masked(self):
+        """When UI submits masked secrets back, stored unmasked values are restored."""
+        displayed = self._credentials_for_display("whatsapp", self.stored)
+        request_dict = dict(displayed)
+
+        self.preserve_masked_fields("whatsapp", request_dict, self.stored)
+
+        self.assertEqual(request_dict["access_token"], "secret_access_token_value")
+        self.assertEqual(request_dict["app_secret"], "secret_app_secret_value")
+        self.assertEqual(request_dict["webhook_verify_token"], "secret_verify_token_value")
+
+    def test_preserve_masked_fields_restores_stored_secrets_when_omitted_or_empty(self):
+        """When UI or client omits secrets or submits empty string on update, stored values are preserved."""
+        request_dict = {
+            "provider": "whatsapp",
+            "phone_number_id": "106540352242922",
+            "access_token": None,
+            "app_secret": "",
+            "webhook_verify_token": None,
+        }
+
+        self.preserve_masked_fields("whatsapp", request_dict, self.stored)
+
+        self.assertEqual(request_dict["access_token"], "secret_access_token_value")
+        self.assertEqual(request_dict["app_secret"], "secret_app_secret_value")
+        self.assertEqual(request_dict["webhook_verify_token"], "secret_verify_token_value")
+
+    def test_preserve_masked_fields_accepts_new_secrets_when_updated(self):
+        """When user provides a new real secret, it is not overwritten by existing value."""
+        request_dict = {
+            "provider": "whatsapp",
+            "phone_number_id": "106540352242922",
+            "access_token": "new_rotated_access_token",
+            "app_secret": "new_rotated_app_secret",
+            "webhook_verify_token": "new_rotated_verify_token",
+        }
+
+        self.preserve_masked_fields("whatsapp", request_dict, self.stored)
+
+        self.assertEqual(request_dict["access_token"], "new_rotated_access_token")
+        self.assertEqual(request_dict["app_secret"], "new_rotated_app_secret")
+        self.assertEqual(request_dict["webhook_verify_token"], "new_rotated_verify_token")
+
+

--- a/api/tests/telephony/whatsapp/test_routes.py
+++ b/api/tests/telephony/whatsapp/test_routes.py
@@ -1,0 +1,48 @@
+"""Regression tests for WhatsApp webhook verification."""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from fastapi.responses import PlainTextResponse
+
+from api.services.telephony.providers.whatsapp.routes import (
+    handle_webhook_verification,
+    router,
+)
+
+
+class TestWhatsAppRoutes(IsolatedAsyncioTestCase):
+    def test_whatsapp_webhook_route_path_is_webhook(self):
+        paths = [route.path for route in router.routes if getattr(route, "path", None)]
+        self.assertIn("/webhook", paths)
+
+    async def test_whatsapp_webhook_verification_returns_plain_text_challenge(self):
+        with patch(
+            "api.services.telephony.providers.whatsapp.routes.WHATSAPP_WEBHOOK_VERIFY_TOKEN",
+            "verify-me",
+        ):
+            response = await handle_webhook_verification(
+                hub_mode="subscribe",
+                hub_verify_token="verify-me",
+                hub_challenge="123456789",
+            )
+
+        self.assertIsInstance(response, PlainTextResponse)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.body, b"123456789")
+
+    async def test_whatsapp_webhook_verification_rejects_bad_token(self):
+        with patch(
+            "api.services.telephony.providers.whatsapp.routes.WHATSAPP_WEBHOOK_VERIFY_TOKEN",
+            "verify-me",
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                await handle_webhook_verification(
+                    hub_mode="subscribe",
+                    hub_verify_token="wrong-token",
+                    hub_challenge="123456789",
+                )
+
+        self.assertEqual(ctx.exception.status_code, 403)
+        self.assertEqual(ctx.exception.detail, "Invalid verification token")

--- a/api/tests/telephony/whatsapp/test_routes.py
+++ b/api/tests/telephony/whatsapp/test_routes.py
@@ -15,7 +15,7 @@ from api.services.telephony.providers.whatsapp.routes import (
 class TestWhatsAppRoutes(IsolatedAsyncioTestCase):
     def test_whatsapp_webhook_route_path_is_webhook(self):
         paths = [route.path for route in router.routes if getattr(route, "path", None)]
-        self.assertIn("/webhook", paths)
+        self.assertIn("/whatsapp/webhook", paths)
 
     async def test_whatsapp_webhook_verification_returns_plain_text_challenge(self):
         with patch(

--- a/api/tests/telephony/whatsapp/test_routes.py
+++ b/api/tests/telephony/whatsapp/test_routes.py
@@ -1,7 +1,7 @@
 """Regression tests for WhatsApp webhook verification."""
 
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import HTTPException
 from fastapi.responses import PlainTextResponse
@@ -36,6 +36,9 @@ class TestWhatsAppRoutes(IsolatedAsyncioTestCase):
         with patch(
             "api.services.telephony.providers.whatsapp.routes.WHATSAPP_WEBHOOK_VERIFY_TOKEN",
             "verify-me",
+        ), patch(
+            "api.services.telephony.providers.whatsapp.routes.db_client.get_whatsapp_configuration_by_verify_token",
+            AsyncMock(return_value=None),
         ):
             with self.assertRaises(HTTPException) as ctx:
                 await handle_webhook_verification(
@@ -46,3 +49,23 @@ class TestWhatsAppRoutes(IsolatedAsyncioTestCase):
 
         self.assertEqual(ctx.exception.status_code, 403)
         self.assertEqual(ctx.exception.detail, "Invalid verification token")
+
+    async def test_whatsapp_webhook_verification_matches_db_token(self):
+        mock_config = MagicMock()
+        mock_config.id = 42
+        with patch(
+            "api.services.telephony.providers.whatsapp.routes.WHATSAPP_WEBHOOK_VERIFY_TOKEN",
+            "",
+        ), patch(
+            "api.services.telephony.providers.whatsapp.routes.db_client.get_whatsapp_configuration_by_verify_token",
+            AsyncMock(return_value=mock_config),
+        ):
+            response = await handle_webhook_verification(
+                hub_mode="subscribe",
+                hub_verify_token="db-verify-token",
+                hub_challenge="challenge-from-db",
+            )
+
+        self.assertIsInstance(response, PlainTextResponse)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.body, b"challenge-from-db")

--- a/api/tests/telephony/whatsapp/test_sync.py
+++ b/api/tests/telephony/whatsapp/test_sync.py
@@ -60,6 +60,7 @@ class TestPhoneNumberSyncLifecycle(IsolatedAsyncioTestCase):
     async def test_sync_handles_unparseable_address_without_crashing(self):
         """Unparseable addresses returned by provider are skipped, and do not crash building discovered set."""
         mock_provider = MagicMock()
+        mock_provider.is_full_inventory = True
         mock_provider.get_available_phone_number_records = AsyncMock(
             return_value=[
                 {"address": "   "},
@@ -201,33 +202,6 @@ class TestPhoneNumberSyncLifecycle(IsolatedAsyncioTestCase):
             self.assertTrue(status.ok)
             # update_phone_number must NOT be called for deactivation
             mock_update.assert_not_called()
-
-
-class TestAtomicWorkflowRunFailure(IsolatedAsyncioTestCase):
-    async def test_update_workflow_run_skips_if_already_completed(self):
-        """When only_if_incomplete=True and run is already completed, update_workflow_run does not overwrite."""
-        mock_run = MagicMock()
-        mock_run.id = 101
-        mock_run.is_completed = True
-        mock_run.state = "completed"
-
-        mock_session = AsyncMock()
-        mock_session_ctx = AsyncMock()
-        mock_session_ctx.__aenter__.return_value = mock_session
-        mock_session_ctx.__aexit__.return_value = None
-
-        exec_res = MagicMock()
-        exec_res.scalars.return_value.first.return_value = mock_run
-        mock_session.execute = AsyncMock(return_value=exec_res)
-
-        with patch.object(db_client, "async_session", return_value=mock_session_ctx):
-            result = await db_client.update_workflow_run(
-                run_id=101,
-                state="failed",
-                only_if_incomplete=True,
-            )
-            self.assertEqual(result.state, "completed")
-            mock_session.commit.assert_not_awaited()
 
 
 class TestWhatsAppWABADiscovery(IsolatedAsyncioTestCase):

--- a/api/tests/telephony/whatsapp/test_sync.py
+++ b/api/tests/telephony/whatsapp/test_sync.py
@@ -1,0 +1,294 @@
+"""Tests for WhatsApp phone number sync and configuration deduplication."""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from api.db import db_client
+from api.services.telephony.phone_number_sync import (
+    sync_available_phone_numbers_for_config,
+)
+
+
+class TestWhatsAppConfigDeduplication(IsolatedAsyncioTestCase):
+    async def test_get_whatsapp_config_multiple_phone_rows_same_config_deduplicated(self):
+        """When multiple phone rows on the SAME config carry the phone_number_id, it is NOT ambiguous."""
+        mock_config = MagicMock()
+        mock_config.id = 10
+
+        mock_session = AsyncMock()
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__.return_value = mock_session
+        mock_session_ctx.__aexit__.return_value = None
+
+        res1 = MagicMock()
+        res1.scalars.return_value.all.return_value = []
+        res2 = MagicMock()
+        res2.scalars.return_value.all.return_value = [mock_config, mock_config]
+
+        mock_session.execute = AsyncMock(side_effect=[res1, res2])
+
+        with patch.object(db_client, "async_session", return_value=mock_session_ctx):
+            config = await db_client.get_whatsapp_configuration_by_phone_number_id("12345")
+            self.assertIsNotNone(config)
+            self.assertEqual(config.id, 10)
+
+    async def test_get_whatsapp_config_multiple_different_configs_rejected_as_ambiguous(self):
+        """When multiple DIFFERENT configs carry the phone_number_id, it IS rejected as ambiguous."""
+        mock_config_1 = MagicMock()
+        mock_config_1.id = 10
+        mock_config_2 = MagicMock()
+        mock_config_2.id = 20
+
+        mock_session = AsyncMock()
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__.return_value = mock_session
+        mock_session_ctx.__aexit__.return_value = None
+
+        res1 = MagicMock()
+        res1.scalars.return_value.all.return_value = []
+        res2 = MagicMock()
+        res2.scalars.return_value.all.return_value = [mock_config_1, mock_config_2]
+
+        mock_session.execute = AsyncMock(side_effect=[res1, res2])
+
+        with patch.object(db_client, "async_session", return_value=mock_session_ctx):
+            config = await db_client.get_whatsapp_configuration_by_phone_number_id("12345")
+            self.assertIsNone(config)
+
+
+class TestPhoneNumberSyncLifecycle(IsolatedAsyncioTestCase):
+    async def test_sync_handles_unparseable_address_without_crashing(self):
+        """Unparseable addresses returned by provider are skipped, and do not crash building discovered set."""
+        mock_provider = MagicMock()
+        mock_provider.get_available_phone_number_records = AsyncMock(
+            return_value=[
+                {"address": "   "},
+                {"address": "+15551234567"},
+            ]
+        )
+
+        with patch(
+            "api.services.telephony.phone_number_sync.get_telephony_provider_by_id",
+            AsyncMock(return_value=mock_provider),
+        ), patch.object(
+            db_client, "list_phone_numbers_for_config", AsyncMock(return_value=[])
+        ), patch.object(
+            db_client,
+            "get_telephony_configuration",
+            AsyncMock(return_value=MagicMock(provider="whatsapp", credentials={})),
+        ), patch(
+            "api.services.telephony.phone_number_sync.assert_no_inbound_routing_conflict",
+            AsyncMock(),
+        ), patch.object(
+            db_client, "create_phone_number", AsyncMock()
+        ) as mock_create:
+            status = await sync_available_phone_numbers_for_config(1, 100)
+            self.assertTrue(status.ok)
+            self.assertIn("Imported 1 phone number(s)", status.message)
+            self.assertIn("Skipped 1 duplicate or invalid", status.message)
+            mock_create.assert_awaited_once()
+
+    async def test_sync_reactivates_inactive_returned_row(self):
+        """When an inactive number reappears in provider results, it is reactivated."""
+        inactive_row = MagicMock()
+        inactive_row.id = 55
+        inactive_row.address_normalized = "+15551234567"
+        inactive_row.is_active = False
+        inactive_row.extra_metadata = {}
+
+        mock_provider = MagicMock()
+        mock_provider.get_available_phone_number_records = AsyncMock(
+            return_value=[{"address": "+15551234567"}]
+        )
+
+        with patch(
+            "api.services.telephony.phone_number_sync.get_telephony_provider_by_id",
+            AsyncMock(return_value=mock_provider),
+        ), patch.object(
+            db_client,
+            "list_phone_numbers_for_config",
+            AsyncMock(return_value=[inactive_row]),
+        ), patch.object(
+            db_client,
+            "get_telephony_configuration",
+            AsyncMock(return_value=MagicMock(provider="whatsapp", credentials={})),
+        ), patch.object(
+            db_client, "update_phone_number", AsyncMock()
+        ) as mock_update:
+            status = await sync_available_phone_numbers_for_config(1, 100)
+            self.assertTrue(status.ok)
+            mock_update.assert_awaited_once_with(
+                phone_number_id=55,
+                telephony_configuration_id=1,
+                is_active=True,
+            )
+
+    async def test_sync_deactivates_stale_row_and_clears_default_caller_id(self):
+        """When a stale row with default caller ID is deactivated, is_default_caller_id is cleared."""
+        stale_default_row = MagicMock()
+        stale_default_row.id = 77
+        stale_default_row.address_normalized = "+15559999999"
+        stale_default_row.is_active = True
+        stale_default_row.is_default_caller_id = True
+
+        mock_provider = MagicMock()
+        mock_provider.get_available_phone_number_records = AsyncMock(
+            return_value=[{"address": "+15551234567"}]
+        )
+
+        with patch(
+            "api.services.telephony.phone_number_sync.get_telephony_provider_by_id",
+            AsyncMock(return_value=mock_provider),
+        ), patch.object(
+            db_client,
+            "list_phone_numbers_for_config",
+            AsyncMock(return_value=[stale_default_row]),
+        ), patch.object(
+            db_client,
+            "get_telephony_configuration",
+            AsyncMock(return_value=MagicMock(provider="whatsapp", credentials={})),
+        ), patch(
+            "api.services.telephony.phone_number_sync.assert_no_inbound_routing_conflict",
+            AsyncMock(),
+        ), patch.object(
+            db_client, "create_phone_number", AsyncMock()
+        ), patch.object(
+            db_client, "update_phone_number", AsyncMock()
+        ) as mock_update:
+            status = await sync_available_phone_numbers_for_config(1, 100)
+            self.assertTrue(status.ok)
+            mock_update.assert_awaited_once_with(
+                phone_number_id=77,
+                telephony_configuration_id=1,
+                is_active=False,
+                is_default_caller_id=False,
+            )
+
+    async def test_sync_does_not_deactivate_when_is_full_inventory_false(self):
+        """When provider discovery is partial (is_full_inventory=False), valid local numbers are NOT deactivated."""
+        active_row = MagicMock()
+        active_row.id = 88
+        active_row.address_normalized = "+15559999999"
+        active_row.is_active = True
+        active_row.is_default_caller_id = False
+
+        mock_provider = MagicMock()
+        mock_provider.is_full_inventory = False
+        mock_provider.get_available_phone_number_records = AsyncMock(
+            return_value=[{"address": "+15551234567"}]
+        )
+
+        with patch(
+            "api.services.telephony.phone_number_sync.get_telephony_provider_by_id",
+            AsyncMock(return_value=mock_provider),
+        ), patch.object(
+            db_client,
+            "list_phone_numbers_for_config",
+            AsyncMock(return_value=[active_row]),
+        ), patch.object(
+            db_client,
+            "get_telephony_configuration",
+            AsyncMock(return_value=MagicMock(provider="whatsapp", credentials={})),
+        ), patch(
+            "api.services.telephony.phone_number_sync.assert_no_inbound_routing_conflict",
+            AsyncMock(),
+        ), patch.object(
+            db_client, "create_phone_number", AsyncMock()
+        ), patch.object(
+            db_client, "update_phone_number", AsyncMock()
+        ) as mock_update:
+            status = await sync_available_phone_numbers_for_config(1, 100)
+            self.assertTrue(status.ok)
+            # update_phone_number must NOT be called for deactivation
+            mock_update.assert_not_called()
+
+
+class TestAtomicWorkflowRunFailure(IsolatedAsyncioTestCase):
+    async def test_update_workflow_run_skips_if_already_completed(self):
+        """When only_if_incomplete=True and run is already completed, update_workflow_run does not overwrite."""
+        mock_run = MagicMock()
+        mock_run.id = 101
+        mock_run.is_completed = True
+        mock_run.state = "completed"
+
+        mock_session = AsyncMock()
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__.return_value = mock_session
+        mock_session_ctx.__aexit__.return_value = None
+
+        exec_res = MagicMock()
+        exec_res.scalars.return_value.first.return_value = mock_run
+        mock_session.execute = AsyncMock(return_value=exec_res)
+
+        with patch.object(db_client, "async_session", return_value=mock_session_ctx):
+            result = await db_client.update_workflow_run(
+                run_id=101,
+                state="failed",
+                only_if_incomplete=True,
+            )
+            self.assertEqual(result.state, "completed")
+            mock_session.commit.assert_not_awaited()
+
+
+class TestWhatsAppWABADiscovery(IsolatedAsyncioTestCase):
+    async def test_whatsapp_provider_discovery_queries_waba_when_present(self):
+        """When direct lookup returns whatsapp_business_account, provider queries WABA /phone_numbers edge."""
+        import json
+        from api.services.telephony.providers.whatsapp.provider import WhatsAppProvider
+
+        provider = WhatsAppProvider({
+            "access_token": "test_token",
+            "phone_number_id": "direct_phone_id",
+            "webhook_verify_token": "test_verify_token",
+            "app_secret": "test_secret",
+        })
+
+        class DummyResponse:
+            def __init__(self, status, payload):
+                self.status = status
+                self._payload = payload
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+            async def json(self):
+                return self._payload
+
+            async def text(self):
+                return json.dumps(self._payload)
+
+        class DummySession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+            def get(self, url, **kwargs):
+                if url.endswith("/direct_phone_id"):
+                    return DummyResponse(200, {
+                        "display_phone_number": "+1 555-123-4567",
+                        "verified_name": "Test Business",
+                        "id": "direct_phone_id",
+                        "whatsapp_business_account": {"id": "waba_999"},
+                    })
+                elif "waba_999/phone_numbers" in url:
+                    return DummyResponse(200, {
+                        "data": [
+                            {"display_phone_number": "+1 555-123-4567", "id": "direct_phone_id"},
+                            {"display_phone_number": "+1 555-987-6543", "id": "second_phone_id"},
+                        ]
+                    })
+                return DummyResponse(404, {})
+
+        with patch("aiohttp.ClientSession", return_value=DummySession()):
+            records = await provider.get_available_phone_number_records()
+            addresses = [r["address"] for r in records]
+            self.assertEqual(len(records), 2)
+            self.assertIn("+15551234567", addresses)
+            self.assertIn("+15559876543", addresses)
+            self.assertTrue(provider.is_full_inventory)
+

--- a/api/tests/test_workflow_run_failure.py
+++ b/api/tests/test_workflow_run_failure.py
@@ -83,3 +83,47 @@ async def test_mark_workflow_run_failed_swallows_enqueue_errors(
 
     mock_db.update_workflow_run.assert_awaited_once()
     enqueue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_mark_workflow_run_failed_skips_enqueue_when_only_if_incomplete_and_already_completed(
+    no_disposition_mapping,
+):
+    enqueue = AsyncMock()
+    with (
+        patch("api.services.workflow_run_failure.db_client") as mock_db,
+        patch("api.tasks.arq.enqueue_job", enqueue),
+    ):
+        mock_db.update_workflow_run = AsyncMock(return_value=None)
+        mock_db.get_organization_id_by_workflow_run_id = AsyncMock(return_value=7)
+
+        await mark_workflow_run_failed(
+            101, "Error after complete", only_if_incomplete=True
+        )
+
+    mock_db.update_workflow_run.assert_awaited_once()
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mark_workflow_run_failed_enqueues_when_only_if_incomplete_and_not_completed(
+    no_disposition_mapping,
+):
+    enqueue = AsyncMock()
+    with (
+        patch("api.services.workflow_run_failure.db_client") as mock_db,
+        patch("api.tasks.arq.enqueue_job", enqueue),
+    ):
+        mock_db.update_workflow_run = AsyncMock(return_value={"id": 101})
+        mock_db.get_organization_id_by_workflow_run_id = AsyncMock(return_value=7)
+
+        await mark_workflow_run_failed(
+            101, "Error on incomplete", only_if_incomplete=True
+        )
+
+    mock_db.update_workflow_run.assert_awaited_once()
+    enqueue.assert_awaited_once_with(
+        FunctionNames.RUN_INTEGRATIONS_POST_WORKFLOW_RUN,
+        101,
+    )
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -156,6 +156,7 @@ services:
       # install only needs PUBLIC_BASE_URL + PUBLIC_HOST in .env.
       PUBLIC_BASE_URL: "${PUBLIC_BASE_URL:-}"
       PUBLIC_HOST: "${PUBLIC_HOST:-}"
+      WHATSAPP_WEBHOOK_VERIFY_TOKEN: "${WHATSAPP_WEBHOOK_VERIFY_TOKEN:-}"
 
       # Optional explicit override of the public URL the backend builds webhook /
       # embed links from. Defaults to PUBLIC_BASE_URL. When the value is non-public

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -4,6 +4,14 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   output: 'standalone',
+  // Skip type-checking and linting during Docker builds to prevent OOM kills.
+  // Type checking is handled separately in CI (tsc --noEmit) and local development.
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   experimental: {
     serverSourceMaps: true,
   },

--- a/ui/src/app/telephony-configurations/[configId]/page.tsx
+++ b/ui/src/app/telephony-configurations/[configId]/page.tsx
@@ -81,8 +81,12 @@ export default function TelephonyConfigurationDetailPage() {
   const { config: appConfig } = useAppConfig();
   const { externalPbxIntegrationsEnabled } = useOrgConfig();
   const organizationTimezone = useOrganizationTimezone();
-  const inboundWebhookUrl = `${resolveWebhookBaseUrl(appConfig?.tunnelUrl)}${INBOUND_WEBHOOK_PATH}`;
   const [config, setConfig] = useState<TelephonyConfigurationDetail | null>(null);
+  const isWhatsApp = config?.provider === "whatsapp";
+  const webhookPath = isWhatsApp
+    ? "/api/v1/telephony/whatsapp/webhook"
+    : INBOUND_WEBHOOK_PATH;
+  const inboundWebhookUrl = `${resolveWebhookBaseUrl(appConfig?.tunnelUrl)}${webhookPath}`;
   // ARI only: Dograh generates the Stasis application name, so the dialplan
   // line cannot be written until the configuration has been saved.
   const stasisAppName =
@@ -160,6 +164,32 @@ export default function TelephonyConfigurationDetailPage() {
       fetchAll();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to set default");
+    }
+  };
+
+  const onSyncMetaPhoneNumbers = async () => {
+    if (!config || config.provider !== "whatsapp") return;
+    try {
+      const token = await getAccessToken();
+      const response = await fetch(
+        `/api/v1/organizations/telephony-configs/${config.id}/sync-phone-numbers`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(
+          payload?.detail ?? payload?.message ?? "Failed to sync phone numbers",
+        );
+      }
+      toast.success(payload?.message ?? "Imported phone numbers from Meta");
+      fetchAll();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to sync phone numbers");
     }
   };
 
@@ -364,23 +394,58 @@ export default function TelephonyConfigurationDetailPage() {
             </div>
           )}
           <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">Inbound webhook URL</p>
+            <p className="text-xs text-muted-foreground">
+              {isWhatsApp ? "Meta callback URL" : "Inbound webhook URL"}
+            </p>
             <button
               type="button"
               onClick={() => {
                 const url = inboundWebhookUrl;
                 copyTextToClipboard(url)
-                  .then(() => toast.success("Inbound webhook URL copied"))
+                  .then(() =>
+                    toast.success(
+                      isWhatsApp ? "Meta callback URL copied" : "Inbound webhook URL copied",
+                    ),
+                  )
                   .catch(() => toast.error("Failed to copy URL"));
               }}
-              title="Click to copy inbound webhook URL"
-              aria-label="Copy inbound webhook URL"
-              className="inline-flex items-center gap-1 self-start rounded font-mono text-xs text-muted-foreground hover:text-foreground"
+              title={isWhatsApp ? "Click to copy Meta callback URL" : "Click to copy inbound webhook URL"}
+              aria-label={isWhatsApp ? "Copy Meta callback URL" : "Copy inbound webhook URL"}
+              className="inline-flex items-center gap-1.5 self-start rounded font-mono text-xs text-muted-foreground hover:text-foreground max-w-full min-w-0"
             >
-              <span className="truncate">{inboundWebhookUrl}</span>
-              <Copy className="h-3 w-3 shrink-0" />
+              <span className="truncate min-w-0">{inboundWebhookUrl}</span>
+              <Copy className="h-3.5 w-3.5 shrink-0" />
             </button>
           </div>
+          {isWhatsApp && (
+            <div className="space-y-1 min-w-0 max-w-full">
+              <p className="text-xs text-muted-foreground">Webhook verify token</p>
+              <button
+                type="button"
+                onClick={() => {
+                  const token = String(
+                    (config?.credentials as Record<string, any>)?.webhook_verify_token || "",
+                  );
+                  copyTextToClipboard(token)
+                    .then(() => toast.success("Webhook verify token copied"))
+                    .catch(() => toast.error("Failed to copy token"));
+                }}
+                title="Click to copy webhook verify token"
+                aria-label="Copy webhook verify token"
+                className="inline-flex items-center gap-1.5 self-start rounded font-mono text-xs text-muted-foreground hover:text-foreground max-w-full min-w-0"
+              >
+                <span className="truncate min-w-0">
+                  {String(
+                    (config?.credentials as Record<string, any>)?.webhook_verify_token || "-",
+                  )}
+                </span>
+                <Copy className="h-3.5 w-3.5 shrink-0" />
+              </button>
+              <p className="text-xs text-muted-foreground mt-1">
+                In Meta App Dashboard (<strong>WhatsApp &gt; Configuration &gt; Edit</strong>): paste the Callback URL and Verify Token, then click <strong>Verify and Save</strong> and subscribe to the <code>calls</code> field.
+              </p>
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -413,30 +478,57 @@ export default function TelephonyConfigurationDetailPage() {
       <Card>
         <CardHeader className="flex flex-row items-start justify-between gap-4">
           <div className="space-y-1">
-            <CardTitle>Phone numbers</CardTitle>
+            <CardTitle>
+              {config.provider === "whatsapp" ? "WhatsApp numbers" : "Phone numbers"}
+            </CardTitle>
             <CardDescription>
-              Numbers used as caller ID for outbound and accepted for inbound matching.
-              SIP URIs and extensions are supported alongside PSTN numbers.{" "}
-              <a
-                href="https://docs.dograh.com/integrations/telephony/inbound"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-0.5 underline"
-              >
-                Inbound docs <ExternalLink className="h-3 w-3" />
-              </a>
+              {config.provider === "whatsapp" ? (
+                <>
+                  Dograh pulls the Meta phone numbers attached to this WhatsApp Business
+                  Account automatically. If nothing shows up yet, use{" "}
+                  <span className="font-medium text-foreground">Refresh from Meta</span>{" "}
+                  after confirming the WhatsApp connection is active.
+                </>
+              ) : (
+                <>
+                  Numbers used as caller ID for outbound and accepted for inbound matching.
+                  SIP URIs and extensions are supported alongside PSTN numbers.{" "}
+                  <a
+                    href="https://docs.dograh.com/integrations/telephony/inbound"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-0.5 underline"
+                  >
+                    Inbound docs <ExternalLink className="h-3 w-3" />
+                  </a>
+                </>
+              )}
             </CardDescription>
           </div>
-          <Button size="sm" onClick={() => openPhoneDialog(null)}>
-            <Plus className="h-4 w-4 mr-2" /> Add phone number
-          </Button>
+          {config.provider === "whatsapp" ? (
+            <Button size="sm" onClick={onSyncMetaPhoneNumbers}>
+              <RotateCcw className="h-4 w-4 mr-2" /> Refresh from Meta
+            </Button>
+          ) : (
+            <Button size="sm" onClick={() => openPhoneDialog(null)}>
+              <Plus className="h-4 w-4 mr-2" /> Add phone number
+            </Button>
+          )}
         </CardHeader>
         <CardContent>
           {phoneNumbers.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No phone numbers yet. Add one to start placing or receiving calls on this
-              configuration.
-            </p>
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">
+                {config.provider === "whatsapp"
+                  ? "No Meta numbers are synced yet. Refresh from Meta once the WhatsApp Business connection is ready."
+                  : "No phone numbers yet. Add one to start placing or receiving calls on this configuration."}
+              </p>
+              {config.provider === "whatsapp" && (
+                <Button variant="outline" size="sm" onClick={onSyncMetaPhoneNumbers}>
+                  <RotateCcw className="h-4 w-4 mr-2" /> Refresh from Meta
+                </Button>
+              )}
+            </div>
           ) : (
             <Table>
               <TableHeader>
@@ -458,20 +550,32 @@ export default function TelephonyConfigurationDetailPage() {
                   <TableRow key={n.id}>
                     <TableCell className="font-mono">{n.address}</TableCell>
                     <TableCell>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          copyTextToClipboard(String(n.id))
-                            .then(() => toast.success("Phone number ID copied"))
-                            .catch(() => toast.error("Failed to copy ID"));
-                        }}
-                        title="Click to copy phone number ID"
-                        aria-label={`Copy phone number ID ${n.id}`}
-                        className="group inline-flex items-center gap-1 rounded font-mono text-xs text-muted-foreground hover:text-foreground"
-                      >
-                        <span>{n.id}</span>
-                        <Copy className="h-3 w-3 shrink-0" />
-                      </button>
+                      {(() => {
+                        const displayId = isWhatsApp
+                          ? String(
+                              n.extra_metadata?.phone_number_id ||
+                                n.extra_metadata?.meta_phone_number_id ||
+                                (config?.credentials as Record<string, any>)?.phone_number_id ||
+                                n.id,
+                            )
+                          : String(n.id);
+                        return (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              copyTextToClipboard(displayId)
+                                .then(() => toast.success("Phone number ID copied"))
+                                .catch(() => toast.error("Failed to copy ID"));
+                            }}
+                            title="Click to copy phone number ID"
+                            aria-label={`Copy phone number ID ${displayId}`}
+                            className="group inline-flex items-center gap-1 rounded font-mono text-xs text-muted-foreground hover:text-foreground"
+                          >
+                            <span>{displayId}</span>
+                            <Copy className="h-3 w-3 shrink-0" />
+                          </button>
+                        );
+                      })()}
                     </TableCell>
                     <TableCell>
                       <Badge variant="outline">{n.address_type}</Badge>
@@ -584,6 +688,7 @@ export default function TelephonyConfigurationDetailPage() {
         open={phoneDialogOpen}
         onOpenChange={setPhoneDialogOpen}
         configId={configId}
+        provider={config?.provider}
         trunks={config?.trunks}
         defaultTrunkId={phoneDefaultTrunkId}
         existing={phoneEditTarget}

--- a/ui/src/app/workflow/[workflowId]/components/PhoneCallDialog.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/PhoneCallDialog.tsx
@@ -39,6 +39,12 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useUserConfig } from "@/context/UserConfigContext";
 import { detailFromError } from "@/lib/apiError";
 
@@ -233,6 +239,7 @@ export const PhoneCallDialog = ({
     const selectedConfig = telephonyConfigs.find(
         (config) => String(config.id) === selectedConfigId,
     );
+    const isWhatsApp = selectedConfig?.provider === "whatsapp";
     const selectedConfigBlocked =
         selectedConfig !== undefined && !isCallable(selectedConfig);
     // Nothing here can place a call: either the org has no configurations, or
@@ -283,6 +290,10 @@ export const PhoneCallDialog = ({
     };
 
     const handleStartCall = async () => {
+        if (isWhatsApp) {
+            setCallError("Outbound calling via WhatsApp is currently under development. Only inbound calling is supported.");
+            return;
+        }
         setCallLoading(true);
         setCallError(null);
         setCallSuccessMsg(null);
@@ -460,20 +471,30 @@ export const PhoneCallDialog = ({
                 <div className="flex flex-col gap-1.5">
                     <Label htmlFor="telephony-config">Telephony configuration</Label>
                     <Select value={selectedConfigId} onValueChange={setSelectedConfigId}>
-                        <SelectTrigger id="telephony-config" className="w-full">
+                        <SelectTrigger id="telephony-config" className="w-full max-w-full overflow-hidden">
                             <SelectValue placeholder="Select a configuration" />
                         </SelectTrigger>
                         <SelectContent>
-                            {telephonyConfigs.map((config) => (
-                                <SelectItem key={config.id} value={String(config.id)}>
-                                    {config.name} ({config.provider})
-                                    {config.is_default_outbound ? " - default" : ""}
-                                    {!isCallable(config) ? " - setup incomplete" : ""}
-                                </SelectItem>
-                            ))}
+                            {telephonyConfigs.map((config) => {
+                                const statusSuffix = !isCallable(config)
+                                    ? config.provider === "whatsapp"
+                                        ? " - inbound only"
+                                        : " - setup incomplete"
+                                    : "";
+                                const label = `${config.name} (${config.provider})${config.is_default_outbound ? " - default" : ""}${statusSuffix}`;
+                                return (
+                                    <SelectItem key={config.id} value={String(config.id)} title={label}>
+                                        <span className="truncate max-w-[380px]">{label}</span>
+                                    </SelectItem>
+                                );
+                            })}
                         </SelectContent>
                     </Select>
-                    {selectedConfigBlocked && (
+                    {isWhatsApp ? (
+                        <p className="text-xs text-amber-600 dark:text-amber-500">
+                            Outbound calling via WhatsApp is currently under development. Only inbound calling is supported.
+                        </p>
+                    ) : selectedConfigBlocked ? (
                         <p className="text-xs text-amber-600 dark:text-amber-500">
                             {selectedConfig?.inactive
                                 ? "This configuration is disabled after repeated connection failures."
@@ -489,7 +510,7 @@ export const PhoneCallDialog = ({
                                 {selectedConfig?.inactive ? "Open configuration" : "Finish setup"}
                             </button>
                         </p>
-                    )}
+                    ) : null}
                 </div>
             )}
             {selectedConfigId && (
@@ -505,16 +526,18 @@ export const PhoneCallDialog = ({
                             value={selectedFromPhoneNumberId}
                             onValueChange={setSelectedFromPhoneNumberId}
                         >
-                            <SelectTrigger id="from-phone-number" className="w-full">
+                            <SelectTrigger id="from-phone-number" className="w-full max-w-full overflow-hidden">
                                 <SelectValue placeholder="Select a phone number" />
                             </SelectTrigger>
                             <SelectContent>
-                                {fromPhoneNumbers.map((phone) => (
-                                    <SelectItem key={phone.id} value={String(phone.id)}>
-                                        {phone.label ? `${phone.label} - ${phone.address}` : phone.address}
-                                        {phone.is_default_caller_id ? " - default" : ""}
-                                    </SelectItem>
-                                ))}
+                                {fromPhoneNumbers.map((phone) => {
+                                    const label = `${phone.label ? `${phone.label} - ${phone.address}` : phone.address}${phone.is_default_caller_id ? " - default" : ""}`;
+                                    return (
+                                        <SelectItem key={phone.id} value={String(phone.id)} title={label}>
+                                            <span className="truncate max-w-[380px]">{label}</span>
+                                        </SelectItem>
+                                    );
+                                })}
                             </SelectContent>
                         </Select>
                     ) : selectedConfigBlocked ? (
@@ -541,6 +564,8 @@ export const PhoneCallDialog = ({
                     defaultCountry="in"
                     value={phoneNumber}
                     onChange={handlePhoneInputChange}
+                    className="w-full"
+                    inputClassName="!w-full !bg-transparent !text-foreground !border-input"
                 />
             )}
             <button
@@ -565,12 +590,36 @@ export const PhoneCallDialog = ({
                         <Button variant="outline">Cancel</Button>
                     </DialogClose>
                     {!callSuccessMsg ? (
-                        <Button
-                            onClick={handleStartCall}
-                            disabled={callLoading || !phoneNumber || selectedConfigBlocked}
-                        >
-                            {callLoading ? "Calling..." : "Start Call"}
-                        </Button>
+                        isWhatsApp ? (
+                            <TooltipProvider>
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <span
+                                            tabIndex={0}
+                                            className="inline-block cursor-not-allowed"
+                                            title="Outbound calling via WhatsApp is currently under development. Only inbound calling is supported."
+                                        >
+                                            <Button
+                                                disabled
+                                                className="pointer-events-none"
+                                            >
+                                                Start Call
+                                            </Button>
+                                        </span>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="top" className="max-w-xs text-center">
+                                        Outbound calling via WhatsApp is currently under development. Only inbound calling is supported.
+                                    </TooltipContent>
+                                </Tooltip>
+                            </TooltipProvider>
+                        ) : (
+                            <Button
+                                onClick={handleStartCall}
+                                disabled={callLoading || !phoneNumber || selectedConfigBlocked}
+                            >
+                                {callLoading ? "Calling..." : "Start Call"}
+                            </Button>
+                        )
                     ) : (
                         <>
                             <Button variant="outline" onClick={() => { setCallSuccessMsg(null); setCallError(null); }}>
@@ -583,8 +632,8 @@ export const PhoneCallDialog = ({
                     )}
                 </div>
             </DialogFooter>
-            {callError && <div className="text-red-500 text-sm mt-2">{callError}</div>}
-            {callSuccessMsg && <div className="text-green-600 text-sm mt-2">{callSuccessMsg}</div>}
+            {callError && <div className="text-red-500 text-sm mt-2 break-all break-words max-w-full">{callError}</div>}
+            {callSuccessMsg && <div className="text-green-600 text-sm mt-2 break-all break-words max-w-full">{callSuccessMsg}</div>}
         </>
     );
 

--- a/ui/src/app/workflow/[workflowId]/components/PhoneCallDialog.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/PhoneCallDialog.tsx
@@ -257,11 +257,7 @@ export const PhoneCallDialog = ({
     );
     const needsPhoneService =
         needsConfiguration === true ||
-        (hasNonWhatsAppPendingOutbound &&
-            !telephonyConfigs.some(isCallable) &&
-            telephonyConfigs.some(
-                (config) => !config.inactive && config.is_ready_for_outbound === false,
-            ));
+        (hasNonWhatsAppPendingOutbound && !telephonyConfigs.some(isCallable));
 
     const goToConfiguration = (target?: { configId?: number; add?: boolean }) => {
         onOpenChange(false);

--- a/ui/src/app/workflow/[workflowId]/components/PhoneCallDialog.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/PhoneCallDialog.tsx
@@ -246,12 +246,18 @@ export const PhoneCallDialog = ({
     // the ones it has are still waiting on the customer's own carrier. An org
     // whose only configurations are *inactive* or intentionally inbound-only
     // (such as WhatsApp) falls through to the form rather than getting setup instructions.
-    const hasConfiguredWhatsApp = telephonyConfigs.some(
-        (config) => !config.inactive && config.provider === "whatsapp",
+    // Suppress setup guidance only when every not-yet-callable non-inactive config
+    // is WhatsApp (inbound-only). If there are non-WhatsApp configs awaiting carrier
+    // setup, still surface the pointer to finish outbound configuration.
+    const hasNonWhatsAppPendingOutbound = telephonyConfigs.some(
+        (config) =>
+            !config.inactive &&
+            config.provider !== "whatsapp" &&
+            config.is_ready_for_outbound === false,
     );
     const needsPhoneService =
         needsConfiguration === true ||
-        (!hasConfiguredWhatsApp &&
+        (hasNonWhatsAppPendingOutbound &&
             !telephonyConfigs.some(isCallable) &&
             telephonyConfigs.some(
                 (config) => !config.inactive && config.is_ready_for_outbound === false,

--- a/ui/src/app/workflow/[workflowId]/components/PhoneCallDialog.tsx
+++ b/ui/src/app/workflow/[workflowId]/components/PhoneCallDialog.tsx
@@ -244,11 +244,15 @@ export const PhoneCallDialog = ({
         selectedConfig !== undefined && !isCallable(selectedConfig);
     // Nothing here can place a call: either the org has no configurations, or
     // the ones it has are still waiting on the customer's own carrier. An org
-    // whose only configurations are *inactive* is a different problem, so it
-    // falls through to the form rather than getting setup instructions.
+    // whose only configurations are *inactive* or intentionally inbound-only
+    // (such as WhatsApp) falls through to the form rather than getting setup instructions.
+    const hasConfiguredWhatsApp = telephonyConfigs.some(
+        (config) => !config.inactive && config.provider === "whatsapp",
+    );
     const needsPhoneService =
         needsConfiguration === true ||
-        (!telephonyConfigs.some(isCallable) &&
+        (!hasConfiguredWhatsApp &&
+            !telephonyConfigs.some(isCallable) &&
             telephonyConfigs.some(
                 (config) => !config.inactive && config.is_ready_for_outbound === false,
             ));
@@ -471,7 +475,7 @@ export const PhoneCallDialog = ({
                 <div className="flex flex-col gap-1.5">
                     <Label htmlFor="telephony-config">Telephony configuration</Label>
                     <Select value={selectedConfigId} onValueChange={setSelectedConfigId}>
-                        <SelectTrigger id="telephony-config" className="w-full max-w-full overflow-hidden">
+                        <SelectTrigger id="telephony-config" className="w-full max-w-full overflow-hidden min-w-0 [&>span]:truncate [&>span]:min-w-0">
                             <SelectValue placeholder="Select a configuration" />
                         </SelectTrigger>
                         <SelectContent>
@@ -526,7 +530,7 @@ export const PhoneCallDialog = ({
                             value={selectedFromPhoneNumberId}
                             onValueChange={setSelectedFromPhoneNumberId}
                         >
-                            <SelectTrigger id="from-phone-number" className="w-full max-w-full overflow-hidden">
+                            <SelectTrigger id="from-phone-number" className="w-full max-w-full overflow-hidden min-w-0 [&>span]:truncate [&>span]:min-w-0">
                                 <SelectValue placeholder="Select a phone number" />
                             </SelectTrigger>
                             <SelectContent>

--- a/ui/src/components/lead-forms/HireExpertNudge.tsx
+++ b/ui/src/components/lead-forms/HireExpertNudge.tsx
@@ -71,7 +71,7 @@ export function HireExpertNudge({ workflowId }: HireExpertNudgeProps) {
     <div
       role="status"
       aria-live="polite"
-      className="fixed bottom-6 right-6 z-50 flex max-w-xs items-center gap-3 rounded-lg border border-primary bg-background p-3 shadow-lg animate-in fade-in slide-in-from-bottom-2"
+      className="fixed bottom-6 right-6 z-40 flex max-w-xs items-center gap-3 rounded-lg border border-primary bg-background p-3 shadow-lg animate-in fade-in slide-in-from-bottom-2"
     >
       <button type="button" onClick={handleClick} className="flex flex-1 items-center gap-3 text-left">
         <UserRound className="h-5 w-5 shrink-0 text-primary" />

--- a/ui/src/components/telephony/ConfigFormDialog.tsx
+++ b/ui/src/components/telephony/ConfigFormDialog.tsx
@@ -39,6 +39,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { detailFromError } from "@/lib/apiError";
 import { useAuth } from "@/lib/auth";
 import { copyTextToClipboard } from "@/lib/clipboard";
+import { useAppConfig } from "@/context/AppConfigContext";
+import { resolveWebhookBaseUrl } from "@/lib/webhookUrl";
+import { cn } from "@/lib/utils";
 
 interface ConfigFormDialogProps {
   open: boolean;
@@ -105,11 +108,14 @@ export function ConfigFormDialog({
   onSaved,
 }: ConfigFormDialogProps) {
   const { user, getAccessToken } = useAuth();
+  const { config: appConfig } = useAppConfig();
+  const whatsappWebhookUrl = `${resolveWebhookBaseUrl(appConfig?.tunnelUrl)}/api/v1/telephony/whatsapp/webhook`;
   const [providers, setProviders] = useState<TelephonyProviderMetadata[]>([]);
   const [providerName, setProviderName] = useState<string>("");
   const [name, setName] = useState<string>("");
   const [isDefault, setIsDefault] = useState<boolean>(false);
   const [values, setValues] = useState<FieldValues>({});
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState<boolean>(false);
 
   const isEdit = !!existing;
@@ -157,8 +163,20 @@ export function ConfigFormDialog({
       } else {
         setIsDefault(suggestDefaultOutbound);
         if (list.length > 0 && !providerName) {
-          setProviderName(list[0].provider);
-          setValues({});
+          const defaultProvider = list[0].provider;
+          setProviderName(defaultProvider);
+          if (defaultProvider === "whatsapp") {
+            const randomToken =
+              "dograh_wa_" +
+              Math.random().toString(36).substring(2, 10) +
+              Math.random().toString(36).substring(2, 10);
+            setValues({
+              webhook_verify_token: randomToken,
+              call_icon_visibility: "enabled",
+            });
+          } else {
+            setValues({});
+          }
         }
       }
     })();
@@ -168,10 +186,27 @@ export function ConfigFormDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, existing, user, getAccessToken]);
 
-  // When provider changes during create, clear field values.
+  // When provider changes during create, set initial field values.
   useEffect(() => {
-    if (!isEdit) setValues({});
+    if (!isEdit) {
+      if (providerName === "whatsapp") {
+        const randomToken =
+          "dograh_wa_" +
+          Math.random().toString(36).substring(2, 10) +
+          Math.random().toString(36).substring(2, 10);
+        setValues({
+          webhook_verify_token: randomToken,
+          call_icon_visibility: "enabled",
+        });
+      } else {
+        setValues({});
+      }
+    }
   }, [providerName, isEdit]);
+
+  useEffect(() => {
+    if (!open) setFieldErrors({});
+  }, [open]);
 
   const updateField = (fieldName: string, value: FieldValue) => {
     setValues((prev) => {
@@ -183,14 +218,55 @@ export function ConfigFormDialog({
       }
       return next;
     });
+    setFieldErrors((prev) => {
+      if (!prev[fieldName]) return prev;
+      const next = { ...prev };
+      delete next[fieldName];
+      return next;
+    });
+  };
+
+  const isFieldMissing = (
+    field: TelephonyProviderMetadata["fields"][number],
+    value: FieldValue,
+  ) =>
+    field.required &&
+    field.type !== "readonly" &&
+    (value === undefined || value === null || value === "");
+
+  const fieldLabelByName = (fieldName: string) => {
+    if (fieldName === "name") return "Name";
+    return currentProvider?.fields.find((field) => field.name === fieldName)?.label ?? fieldName;
   };
 
   const handleSubmit = async () => {
     if (!currentProvider) return;
+    const nextFieldErrors: Record<string, string> = {};
+    const missingFields: string[] = [];
+
     if (!isEdit && !name.trim()) {
-      toast.error("Name is required");
+      nextFieldErrors.name = "Required";
+      missingFields.push("Name");
+    }
+
+    for (const field of visibleFields) {
+      if (isFieldMissing(field, values[field.name])) {
+        nextFieldErrors[field.name] = "Required";
+        missingFields.push(field.label);
+      }
+    }
+
+    if (missingFields.length > 0) {
+      setFieldErrors(nextFieldErrors);
+      toast.error(
+        missingFields.length === 1
+          ? `${missingFields[0]} is required`
+          : `Please fill in: ${missingFields.join(", ")}`,
+      );
       return;
     }
+
+    setFieldErrors({});
 
     setSubmitting(true);
     try {
@@ -229,7 +305,12 @@ export function ConfigFormDialog({
       onOpenChange(false);
       onSaved();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to save");
+      const message = err instanceof Error ? err.message : "Failed to save";
+      toast.error(
+        message.includes("Field required Field required")
+          ? "Please fill in all required fields."
+          : message,
+      );
     } finally {
       setSubmitting(false);
     }
@@ -275,8 +356,20 @@ export function ConfigFormDialog({
               id="cfg-name"
               placeholder="e.g. Twilio US prod"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => {
+                setName(e.target.value);
+                setFieldErrors((prev) => {
+                  if (!prev.name) return prev;
+                  const next = { ...prev };
+                  delete next.name;
+                  return next;
+                });
+              }}
+              className={cn(fieldErrors.name && "border-destructive focus-visible:ring-destructive")}
             />
+            {fieldErrors.name && (
+              <p className="text-xs text-destructive">Name is required.</p>
+            )}
           </div>
 
           <div className="space-y-2">
@@ -330,12 +423,42 @@ export function ConfigFormDialog({
           )}
 
           {currentProvider && (
-            <div className="space-y-3 border-t pt-3">
+            <div className="space-y-3 border-t pt-3 min-w-0 w-full">
               {visibleFields.map((field, index) => (
-                <div className="space-y-1" key={field.name}>
+                <div className="space-y-1 min-w-0 w-full" key={field.name}>
                   {field.section && field.section !== visibleFields[index - 1]?.section && (
-                    <div className="pb-2 pt-3">
+                    <div className="pb-1 pt-3">
                       <h3 className="text-sm font-semibold">{field.section}</h3>
+                    </div>
+                  )}
+                  {providerName === "whatsapp" && field.name === "webhook_verify_token" && (
+                    <div className="space-y-1 min-w-0 w-full pb-1">
+                      <Label htmlFor="cfg-callback-url">Callback URL</Label>
+                      <div className="relative flex items-center w-full min-w-0">
+                        <Input
+                          id="cfg-callback-url"
+                          readOnly
+                          value={whatsappWebhookUrl}
+                          className="pr-10 font-mono text-xs bg-muted/30 select-all cursor-default w-full min-w-0 truncate"
+                          title={whatsappWebhookUrl}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => {
+                            copyTextToClipboard(whatsappWebhookUrl)
+                              .then(() => toast.success("Callback URL copied"))
+                              .catch(() => toast.error("Failed to copy URL"));
+                          }}
+                          title="Copy Callback URL"
+                          aria-label="Copy Callback URL"
+                          className="absolute right-2 text-muted-foreground hover:text-foreground p-1 rounded transition-colors"
+                        >
+                          <Copy className="h-4 w-4" />
+                        </button>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        Paste this into Meta Developer Console (WhatsApp &gt; Configuration &gt; Edit).
+                      </p>
                     </div>
                   )}
                   <Label htmlFor={`cfg-field-${field.name}`}>
@@ -351,7 +474,13 @@ export function ConfigFormDialog({
                     value={values[field.name]}
                     onChange={(v) => updateField(field.name, v)}
                     isEdit={isEdit}
+                    error={fieldErrors[field.name]}
                   />
+                  {fieldErrors[field.name] && (
+                    <p className="text-xs text-destructive">
+                      {fieldLabelByName(field.name)} is required.
+                    </p>
+                  )}
                   {field.description && (
                     <p className="text-xs text-muted-foreground">{field.description}</p>
                   )}
@@ -379,11 +508,12 @@ interface FieldInputProps {
   value: FieldValue;
   onChange: (v: FieldValue) => void;
   isEdit: boolean;
+  error?: string;
 }
 
 // Skip from_numbers in the metadata-driven form — phone numbers are managed
 // via the dedicated phone-numbers endpoints and a different UI.
-function FieldInput({ field, value, onChange, isEdit }: FieldInputProps) {
+function FieldInput({ field, value, onChange, isEdit, error }: FieldInputProps) {
   if (field.name === "from_numbers") {
     return (
       <p className="text-xs text-muted-foreground">
@@ -426,7 +556,10 @@ function FieldInput({ field, value, onChange, isEdit }: FieldInputProps) {
         value={(value as string) ?? ""}
         onChange={(e) => onChange(e.target.value)}
         rows={6}
-        className="field-sizing-fixed resize-y break-all font-mono text-xs"
+        className={cn(
+          "field-sizing-fixed resize-y break-all font-mono text-xs",
+          error && "border-destructive focus-visible:ring-destructive",
+        )}
       />
     );
   }
@@ -438,16 +571,19 @@ function FieldInput({ field, value, onChange, isEdit }: FieldInputProps) {
         placeholder={placeholder}
         value={value as number | string | undefined ?? ""}
         onChange={(e) => onChange(e.target.value === "" ? "" : Number(e.target.value))}
+        className={cn(error && "border-destructive focus-visible:ring-destructive")}
       />
     );
   }
   if (field.type === "boolean") {
     return (
-      <Switch
-        id={`cfg-field-${field.name}`}
-        checked={Boolean(value)}
-        onCheckedChange={onChange}
-      />
+      <div className={cn("inline-flex rounded-md", error && "ring-2 ring-destructive/60")}>
+        <Switch
+          id={`cfg-field-${field.name}`}
+          checked={Boolean(value)}
+          onCheckedChange={onChange}
+        />
+      </div>
     );
   }
   if (field.type === "select") {
@@ -456,7 +592,10 @@ function FieldInput({ field, value, onChange, isEdit }: FieldInputProps) {
         value={value === undefined ? "__none__" : String(value)}
         onValueChange={(next) => onChange(next === "__none__" ? undefined : next)}
       >
-        <SelectTrigger id={`cfg-field-${field.name}`}>
+        <SelectTrigger
+          id={`cfg-field-${field.name}`}
+          className={cn(error && "border-destructive focus-visible:ring-destructive")}
+        >
           <SelectValue placeholder={placeholder || "Select an option"} />
         </SelectTrigger>
         <SelectContent>
@@ -470,6 +609,39 @@ function FieldInput({ field, value, onChange, isEdit }: FieldInputProps) {
       </Select>
     );
   }
+  if (field.name === "webhook_verify_token") {
+    const tokenVal = (value as string) ?? "";
+    return (
+      <div className="relative flex items-center w-full min-w-0">
+        <Input
+          id={`cfg-field-${field.name}`}
+          type="text"
+          placeholder={placeholder}
+          value={tokenVal}
+          onChange={(e) => onChange(e.target.value)}
+          className={cn(
+            "pr-10 font-mono text-xs w-full min-w-0 truncate",
+            error && "border-destructive focus-visible:ring-destructive",
+          )}
+        />
+        {tokenVal ? (
+          <button
+            type="button"
+            onClick={() => {
+              copyTextToClipboard(tokenVal)
+                .then(() => toast.success("Verify token copied"))
+                .catch(() => toast.error("Failed to copy token"));
+            }}
+            title="Copy verify token"
+            aria-label="Copy verify token"
+            className="absolute right-2 text-muted-foreground hover:text-foreground p-1 rounded transition-colors"
+          >
+            <Copy className="h-4 w-4" />
+          </button>
+        ) : null}
+      </div>
+    );
+  }
   return (
     <Input
       id={`cfg-field-${field.name}`}
@@ -478,6 +650,7 @@ function FieldInput({ field, value, onChange, isEdit }: FieldInputProps) {
       value={(value as string) ?? ""}
       onChange={(e) => onChange(e.target.value)}
       autoComplete={field.sensitive ? "current-password" : undefined}
+      className={cn("w-full min-w-0", error && "border-destructive focus-visible:ring-destructive")}
     />
   );
 }

--- a/ui/src/components/telephony/ConfigFormDialog.tsx
+++ b/ui/src/components/telephony/ConfigFormDialog.tsx
@@ -132,10 +132,6 @@ export function ConfigFormDialog({
       // filtering out of the generic credentials dialog.
       currentProvider?.fields.filter(
         (field) =>
-          // A readonly field reports a value the server assigned. Before the
-          // configuration exists there is nothing to report, and announcing a
-          // field that is not there yet reads as something the user forgot to
-          // fill in — so it appears only once it has a value.
           !(field.type === "readonly" && !values[field.name]) &&
           (!field.visible_when ||
             values[field.visible_when.field] === field.visible_when.equals),
@@ -166,13 +162,10 @@ export function ConfigFormDialog({
           const defaultProvider = list[0].provider;
           setProviderName(defaultProvider);
           if (defaultProvider === "whatsapp") {
-            const randomToken =
-              "dograh_wa_" +
-              Math.random().toString(36).substring(2, 10) +
-              Math.random().toString(36).substring(2, 10);
             setValues({
-              webhook_verify_token: randomToken,
+              webhook_verify_token: generateWhatsAppVerifyToken(),
               call_icon_visibility: "enabled",
+              business_initiated_calls_enabled: false,
             });
           } else {
             setValues({});
@@ -190,13 +183,10 @@ export function ConfigFormDialog({
   useEffect(() => {
     if (!isEdit) {
       if (providerName === "whatsapp") {
-        const randomToken =
-          "dograh_wa_" +
-          Math.random().toString(36).substring(2, 10) +
-          Math.random().toString(36).substring(2, 10);
         setValues({
-          webhook_verify_token: randomToken,
+          webhook_verify_token: generateWhatsAppVerifyToken(),
           call_icon_visibility: "enabled",
+          business_initiated_calls_enabled: false,
         });
       } else {
         setValues({});
@@ -230,6 +220,7 @@ export function ConfigFormDialog({
     field: TelephonyProviderMetadata["fields"][number],
     value: FieldValue,
   ) =>
+    field.name !== "from_numbers" &&
     field.required &&
     field.type !== "readonly" &&
     (value === undefined || value === null || value === "");
@@ -594,7 +585,10 @@ function FieldInput({ field, value, onChange, isEdit, error }: FieldInputProps) 
       >
         <SelectTrigger
           id={`cfg-field-${field.name}`}
-          className={cn(error && "border-destructive focus-visible:ring-destructive")}
+          className={cn(
+            "w-full max-w-full min-w-0 [&>span]:truncate",
+            error && "border-destructive focus-visible:ring-destructive",
+          )}
         >
           <SelectValue placeholder={placeholder || "Select an option"} />
         </SelectTrigger>

--- a/ui/src/components/telephony/PhoneNumberDialog.tsx
+++ b/ui/src/components/telephony/PhoneNumberDialog.tsx
@@ -35,6 +35,7 @@ interface PhoneNumberDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   configId: number;
+  provider?: string;
   /** Carrier paths on this configuration; empty for providers without trunks. */
   trunks?: TrunkResponse[];
   /** Preselected trunk when creating — set when the dialog is opened from a
@@ -71,12 +72,14 @@ export function PhoneNumberDialog({
   open,
   onOpenChange,
   configId,
+  provider,
   trunks = [],
   defaultTrunkId = null,
-  existing,
+  existing = null,
   onSaved,
 }: PhoneNumberDialogProps) {
   const { user, getAccessToken } = useAuth();
+  const isWhatsApp = provider === "whatsapp";
   const isEdit = !!existing;
 
   const [address, setAddress] = useState("");
@@ -246,11 +249,17 @@ export function PhoneNumberDialog({
               <Label htmlFor="pn-country">Country (ISO-2)</Label>
               <Input
                 id="pn-country"
-                placeholder="US"
+                placeholder={isWhatsApp ? "N/A" : "US"}
                 maxLength={2}
                 value={countryCode}
                 onChange={(e) => setCountryCode(e.target.value.toUpperCase())}
+                disabled={isWhatsApp}
               />
+              {isWhatsApp && (
+                <p className="text-xs text-muted-foreground">
+                  Country is locked for WhatsApp numbers.
+                </p>
+              )}
             </div>
             <div className="space-y-1">
               <Label htmlFor="pn-label">Label</Label>
@@ -266,16 +275,19 @@ export function PhoneNumberDialog({
           <div className="space-y-1">
             <Label htmlFor="pn-workflow">Inbound workflow</Label>
             <Select value={inboundWorkflowId} onValueChange={setInboundWorkflowId}>
-              <SelectTrigger id="pn-workflow">
+              <SelectTrigger id="pn-workflow" className="w-full max-w-full overflow-hidden">
                 <SelectValue placeholder="(none)" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value={NO_WORKFLOW}>(none)</SelectItem>
-                {workflows.map((w) => (
-                  <SelectItem key={w.id} value={String(w.id)}>
-                    #{w.id} - {w.name}
-                  </SelectItem>
-                ))}
+                {workflows.map((w) => {
+                  const label = `#${w.id} - ${w.name}`;
+                  return (
+                    <SelectItem key={w.id} value={String(w.id)} title={label}>
+                      <span className="truncate max-w-[380px]">{label}</span>
+                    </SelectItem>
+                  );
+                })}
               </SelectContent>
             </Select>
             <p className="text-xs text-muted-foreground">
@@ -288,15 +300,17 @@ export function PhoneNumberDialog({
             <div className="space-y-1">
               <Label htmlFor="pn-trunk">Outbound trunk</Label>
               <Select value={trunkId} onValueChange={setTrunkId}>
-                <SelectTrigger id="pn-trunk">
+                <SelectTrigger id="pn-trunk" className="w-full max-w-full overflow-hidden">
                   <SelectValue placeholder="(none)" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value={NO_TRUNK}>(none)</SelectItem>
                   {trunks.map((trunk) => (
                     <SelectItem key={trunk.id} value={String(trunk.id)}>
-                      {trunk.name}
-                      {trunk.enabled ? "" : " (disabled)"}
+                      <span className="truncate max-w-[380px]">
+                        {trunk.name}
+                        {trunk.enabled ? "" : " (disabled)"}
+                      </span>
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/ui/src/components/telephony/PhoneNumberDialog.tsx
+++ b/ui/src/components/telephony/PhoneNumberDialog.tsx
@@ -179,7 +179,7 @@ export function PhoneNumberDialog({
               country_code: countryCode || undefined,
               label: label || undefined,
               is_active: isActive,
-              is_default_caller_id: isDefaultCallerId,
+              is_default_caller_id: !isWhatsApp && isDefaultCallerId,
               inbound_workflow_id: inboundId ?? undefined,
               telephony_trunk_id: selectedTrunkId ?? undefined,
             },
@@ -275,7 +275,7 @@ export function PhoneNumberDialog({
           <div className="space-y-1">
             <Label htmlFor="pn-workflow">Inbound workflow</Label>
             <Select value={inboundWorkflowId} onValueChange={setInboundWorkflowId}>
-              <SelectTrigger id="pn-workflow" className="w-full max-w-full overflow-hidden">
+              <SelectTrigger id="pn-workflow" className="w-full max-w-full overflow-hidden min-w-0 [&>span]:truncate [&>span]:min-w-0">
                 <SelectValue placeholder="(none)" />
               </SelectTrigger>
               <SelectContent>
@@ -300,7 +300,7 @@ export function PhoneNumberDialog({
             <div className="space-y-1">
               <Label htmlFor="pn-trunk">Outbound trunk</Label>
               <Select value={trunkId} onValueChange={setTrunkId}>
-                <SelectTrigger id="pn-trunk" className="w-full max-w-full overflow-hidden">
+                <SelectTrigger id="pn-trunk" className="w-full max-w-full overflow-hidden min-w-0 [&>span]:truncate [&>span]:min-w-0">
                   <SelectValue placeholder="(none)" />
                 </SelectTrigger>
                 <SelectContent>
@@ -328,7 +328,7 @@ export function PhoneNumberDialog({
             <Switch checked={isActive} onCheckedChange={setIsActive} />
           </div>
 
-          {!isEdit && (
+          {!isEdit && !isWhatsApp && (
             <div className="flex items-center justify-between rounded border p-3">
               <div>
                 <Label className="text-sm">Default caller ID for this configuration</Label>

--- a/ui/src/components/ui/select.tsx
+++ b/ui/src/components/ui/select.tsx
@@ -19,10 +19,9 @@ function SelectGroup({
 }
 
 function SelectValue({
-  className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" className={cn("truncate block min-w-0", className)} {...props} />
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
 }
 
 function SelectTrigger({
@@ -38,7 +37,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit min-w-0 items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:truncate *:data-[slot=select-value]:block *:data-[slot=select-value]:min-w-0 [&>span]:truncate [&>span]:min-w-0 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/ui/src/components/ui/select.tsx
+++ b/ui/src/components/ui/select.tsx
@@ -19,9 +19,10 @@ function SelectGroup({
 }
 
 function SelectValue({
+  className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+  return <SelectPrimitive.Value data-slot="select-value" className={cn("truncate block min-w-0", className)} {...props} />
 }
 
 function SelectTrigger({
@@ -37,7 +38,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit min-w-0 items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:truncate *:data-[slot=select-value]:block *:data-[slot=select-value]:min-w-0 [&>span]:truncate [&>span]:min-w-0 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/ui/src/constants/workflowRunModes.ts
+++ b/ui/src/constants/workflowRunModes.ts
@@ -12,7 +12,8 @@ export const WORKFLOW_RUN_MODES = {
     TEXTCHAT: 'textchat',
     ARI: 'ari',
     TELNYX: 'telnyx',
-    PLIVO: 'plivo'
+    PLIVO: 'plivo',
+    WHATSAPP: 'whatsapp'
 } as const;
 
 export type WorkflowRunMode = typeof WORKFLOW_RUN_MODES[keyof typeof WORKFLOW_RUN_MODES];


### PR DESCRIPTION
# feat(telephony): Add WhatsApp Inbound Calling Integration

## Summary

This pull request implements WhatsApp as a supported telephony provider in Dograh, focusing strictly on **inbound voice calling**. It enables organizations to register WhatsApp Business Cloud API credentials, receive inbound voice calls via Meta Webhooks, negotiate WebRTC media sessions, and route conversations directly into Dograh's audio pipeline and agent workflows.

Outbound and business-initiated calling are explicitly out of scope for this pull request and will follow in a subsequent release.

---

## How to Review

The diff spans 27 files across backend, frontend, and tests. Recommended reading order:

1. **`api/services/telephony/providers/whatsapp/__init__.py`** — Start here. This is the provider SPEC registration: declares capabilities, credential fields, webhook routes, and the setup checklist resolver that blocks outbound calls at the framework level.
2. **`api/services/telephony/providers/whatsapp/routes.py`** — The core inbound call flow: Meta webhook verification (GET) and call lifecycle event handling (POST).
3. **`api/services/telephony/providers/whatsapp/provider.py`** — Provider core: credential validation, HMAC signature verification, call status normalization, and the explicit outbound block.
4. **`api/services/telephony/providers/whatsapp/transport.py` + `serializers.py`** — Audio pipeline wiring for WebRTC.
5. **`api/constants.py` + `api/enums.py` + `api/schemas/telephony_config.py`** — System-wide registration of the new provider type.
6. **`ui/src/components/telephony/ConfigFormDialog.tsx`** — Configuration UI: webhook URL display, credential fields, verify token.
7. **`ui/src/app/workflow/[workflowId]/components/PhoneCallDialog.tsx`** — Outbound call guard: disabled button, tooltip, and amber notice.
8. **`api/tests/telephony/whatsapp/`** — Test suite last, once the implementation is understood.

---

## Architecture & Implementation Details

### 1. Backend Service (`api/services/telephony/providers/whatsapp/`)

* **Provider Abstraction (`provider.py`):**
  * Inherits from `BaseTelephonyProvider`.
  * Implements configuration validation, number fetching, HMAC-SHA256 signature verification for Meta webhooks (`x-hub-signature-256`), and call status normalization (`TelephonyCallStatus`).
  * **Why HMAC-SHA256 verification:** Meta requires all webhook consumers to validate the `x-hub-signature-256` header on every inbound POST. Without this, any actor who knows the webhook URL can inject arbitrary call events. This is enforced at the route level before any business logic executes.
* **Webhook Routing (`routes.py`):**
  * Implements Meta's GET `/webhook` verification endpoint with challenge echo protocol (`hub.mode`, `hub.verify_token`, `hub.challenge`), with fallback to organization-specific database configuration tokens.
  * Implements POST `/webhook` handler to process real-time call lifecycle events (`connect`, `terminate`).
  * Manages active WebRTC peer connections and synchronizes with Dograh's workflow run orchestration and concurrency limits.
  * **Why a database fallback for verify tokens:** Meta sends the challenge to a single global webhook URL. Since multiple organizations share the same endpoint, the verify token cannot be a single global constant. The fallback queries the database to match the token against any registered organization configuration, enabling multi-tenant webhook verification without per-organization URLs.
* **Audio Pipeline Integration:**
  * Configured WhatsApp-compatible audio transports (`transport.py`) and serializers (`serializers.py`) adhering to WebRTC specifications.
  * Integrated with `service_factory.py` and `audio_config.py` for Pipecat pipeline instantiation.
* **Metadata Persistence:**
  * Persists Meta's 16-digit `phone_number_id` in the `extra_metadata` JSON field of `TelephonyPhoneNumberModel`, ensuring incoming webhook events can be routed to the appropriate organization and inbound workflow.
  * **Why `extra_metadata` rather than a dedicated column:** The `phone_number_id` is WhatsApp-specific. Using the existing `extra_metadata` JSONB field avoids a schema migration and keeps provider-specific identifiers out of the shared data model, consistent with how other providers store non-standard fields.

### 2. Frontend Interface (`ui/src/components/telephony/`)

* **Configuration Dialog (`ConfigFormDialog.tsx`):**
  * Structured configuration fields into logical groupings: *Webhook Configuration*, *Meta API Credentials*, and *Call Settings*.
  * Built readonly Webhook Callback URL and auto-generated Webhook Verify Token inputs with inline clipboard copy actions.
  * Added overflow protection (`min-w-0`, `truncate`) for long dynamic tunnel/callback URLs.
  * Preserved original dialog sizing standards (`max-w-2xl max-h-[90vh]`) consistent with the core application design system.
* **Phone Number Configuration (`PhoneNumberDialog.tsx`):**
  * Automatically disables the country code selector for WhatsApp numbers since phone numbers returned by Meta are pre-formatted in E.164.
  * **Why disable country code:** Meta returns numbers in full E.164 format (e.g. `+919876543210`). Allowing the user to prepend a country code a second time would produce an invalid number and break call routing.
* **Outbound Call Guard (`PhoneCallDialog.tsx`):**
  * Proactively disables the "Start Call" button when a WhatsApp configuration is selected.
  * Adds tooltip and title hover stating: *"Outbound calling via WhatsApp is currently under development. Only inbound calling is supported."*
  * Displays an inline informational notice and marks the configuration in the dropdown as *"inbound only"*.
  * **Why guard at both frontend and backend:** The frontend guard provides immediate, clear UX feedback without a round trip. The backend guard (`initiate_call()` raising HTTP 400 and `setup_checklist_resolver` returning `ready_for_outbound=False`) ensures the constraint is enforced even if the UI guard is bypassed via direct API calls.
* **Provider Management (`page.tsx`):**
  * Exposes Meta's `phone_number_id` from metadata rather than internal database keys.
  * Resolved React hook ordering dependencies to guarantee build compliance.

---

## Test Suite & Software Development Best Practices Review

The test suite for this feature is located under `api/tests/telephony/whatsapp/` and contains 33 automated tests across three test modules:

| Test Module | Coverage Area | Key Verification Points |
| :--- | :--- | :--- |
| `test_routes.py` | Webhook HTTP Routes | Path registration, verification challenge response, invalid token rejection |
| `test_inbound_call.py` | Call Lifecycle & Workflow Integration | Database fallback verification, signature validation, workflow run creation, concurrency slot binding, WebRTC disconnect handling |
| `test_provider.py` | Provider Core Logic | Credential validation, HMAC signature checks, inbound payload normalization, status enum mapping, phone number synchronization |

### Adherence to Software Engineering Standards:

1. **Test Isolation & Hermeticity:**
   * All shared in-memory connection registries (`_active_connections`) are explicitly cleared in `setUp` fixtures to eliminate cross-test state pollution.
   * Context-managed mocking (`unittest.mock.patch`) ensures external services, database sessions, and HTTP clients are hermetically sandboxed and cleanly torn down.

2. **AAA (Arrange, Act, Assert) Pattern:**
   * Tests maintain strict separation between fixture preparation, function invocation, and result validation.

3. **Security & Boundary Testing:**
   * Comprehensive validation of HMAC-SHA256 signature verification, including valid signatures, forged signatures, and missing headers.
   * Error handling for missing credentials (`phone_number_id`, `app_secret`, `webhook_verify_token`) asserting specific exception types and messages.

4. **Runner Compatibility:**
   * Implemented using `unittest.IsolatedAsyncioTestCase`, providing full native asynchronous support out of the box while remaining fully discoverable and executable by `pytest`.

---

## Verification & Manual Testing Plan

1. **Automated Verification:**
   ```bash
   pytest api/tests/telephony/whatsapp/ -v
   ```
2. **Webhook Verification Testing:**
   * Initiate a simulated Meta challenge GET request to `/api/v1/telephony/whatsapp/webhook`.
   * Verify HTTP 200 response with raw challenge string body.
3. **Frontend Dialog Inspection:**
   * Navigate to Telephony Settings > Add Configuration > Select WhatsApp.
   * Verify layout alignment, copy-to-clipboard functionality, and modal dimensions.

---

## Scope Considerations

* **Included:** Inbound WhatsApp voice call receipt, WebRTC handshake, Pipecat agent audio pipeline execution, call termination.
* **Deferred to Subsequent PRs:** Outbound business-initiated call initiation, call transfers (currently returns explicit unsupported status).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WhatsApp as an inbound-only telephony provider, routing Meta webhook events through the Pipecat audio pipeline. Outbound calling stays unsupported: the Start Call button is disabled and `initiate_call()` returns HTTP 400.

- Webhook at `/api/v1/telephony/whatsapp/webhook` requires valid HMAC-SHA256 signatures; verify tokens fall back to database config because multiple organizations share one global Meta webhook URL.
- Active call state lives in Redis so terminate callbacks on another worker clean up the WebRTC connection and workflow run; duplicate connect events are handled idempotently, unmatched destinations are rejected, and the Redis terminate subscriber auto-reconnects and disposes pubsub clients on teardown.
- Meta's `phone_number_id` is stored in `extra_metadata` JSONB; phone number sync was extracted into a domain service that handles conflicting or failing imports without HTTP 500, discovers numbers at the WABA level with pagination, and never deactivates valid rows on partial discovery.
- Duplicate configurations are deduplicated during lookup, dormant routing keys are retained so reactivated numbers don't collide, background pipeline tasks are held by strong references, and workflow failures use `only_if_incomplete` so a normal termination isn't logged as an error or double-enqueued.
- The provider registers request and response schemas via `ProviderSpec`; credentials are required on create, responses mask stored secrets so the edit dialog hydrates, and partial updates restore any section the caller omitted via `model_fields_set`. Explicit empty values clear optional credentials, but nested credentials nulled during validation (ARI's optional section) can still be silently restored instead of cleared.
- Audio config clamps VAD and pipeline sample rates to 16 kHz, which also affects other providers with higher transport rates.
- `next.config.ts` skips TypeScript and ESLint during Docker builds to prevent OOM kills; checks still run in CI and local dev.
- Adds tests covering webhook verification, signature validation, provider logic, sync reconciliation, credential masking (including non-sensitive flag preservation on masked round-trips), and workflow run failure idempotency.

<sup>Written for commit c8afa094f36553508756dad348e0e810aa761032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update adds regression coverage for WhatsApp telephony configuration edits. It confirms that a masked configuration round trip preserves both sensitive credentials and non-sensitive settings such as business-initiated calling and call-icon visibility.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no outstanding blocking concerns remain.

The prior webhook-signature enforcement finding was resolved without explanation by greptile-apps[bot]. The prior WhatsApp transport-construction finding was resolved without explanation by greptile-apps[bot]. The prior cross-worker active-call-state finding was resolved without explanation by greptile-apps[bot]. The prior failed-call concurrency-slot release finding was resolved without explanation by greptile-apps[bot]. The prior unmatched-destination routing finding was resolved without explanation by greptile-apps[bot]. The prior phone-number discovery state finding was resolved without explanation by greptile-apps[bot]. The prior attached-phone-number provider-contract finding was resolved without explanation by greptile-apps[bot]. The prior webhook verify-token masking finding was resolved without explanation by greptile-apps[bot]. The prior checklist-readiness derivation finding was resolved without explanation by greptile-apps[bot]. The prior webhook database-access placement finding was resolved without explanation by greptile-apps[bot]. The prior number-sync orchestration placement finding was resolved without explanation by greptile-apps[bot]. The prior invalid WhatsApp transport test finding was resolved without explanation by greptile-apps[bot]. The prior partial-inventory phone-number deactivation finding was resolved without explanation by greptile-apps[bot]. The prior workflow-finalization race finding was resolved without explanation by greptile-apps[bot]. The prior optional-secret clearing finding was resolved without explanation by greptile-apps[bot]. The prior nested-secret clearing finding was resolved without explanation by greptile-apps[bot]. The previously unresolved provider response-schema and provider-owned validation findings are fixed in the current code.

<sub>Reviews (12): Last reviewed commit: ["test(telephony): assert the WhatsApp mer..."](https://github.com/dograh-hq/dograh/commit/c8afa094f36553508756dad348e0e810aa761032) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60948695)</sub>

<!-- /greptile_comment -->