### PR TITLE
fix(api): reset queued-speech mute when the recording cannot be fetched

### DIFF
--- a/api/services/workflow/pipecat_engine.py
+++ b/api/services/workflow/pipecat_engine.py
@@ -111,6 +111,13 @@ FINAL_EXTRACTION_TIMEOUT_SECONDS = 8.0
 # provider error, an empty synthesis -- gets no BotStoppedSpeakingFrame, and
 # without this deadline the caller would stay muted for the rest of the call.
 # Same question, same answer as the transfer path's playback start timeout.
+#
+# The deadline cannot tell "no audio ever" from "first audio later than this",
+# so a TTS that is merely slow (and nothing else speaking to hold the mute)
+# unmutes the caller shortly before the message plays. That is the trade: an
+# early unmute is recoverable, a mute that lasts the rest of the call is not.
+# Timing it from the TTSStartedFrame instead of from the handover, or setting
+# it per provider, would narrow the window if that ever proves too tight.
 _QUEUED_SPEECH_PLAYBACK_START_TIMEOUT_SECONDS = 5.0
 
 
@@ -1203,7 +1210,12 @@ class PipecatEngine:
 
         async def sink(frame: "Frame") -> None:
             await self._transport_output.queue_frame(frame)
-            if isinstance(frame, TTSAudioRawFrame):
+            # Only while the hold is still its owner's: today play_audio sends
+            # one audio frame, but if that audio is ever chunked, a later chunk
+            # must not take the hold back after playback released it.
+            if isinstance(frame, TTSAudioRawFrame) and (
+                token in self._queued_speech_mute_pending
+            ):
                 self._hold_until_playback_ends(token)
 
         return sink

--- a/api/services/workflow/pipecat_engine.py
+++ b/api/services/workflow/pipecat_engine.py
@@ -176,9 +176,15 @@ class PipecatEngine:
         # Controls whether user input should be muted
         self._mute_pipeline: bool = False
 
-        # Mute state for queued TTSSpeakFrames (transition speech, custom tool messages)
-        # "idle" = not muting, "waiting" = speech queued, "playing" = bot speaking it
-        self._queued_speech_mute_state: str = "idle"
+        # Mute holds for queued speech (transition speech, custom tool
+        # messages). Function calls run in parallel, so each operation takes
+        # its own hold and the user stays muted while any hold is alive.
+        # A hold is "pending" until the speech reaches the transport, and only
+        # its owner may release it; once queued it becomes "playing" and the
+        # BotStoppedSpeakingFrame that ends playback releases it.
+        self._queued_speech_mute_pending: set[int] = set()
+        self._queued_speech_mute_playing: set[int] = set()
+        self._queued_speech_mute_last_token: int = 0
 
         # Tracks whether the bot is currently speaking (for allow_interrupt logic)
         self._bot_is_speaking: bool = False
@@ -354,8 +360,7 @@ class PipecatEngine:
                     logger.info(
                         f"Playing transition audio: {transition_speech_recording_id}"
                     )
-                    self._queued_speech_mute_state = "waiting"
-                    played = False
+                    mute_token = self.acquire_queued_speech_mute()
                     try:
                         result = await self._fetch_recording_audio(
                             recording_pk=int(transition_speech_recording_id)
@@ -366,23 +371,21 @@ class PipecatEngine:
                                 sample_rate=self._audio_config.pipeline_sample_rate
                                 if self._audio_config
                                 else 16000,
-                                queue_frame=self._transport_output.queue_frame,
+                                queue_frame=self.queued_speech_frame_sink(mute_token),
                                 transcript=result.transcript,
                                 persist_to_logs=True,
                             )
-                            played = True
                         else:
                             logger.warning(
                                 f"Failed to fetch transition audio {transition_speech_recording_id}"
                             )
                     finally:
                         # Nothing was queued, so no BotStoppedSpeakingFrame will
-                        # ever release the mute; release it here instead.
-                        if not played:
-                            self._queued_speech_mute_state = "idle"
+                        # ever release this hold; release it here instead.
+                        self.release_queued_speech_mute(mute_token)
                 elif transition_speech:
                     logger.info(f"Playing transition speech: {transition_speech}")
-                    self._queued_speech_mute_state = "waiting"
+                    self.mute_until_speech_playback_ends()
                     await self.task.queue_frame(
                         TTSSpeakFrame(
                             transition_speech,
@@ -1121,6 +1124,56 @@ class PipecatEngine:
         )
         await self.task.queue_frame(frame_to_push)
 
+    def acquire_queued_speech_mute(self) -> int:
+        """Mute the user for one piece of queued speech, before it exists.
+
+        Function calls run in parallel (pipecat's ``run_in_parallel`` default),
+        so the mute is a set of holds rather than a single flag: the returned
+        token is the caller's own hold and releasing it leaves every other
+        operation muted.
+        """
+        self._queued_speech_mute_last_token += 1
+        token = self._queued_speech_mute_last_token
+        self._queued_speech_mute_pending.add(token)
+        return token
+
+    def mute_until_speech_playback_ends(self) -> None:
+        """Mute the user for speech being queued right now.
+
+        For speech that goes straight to the pipeline there is nothing to
+        release by hand: the hold ends with the BotStoppedSpeakingFrame that
+        closes playback.
+        """
+        token = self.acquire_queued_speech_mute()
+        self._queued_speech_mute_pending.discard(token)
+        self._queued_speech_mute_playing.add(token)
+
+    def queued_speech_frame_sink(
+        self, token: int
+    ) -> Callable[["Frame"], Awaitable[None]]:
+        """Frame sink that hands *token* over to playback once audio is queued.
+
+        The first frame to reach the transport puts the utterance in flight, so
+        from then on the hold belongs to the BotStoppedSpeakingFrame that ends
+        it: a later frame failing must not unmute the user mid-utterance.
+        """
+
+        async def sink(frame: "Frame") -> None:
+            await self._transport_output.queue_frame(frame)
+            if token in self._queued_speech_mute_pending:
+                self._queued_speech_mute_pending.discard(token)
+                self._queued_speech_mute_playing.add(token)
+
+        return sink
+
+    def release_queued_speech_mute(self, token: int) -> None:
+        """Release a hold whose speech never reached the transport.
+
+        A hold already handed over to playback is left alone; no frame was
+        queued for this one, so no BotStoppedSpeakingFrame will ever release it.
+        """
+        self._queued_speech_mute_pending.discard(token)
+
     def arm_speech_playback(self) -> None:
         """Start tracking the next piece of speech queued to the transport.
 
@@ -1151,6 +1204,11 @@ class PipecatEngine:
         Returns:
             True if the speech played to completion, False if either wait timed
             out (the caller should carry on regardless).
+
+        A timeout leaves the queued-speech mute alone: this path arms playback
+        without taking a hold (see the transfer handler and
+        ``_play_config_message``), so anything it released would belong to
+        another operation.
         """
         try:
             await asyncio.wait_for(
@@ -1161,7 +1219,6 @@ class PipecatEngine:
                 f"Queued speech never started playing within {start_timeout}s; "
                 "continuing without it"
             )
-            self._queued_speech_mute_state = "idle"
             return False
 
         try:
@@ -1173,7 +1230,6 @@ class PipecatEngine:
                 f"Queued speech did not finish playing within {playback_timeout}s; "
                 "continuing"
             )
-            self._queued_speech_mute_state = "idle"
             return False
 
         return True
@@ -1192,13 +1248,14 @@ class PipecatEngine:
         # Track bot speaking state from frames
         if isinstance(frame, BotStartedSpeakingFrame):
             self._bot_is_speaking = True
-            if self._queued_speech_mute_state == "waiting":
-                self._queued_speech_mute_state = "playing"
             self._speech_playback_started.set()
             self._speech_playback_finished.clear()
         elif isinstance(frame, BotStoppedSpeakingFrame):
             self._bot_is_speaking = False
-            self._queued_speech_mute_state = "idle"
+            # Playback has drained, so every hold whose speech was queued
+            # before this point has been heard. Holds still waiting for audio
+            # belong to their own operation and keep the user muted.
+            self._queued_speech_mute_playing.clear()
             self._speech_playback_finished.set()
 
         # Always mute if pipeline is shutting down
@@ -1206,7 +1263,7 @@ class PipecatEngine:
             return True
 
         # Mute while queued speech (transition/tool message) is pending or playing
-        if self._queued_speech_mute_state != "idle":
+        if self._queued_speech_mute_pending or self._queued_speech_mute_playing:
             return True
 
         # Mute if bot is speaking and current node doesn't allow interruption

--- a/api/services/workflow/pipecat_engine.py
+++ b/api/services/workflow/pipecat_engine.py
@@ -106,6 +106,13 @@ _ENGINE_OWNED_CONTEXT_KEYS = frozenset(
 # p50 1.4s / p90 4.0s / max 21.3s, so this cuts off the tail and nothing else.
 FINAL_EXTRACTION_TIMEOUT_SECONDS = 8.0
 
+# Seconds a queued-speech mute hold waits for playback to begin before it is
+# dropped. Speech handed to the pipeline that never produces audio -- a TTS
+# provider error, an empty synthesis -- gets no BotStoppedSpeakingFrame, and
+# without this deadline the caller would stay muted for the rest of the call.
+# Same question, same answer as the transfer path's playback start timeout.
+_QUEUED_SPEECH_PLAYBACK_START_TIMEOUT_SECONDS = 5.0
+
 
 class PipecatEngine:
     def __init__(
@@ -186,6 +193,7 @@ class PipecatEngine:
         self._queued_speech_mute_pending: set[int] = set()
         self._queued_speech_mute_playing: set[int] = set()
         self._queued_speech_mute_last_token: int = 0
+        self._queued_speech_mute_watchdogs: set[asyncio.Task] = set()
 
         # Tracks whether the bot is currently speaking (for allow_interrupt logic)
         self._bot_is_speaking: bool = False
@@ -1145,9 +1153,41 @@ class PipecatEngine:
         """Mute the user for speech being queued right now.
 
         For speech that goes straight to the pipeline there is nothing to
-        release by hand: the hold ends with a BotStoppedSpeakingFrame.
+        release by hand: the hold ends with a BotStoppedSpeakingFrame, or with
+        the deadline below if that speech never reaches the caller.
         """
-        self._queued_speech_mute_playing.add(self._next_queued_speech_mute_token())
+        self._hold_until_playback_ends(self._next_queued_speech_mute_token())
+
+    def _hold_until_playback_ends(self, token: int) -> None:
+        """Hand *token* to playback, and guard it against speech that never plays.
+
+        TTS can yield nothing at all (provider error, empty synthesis) and the
+        transport only speaks once audio reaches it, so a hold waiting on a
+        BotStoppedSpeakingFrame needs a deadline of its own. Missing it is
+        rare; staying muted for the rest of the call is not recoverable, so the
+        hold is dropped rather than kept.
+        """
+        self._queued_speech_mute_pending.discard(token)
+        self._queued_speech_mute_playing.add(token)
+
+        async def drop_if_playback_never_starts() -> None:
+            await asyncio.sleep(_QUEUED_SPEECH_PLAYBACK_START_TIMEOUT_SECONDS)
+            # Anything the bot is saying ends in a BotStoppedSpeakingFrame,
+            # which releases this hold; only silence has no way out.
+            if token not in self._queued_speech_mute_playing or self._bot_is_speaking:
+                return
+            logger.warning(
+                f"Queued speech never started playing within "
+                f"{_QUEUED_SPEECH_PLAYBACK_START_TIMEOUT_SECONDS}s; "
+                "releasing the user mute it was holding"
+            )
+            self._queued_speech_mute_playing.discard(token)
+
+        task = asyncio.create_task(
+            drop_if_playback_never_starts(), name=f"queued-speech-mute:{token}"
+        )
+        self._queued_speech_mute_watchdogs.add(task)
+        task.add_done_callback(self._queued_speech_mute_watchdogs.discard)
 
     def queued_speech_frame_sink(
         self, token: int
@@ -1164,8 +1204,7 @@ class PipecatEngine:
         async def sink(frame: "Frame") -> None:
             await self._transport_output.queue_frame(frame)
             if isinstance(frame, TTSAudioRawFrame):
-                self._queued_speech_mute_pending.discard(token)
-                self._queued_speech_mute_playing.add(token)
+                self._hold_until_playback_ends(token)
 
         return sink
 
@@ -1467,6 +1506,9 @@ class PipecatEngine:
             and not self._user_response_timeout_task.done()
         ):
             self._user_response_timeout_task.cancel()
+
+        for watchdog in list(self._queued_speech_mute_watchdogs):
+            watchdog.cancel()
 
         # Cancel any in-flight background summarization.
         if self._context_summarization_manager:

--- a/api/services/workflow/pipecat_engine.py
+++ b/api/services/workflow/pipecat_engine.py
@@ -355,23 +355,31 @@ class PipecatEngine:
                         f"Playing transition audio: {transition_speech_recording_id}"
                     )
                     self._queued_speech_mute_state = "waiting"
-                    result = await self._fetch_recording_audio(
-                        recording_pk=int(transition_speech_recording_id)
-                    )
-                    if result:
-                        await play_audio(
-                            result.audio,
-                            sample_rate=self._audio_config.pipeline_sample_rate
-                            if self._audio_config
-                            else 16000,
-                            queue_frame=self._transport_output.queue_frame,
-                            transcript=result.transcript,
-                            persist_to_logs=True,
+                    played = False
+                    try:
+                        result = await self._fetch_recording_audio(
+                            recording_pk=int(transition_speech_recording_id)
                         )
-                    else:
-                        logger.warning(
-                            f"Failed to fetch transition audio {transition_speech_recording_id}"
-                        )
+                        if result:
+                            await play_audio(
+                                result.audio,
+                                sample_rate=self._audio_config.pipeline_sample_rate
+                                if self._audio_config
+                                else 16000,
+                                queue_frame=self._transport_output.queue_frame,
+                                transcript=result.transcript,
+                                persist_to_logs=True,
+                            )
+                            played = True
+                        else:
+                            logger.warning(
+                                f"Failed to fetch transition audio {transition_speech_recording_id}"
+                            )
+                    finally:
+                        # Nothing was queued, so no BotStoppedSpeakingFrame will
+                        # ever release the mute; release it here instead.
+                        if not played:
+                            self._queued_speech_mute_state = "idle"
                 elif transition_speech:
                     logger.info(f"Playing transition speech: {transition_speech}")
                     self._queued_speech_mute_state = "waiting"
@@ -1153,6 +1161,7 @@ class PipecatEngine:
                 f"Queued speech never started playing within {start_timeout}s; "
                 "continuing without it"
             )
+            self._queued_speech_mute_state = "idle"
             return False
 
         try:
@@ -1164,6 +1173,7 @@ class PipecatEngine:
                 f"Queued speech did not finish playing within {playback_timeout}s; "
                 "continuing"
             )
+            self._queued_speech_mute_state = "idle"
             return False
 
         return True

--- a/api/services/workflow/pipecat_engine.py
+++ b/api/services/workflow/pipecat_engine.py
@@ -19,6 +19,7 @@ from pipecat.frames.frames import (
     EndFrame,
     FunctionCallResultProperties,
     LLMContextFrame,
+    TTSAudioRawFrame,
     TTSSpeakFrame,
 )
 from pipecat.pipeline.worker import PipelineWorker
@@ -1124,6 +1125,10 @@ class PipecatEngine:
         )
         await self.task.queue_frame(frame_to_push)
 
+    def _next_queued_speech_mute_token(self) -> int:
+        self._queued_speech_mute_last_token += 1
+        return self._queued_speech_mute_last_token
+
     def acquire_queued_speech_mute(self) -> int:
         """Mute the user for one piece of queued speech, before it exists.
 
@@ -1132,8 +1137,7 @@ class PipecatEngine:
         token is the caller's own hold and releasing it leaves every other
         operation muted.
         """
-        self._queued_speech_mute_last_token += 1
-        token = self._queued_speech_mute_last_token
+        token = self._next_queued_speech_mute_token()
         self._queued_speech_mute_pending.add(token)
         return token
 
@@ -1141,26 +1145,25 @@ class PipecatEngine:
         """Mute the user for speech being queued right now.
 
         For speech that goes straight to the pipeline there is nothing to
-        release by hand: the hold ends with the BotStoppedSpeakingFrame that
-        closes playback.
+        release by hand: the hold ends with a BotStoppedSpeakingFrame.
         """
-        token = self.acquire_queued_speech_mute()
-        self._queued_speech_mute_pending.discard(token)
-        self._queued_speech_mute_playing.add(token)
+        self._queued_speech_mute_playing.add(self._next_queued_speech_mute_token())
 
     def queued_speech_frame_sink(
         self, token: int
     ) -> Callable[["Frame"], Awaitable[None]]:
         """Frame sink that hands *token* over to playback once audio is queued.
 
-        The first frame to reach the transport puts the utterance in flight, so
-        from then on the hold belongs to the BotStoppedSpeakingFrame that ends
-        it: a later frame failing must not unmute the user mid-utterance.
+        The handover happens on the audio frame, not on the first frame of any
+        kind: the transport only counts as speaking once a TTSAudioRawFrame
+        reaches it (``base_output.py`` ``_handle_bot_speech``), so a failure
+        before that point has queued nothing audible and the owner must still
+        release the hold itself.
         """
 
         async def sink(frame: "Frame") -> None:
             await self._transport_output.queue_frame(frame)
-            if token in self._queued_speech_mute_pending:
+            if isinstance(frame, TTSAudioRawFrame):
                 self._queued_speech_mute_pending.discard(token)
                 self._queued_speech_mute_playing.add(token)
 
@@ -1169,7 +1172,7 @@ class PipecatEngine:
     def release_queued_speech_mute(self, token: int) -> None:
         """Release a hold whose speech never reached the transport.
 
-        A hold already handed over to playback is left alone; no frame was
+        A hold already handed over to playback is left alone; no audio was
         queued for this one, so no BotStoppedSpeakingFrame will ever release it.
         """
         self._queued_speech_mute_pending.discard(token)
@@ -1252,9 +1255,16 @@ class PipecatEngine:
             self._speech_playback_finished.clear()
         elif isinstance(frame, BotStoppedSpeakingFrame):
             self._bot_is_speaking = False
-            # Playback has drained, so every hold whose speech was queued
-            # before this point has been heard. Holds still waiting for audio
-            # belong to their own operation and keep the user muted.
+            # The transport emits this frame per utterance (on the
+            # TTSStoppedFrame that follows audio, or after 0.35s of silence),
+            # and it says nothing about *which* speech ended: the callback sees
+            # no context id. So a hold handed over while an earlier utterance
+            # was still playing is released here, one boundary early. That is
+            # the deliberate bias -- unmute a moment too soon rather than leave
+            # the caller muted for the rest of the call. Releasing them in FIFO
+            # order instead would mis-align on the first LLM utterance or silent
+            # TTS and put the stuck mute back. Holds still waiting for audio are
+            # their operation's own and stay.
             self._queued_speech_mute_playing.clear()
             self._speech_playback_finished.set()
 

--- a/api/services/workflow/pipecat_engine_custom_tools.py
+++ b/api/services/workflow/pipecat_engine_custom_tools.py
@@ -423,19 +423,31 @@ class CustomToolManager:
                             f"Playing audio message before HTTP tool: pk={recording_pk}"
                         )
                         self._engine._queued_speech_mute_state = "waiting"
-                        result = await self._engine._fetch_recording_audio(
-                            recording_pk=int(recording_pk)
-                        )
-                        if result:
-                            await play_audio(
-                                result.audio,
-                                sample_rate=self._engine._audio_config.pipeline_sample_rate
-                                if self._engine._audio_config
-                                else 16000,
-                                queue_frame=self._engine._transport_output.queue_frame,
-                                transcript=result.transcript,
-                                persist_to_logs=True,
+                        played = False
+                        try:
+                            result = await self._engine._fetch_recording_audio(
+                                recording_pk=int(recording_pk)
                             )
+                            if result:
+                                await play_audio(
+                                    result.audio,
+                                    sample_rate=self._engine._audio_config.pipeline_sample_rate
+                                    if self._engine._audio_config
+                                    else 16000,
+                                    queue_frame=self._engine._transport_output.queue_frame,
+                                    transcript=result.transcript,
+                                    persist_to_logs=True,
+                                )
+                                played = True
+                            else:
+                                logger.warning(
+                                    f"Failed to fetch recording pk={recording_pk}"
+                                )
+                        finally:
+                            # Nothing was queued, so no BotStoppedSpeakingFrame
+                            # will ever release the mute; release it here.
+                            if not played:
+                                self._engine._queued_speech_mute_state = "idle"
                 elif custom_message:
                     logger.info(
                         f"Playing custom message before HTTP tool: {custom_message}"

--- a/api/services/workflow/pipecat_engine_custom_tools.py
+++ b/api/services/workflow/pipecat_engine_custom_tools.py
@@ -422,8 +422,7 @@ class CustomToolManager:
                         logger.info(
                             f"Playing audio message before HTTP tool: pk={recording_pk}"
                         )
-                        self._engine._queued_speech_mute_state = "waiting"
-                        played = False
+                        mute_token = self._engine.acquire_queued_speech_mute()
                         try:
                             result = await self._engine._fetch_recording_audio(
                                 recording_pk=int(recording_pk)
@@ -434,25 +433,25 @@ class CustomToolManager:
                                     sample_rate=self._engine._audio_config.pipeline_sample_rate
                                     if self._engine._audio_config
                                     else 16000,
-                                    queue_frame=self._engine._transport_output.queue_frame,
+                                    queue_frame=self._engine.queued_speech_frame_sink(
+                                        mute_token
+                                    ),
                                     transcript=result.transcript,
                                     persist_to_logs=True,
                                 )
-                                played = True
                             else:
                                 logger.warning(
                                     f"Failed to fetch recording pk={recording_pk}"
                                 )
                         finally:
                             # Nothing was queued, so no BotStoppedSpeakingFrame
-                            # will ever release the mute; release it here.
-                            if not played:
-                                self._engine._queued_speech_mute_state = "idle"
+                            # will ever release this hold; release it here.
+                            self._engine.release_queued_speech_mute(mute_token)
                 elif custom_message:
                     logger.info(
                         f"Playing custom message before HTTP tool: {custom_message}"
                     )
-                    self._engine._queued_speech_mute_state = "waiting"
+                    self._engine.mute_until_speech_playback_ends()
                     await self._engine.task.queue_frame(
                         TTSSpeakFrame(
                             custom_message,

--- a/api/tests/test_pipecat_engine_transition_mute.py
+++ b/api/tests/test_pipecat_engine_transition_mute.py
@@ -10,6 +10,7 @@ that runs inside the transition function.
 """
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -21,6 +22,7 @@ from pipecat.processors.aggregators.llm_response_universal import (
     LLMContextAggregatorPair,
     LLMUserAggregatorParams,
 )
+from pipecat.services.llm_service import FunctionCallParams
 from pipecat.tests.mock_transport import MockTransport
 from pipecat.transports.base_transport import TransportParams
 from pipecat.turns.user_mute import (
@@ -30,6 +32,7 @@ from pipecat.turns.user_mute import (
 )
 
 from api.services.workflow.pipecat_engine import PipecatEngine
+from api.services.workflow.pipecat_engine_custom_tools import CustomToolManager
 from api.services.workflow.pipecat_engine_variable_extractor import (
     VariableExtractionManager,
 )
@@ -249,3 +252,107 @@ class TestTransitionFunctionMutesUser:
             "set after the transition function's result was delivered, got "
             f"{function_call_mute_strategy._function_call_in_progress}"
         )
+
+
+def _function_call_params(engine: PipecatEngine, name: str) -> FunctionCallParams:
+    return FunctionCallParams(
+        function_name=name,
+        tool_call_id=f"call_{name}",
+        arguments={},
+        llm=engine.llm,
+        pipeline_worker=engine.task,
+        context=engine.context,
+        result_callback=AsyncMock(),
+    )
+
+
+class TestQueuedSpeechMuteResetWithoutAudio:
+    """The queued-speech mute must be released when no audio ever plays.
+
+    ``_queued_speech_mute_state`` is set to ``"waiting"`` before the recording
+    is fetched. If the fetch fails nothing is queued, so the
+    ``BotStoppedSpeakingFrame`` that normally returns the state to ``"idle"``
+    never arrives and the user would stay muted for the rest of the call.
+    """
+
+    @pytest.mark.asyncio
+    async def test_transition_audio_fetch_failure_resets_mute_state(
+        self, simple_workflow: WorkflowGraph
+    ):
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+        engine.set_fetch_recording_audio(AsyncMock(return_value=None))
+
+        transition = await engine._create_transition_func(
+            "end_call",
+            "end",
+            transition_speech_type="audio",
+            transition_speech_recording_id="42",
+        )
+        params = _function_call_params(engine, "end_call")
+
+        with (
+            patch.object(
+                engine, "_perform_variable_extraction_if_needed", new_callable=AsyncMock
+            ),
+            patch.object(engine, "set_node", new_callable=AsyncMock),
+        ):
+            await transition(params)
+
+        assert engine._queued_speech_mute_state == "idle"
+        params.result_callback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_http_tool_audio_fetch_failure_resets_mute_state(
+        self, simple_workflow: WorkflowGraph
+    ):
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+        engine.set_fetch_recording_audio(AsyncMock(return_value=None))
+
+        manager = CustomToolManager(engine)
+        tool = SimpleNamespace(
+            definition={
+                "config": {
+                    "customMessageType": "audio",
+                    "customMessageRecordingId": "42",
+                }
+            }
+        )
+        handler = manager._create_http_tool_handler(tool, "lookup_order")
+        params = _function_call_params(engine, "lookup_order")
+
+        with (
+            patch(
+                "api.services.workflow.pipecat_engine_custom_tools.execute_http_tool",
+                new_callable=AsyncMock,
+                return_value={"status": "ok"},
+            ),
+            patch.object(
+                manager, "get_organization_id", new_callable=AsyncMock, return_value=1
+            ),
+        ):
+            await handler(params)
+
+        assert engine._queued_speech_mute_state == "idle"
+        params.result_callback.assert_awaited_once_with({"status": "ok"})
+
+    @pytest.mark.asyncio
+    async def test_wait_for_speech_playback_timeout_resets_mute_state(
+        self, simple_workflow: WorkflowGraph
+    ):
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+        engine.arm_speech_playback()
+        engine._queued_speech_mute_state = "waiting"
+
+        played = await engine.wait_for_speech_playback(start_timeout=0.01)
+
+        assert played is False
+        assert engine._queued_speech_mute_state == "idle"

--- a/api/tests/test_pipecat_engine_transition_mute.py
+++ b/api/tests/test_pipecat_engine_transition_mute.py
@@ -14,6 +14,11 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
+    TTSSpeakFrame,
+)
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 from pipecat.processors.aggregators.llm_context import LLMContext
@@ -266,17 +271,44 @@ def _function_call_params(engine: PipecatEngine, name: str) -> FunctionCallParam
     )
 
 
-class TestQueuedSpeechMuteResetWithoutAudio:
-    """The queued-speech mute must be released when no audio ever plays.
+def _mute_holds(engine: PipecatEngine) -> set[int]:
+    """Every queued-speech hold currently keeping the user muted."""
+    return engine._queued_speech_mute_pending | engine._queued_speech_mute_playing
 
-    ``_queued_speech_mute_state`` is set to ``"waiting"`` before the recording
-    is fetched. If the fetch fails nothing is queued, so the
-    ``BotStoppedSpeakingFrame`` that normally returns the state to ``"idle"``
-    never arrives and the user would stay muted for the rest of the call.
+
+async def _run_transition_with_audio(engine: PipecatEngine) -> FunctionCallParams:
+    """Run a transition that plays recording 42 as its transition speech."""
+    transition = await engine._create_transition_func(
+        "end_call",
+        "end",
+        transition_speech_type="audio",
+        transition_speech_recording_id="42",
+    )
+    params = _function_call_params(engine, "end_call")
+
+    with (
+        patch.object(
+            engine, "_perform_variable_extraction_if_needed", new_callable=AsyncMock
+        ),
+        patch.object(engine, "set_node", new_callable=AsyncMock),
+    ):
+        await transition(params)
+
+    return params
+
+
+class TestQueuedSpeechMuteOwnership:
+    """Queued speech mutes the user, and each operation releases only its own.
+
+    A hold is taken before the recording is fetched. If the fetch yields no
+    audio nothing is queued, so the ``BotStoppedSpeakingFrame`` that normally
+    ends the hold never arrives and the user would stay muted for the rest of
+    the call. Releasing it must not unmute speech that a parallel function
+    call (pipecat runs them concurrently) is still playing.
     """
 
     @pytest.mark.asyncio
-    async def test_transition_audio_fetch_failure_resets_mute_state(
+    async def test_transition_audio_fetch_failure_releases_mute(
         self, simple_workflow: WorkflowGraph
     ):
         llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
@@ -285,27 +317,32 @@ class TestQueuedSpeechMuteResetWithoutAudio:
         )
         engine.set_fetch_recording_audio(AsyncMock(return_value=None))
 
-        transition = await engine._create_transition_func(
-            "end_call",
-            "end",
-            transition_speech_type="audio",
-            transition_speech_recording_id="42",
-        )
-        params = _function_call_params(engine, "end_call")
+        params = await _run_transition_with_audio(engine)
 
-        with (
-            patch.object(
-                engine, "_perform_variable_extraction_if_needed", new_callable=AsyncMock
-            ),
-            patch.object(engine, "set_node", new_callable=AsyncMock),
-        ):
-            await transition(params)
-
-        assert engine._queued_speech_mute_state == "idle"
+        assert _mute_holds(engine) == set()
         params.result_callback.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_http_tool_audio_fetch_failure_resets_mute_state(
+    async def test_transition_audio_fetch_exception_releases_mute(
+        self, simple_workflow: WorkflowGraph
+    ):
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+        engine.set_fetch_recording_audio(
+            AsyncMock(side_effect=RuntimeError("recording service down"))
+        )
+
+        params = await _run_transition_with_audio(engine)
+
+        assert _mute_holds(engine) == set()
+        params.result_callback.assert_awaited_once_with(
+            {"status": "error", "error": "recording service down"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_http_tool_audio_fetch_failure_releases_mute(
         self, simple_workflow: WorkflowGraph
     ):
         llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
@@ -338,21 +375,137 @@ class TestQueuedSpeechMuteResetWithoutAudio:
         ):
             await handler(params)
 
-        assert engine._queued_speech_mute_state == "idle"
+        assert _mute_holds(engine) == set()
         params.result_callback.assert_awaited_once_with({"status": "ok"})
 
     @pytest.mark.asyncio
-    async def test_wait_for_speech_playback_timeout_resets_mute_state(
+    async def test_http_tool_audio_fetch_exception_releases_mute(
         self, simple_workflow: WorkflowGraph
     ):
         llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
         engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
             simple_workflow, llm
         )
+        engine.set_fetch_recording_audio(
+            AsyncMock(side_effect=RuntimeError("recording service down"))
+        )
+
+        manager = CustomToolManager(engine)
+        tool = SimpleNamespace(
+            definition={
+                "config": {
+                    "customMessageType": "audio",
+                    "customMessageRecordingId": "42",
+                }
+            }
+        )
+        handler = manager._create_http_tool_handler(tool, "lookup_order")
+        params = _function_call_params(engine, "lookup_order")
+
+        with patch.object(
+            manager, "get_organization_id", new_callable=AsyncMock, return_value=1
+        ):
+            await handler(params)
+
+        assert _mute_holds(engine) == set()
+        params.result_callback.assert_awaited_once_with(
+            {"status": "error", "error": "recording service down"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_keeps_parallel_playback_muted(
+        self, simple_workflow: WorkflowGraph
+    ):
+        """A failed operation must not unmute another one's speech.
+
+        Function calls run in parallel, so a transition whose recording never
+        arrives can finish while a second one is still being played out.
+        """
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+        engine.set_fetch_recording_audio(AsyncMock(return_value=None))
+
+        # Another function call already queued its speech.
+        engine.mute_until_speech_playback_ends()
+
+        await _run_transition_with_audio(engine)
+
+        assert await engine.should_mute_user(TTSSpeakFrame("anything")) is True
+
+        # The speech that is playing releases its own hold when it ends.
+        await engine.should_mute_user(BotStoppedSpeakingFrame())
+
+        assert _mute_holds(engine) == set()
+        assert await engine.should_mute_user(TTSSpeakFrame("anything")) is False
+
+    @pytest.mark.asyncio
+    async def test_partial_playback_queue_keeps_user_muted(
+        self, simple_workflow: WorkflowGraph
+    ):
+        """A frame failing mid-utterance must not unmute the queued audio.
+
+        ``play_audio`` pushes several frames. Once the first has reached the
+        transport the utterance is on its way to the caller, so the hold
+        belongs to playback even though the call raised.
+        """
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+        engine.set_fetch_recording_audio(
+            AsyncMock(
+                return_value=SimpleNamespace(audio=b"\x00\x00", transcript="hello")
+            )
+        )
+        engine.set_transport_output(
+            SimpleNamespace(
+                queue_frame=AsyncMock(
+                    side_effect=[None, RuntimeError("transport gone")]
+                )
+            )
+        )
+
+        await _run_transition_with_audio(engine)
+
+        assert engine._queued_speech_mute_pending == set()
+        assert len(engine._queued_speech_mute_playing) == 1
+        assert await engine.should_mute_user(TTSSpeakFrame("anything")) is True
+
+    @pytest.mark.asyncio
+    async def test_wait_for_speech_playback_start_timeout_keeps_other_holds(
+        self, simple_workflow: WorkflowGraph
+    ):
+        """The transfer path arms playback without taking a hold of its own."""
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+        engine.mute_until_speech_playback_ends()
         engine.arm_speech_playback()
-        engine._queued_speech_mute_state = "waiting"
 
         played = await engine.wait_for_speech_playback(start_timeout=0.01)
 
         assert played is False
-        assert engine._queued_speech_mute_state == "idle"
+        assert await engine.should_mute_user(TTSSpeakFrame("anything")) is True
+
+    @pytest.mark.asyncio
+    async def test_wait_for_speech_playback_finish_timeout_keeps_other_holds(
+        self, simple_workflow: WorkflowGraph
+    ):
+        """Playback started but never finished: the hold still belongs to it."""
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+        engine.mute_until_speech_playback_ends()
+        engine.arm_speech_playback()
+        await engine.should_mute_user(BotStartedSpeakingFrame())
+
+        played = await engine.wait_for_speech_playback(
+            start_timeout=1.0, playback_timeout=0.01
+        )
+
+        assert played is False
+        assert await engine.should_mute_user(TTSSpeakFrame("anything")) is True

--- a/api/tests/test_pipecat_engine_transition_mute.py
+++ b/api/tests/test_pipecat_engine_transition_mute.py
@@ -441,14 +441,15 @@ class TestQueuedSpeechMuteOwnership:
         assert await engine.should_mute_user(TTSSpeakFrame("anything")) is False
 
     @pytest.mark.asyncio
-    async def test_partial_playback_queue_keeps_user_muted(
+    async def test_playback_queue_failure_before_audio_releases_mute(
         self, simple_workflow: WorkflowGraph
     ):
-        """A frame failing mid-utterance must not unmute the queued audio.
+        """Failing before the audio frame has queued nothing audible.
 
-        ``play_audio`` pushes several frames. Once the first has reached the
-        transport the utterance is on its way to the caller, so the hold
-        belongs to playback even though the call raised.
+        ``play_audio`` pushes TTSStarted, the transcript, the audio and
+        TTSStopped. The transport only starts speaking on the audio frame, so
+        failing before it means no BotStoppedSpeakingFrame will ever come and
+        the hold has to be released by its owner.
         """
         llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
         engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
@@ -469,9 +470,61 @@ class TestQueuedSpeechMuteOwnership:
 
         await _run_transition_with_audio(engine)
 
+        assert _mute_holds(engine) == set()
+        assert await engine.should_mute_user(TTSSpeakFrame("anything")) is False
+
+    @pytest.mark.asyncio
+    async def test_playback_queue_failure_after_audio_keeps_user_muted(
+        self, simple_workflow: WorkflowGraph
+    ):
+        """A frame failing once the audio is queued must not unmute it.
+
+        The utterance is on its way to the caller, so the hold belongs to
+        playback even though ``play_audio`` raised.
+        """
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+        engine.set_fetch_recording_audio(
+            AsyncMock(
+                return_value=SimpleNamespace(audio=b"\x00\x00", transcript="hello")
+            )
+        )
+        engine.set_transport_output(
+            SimpleNamespace(
+                queue_frame=AsyncMock(
+                    side_effect=[None, None, None, RuntimeError("transport gone")]
+                )
+            )
+        )
+
+        await _run_transition_with_audio(engine)
+
         assert engine._queued_speech_mute_pending == set()
         assert len(engine._queued_speech_mute_playing) == 1
         assert await engine.should_mute_user(TTSSpeakFrame("anything")) is True
+
+    @pytest.mark.asyncio
+    async def test_playback_end_releases_the_hold_it_was_armed_with(
+        self, simple_workflow: WorkflowGraph
+    ):
+        """The normal path: speech plays, and its end unmutes the user."""
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+        engine.mute_until_speech_playback_ends()
+        engine.arm_speech_playback()
+        waiter = asyncio.create_task(engine.wait_for_speech_playback())
+
+        await engine.should_mute_user(BotStartedSpeakingFrame())
+        assert await engine.should_mute_user(TTSSpeakFrame("anything")) is True
+        await engine.should_mute_user(BotStoppedSpeakingFrame())
+
+        assert await waiter is True
+        assert _mute_holds(engine) == set()
+        assert await engine.should_mute_user(TTSSpeakFrame("anything")) is False
 
     @pytest.mark.asyncio
     async def test_wait_for_speech_playback_start_timeout_keeps_other_holds(

--- a/api/tests/test_pipecat_engine_transition_mute.py
+++ b/api/tests/test_pipecat_engine_transition_mute.py
@@ -506,6 +506,56 @@ class TestQueuedSpeechMuteOwnership:
         assert await engine.should_mute_user(TTSSpeakFrame("anything")) is True
 
     @pytest.mark.asyncio
+    async def test_silent_tts_releases_the_hold_it_took(
+        self, simple_workflow: WorkflowGraph
+    ):
+        """Speech that never plays must not mute the caller for the whole call.
+
+        A TTSSpeakFrame whose TTS yields no audio produces no
+        BotStartedSpeakingFrame and no BotStoppedSpeakingFrame, so the hold it
+        took has only its own deadline to release it.
+        """
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+
+        with patch(
+            "api.services.workflow.pipecat_engine._QUEUED_SPEECH_PLAYBACK_START_TIMEOUT_SECONDS",
+            0.01,
+        ):
+            engine.mute_until_speech_playback_ends()
+            assert await engine.should_mute_user(TTSSpeakFrame("anything")) is True
+            await asyncio.sleep(0.05)
+
+        assert _mute_holds(engine) == set()
+        assert await engine.should_mute_user(TTSSpeakFrame("anything")) is False
+
+    @pytest.mark.asyncio
+    async def test_playback_start_keeps_the_hold_past_the_deadline(
+        self, simple_workflow: WorkflowGraph
+    ):
+        """Once the speech is playing, only its end releases the hold."""
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+
+        with patch(
+            "api.services.workflow.pipecat_engine._QUEUED_SPEECH_PLAYBACK_START_TIMEOUT_SECONDS",
+            0.01,
+        ):
+            engine.mute_until_speech_playback_ends()
+            await engine.should_mute_user(BotStartedSpeakingFrame())
+            await asyncio.sleep(0.05)
+
+        assert await engine.should_mute_user(TTSSpeakFrame("anything")) is True
+
+        await engine.should_mute_user(BotStoppedSpeakingFrame())
+
+        assert _mute_holds(engine) == set()
+
+    @pytest.mark.asyncio
     async def test_playback_end_releases_the_hold_it_was_armed_with(
         self, simple_workflow: WorkflowGraph
     ):

--- a/api/tests/test_pipecat_engine_transition_mute.py
+++ b/api/tests/test_pipecat_engine_transition_mute.py
@@ -17,6 +17,7 @@ import pytest
 from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
+    TTSAudioRawFrame,
     TTSSpeakFrame,
 )
 from pipecat.pipeline.pipeline import Pipeline
@@ -44,6 +45,22 @@ from api.services.workflow.pipecat_engine_variable_extractor import (
 from api.services.workflow.workflow_graph import WorkflowGraph
 from api.tests.pipecat_test_utils import run_engine_test_pipeline
 from pipecat.tests import MockLLMService, MockTTSService
+
+
+_engines_under_test: list[PipecatEngine] = []
+
+
+@pytest.fixture(autouse=True)
+async def cleanup_engines():
+    """Tear down every engine a test built.
+
+    Queued-speech holds arm a watchdog that sleeps for the playback start
+    timeout, so without this the tasks outlive the tests that made them.
+    """
+    yield
+    for engine in _engines_under_test:
+        await engine.cleanup()
+    _engines_under_test.clear()
 
 
 async def _build_engine_and_pipeline(
@@ -110,6 +127,7 @@ async def _build_engine_and_pipeline(
 
     task = PipelineWorker(pipeline, params=PipelineParams(), enable_rtvi=False)
     engine.set_task(task)
+    _engines_under_test.append(engine)
 
     return (
         engine,
@@ -504,6 +522,37 @@ class TestQueuedSpeechMuteOwnership:
         assert engine._queued_speech_mute_pending == set()
         assert len(engine._queued_speech_mute_playing) == 1
         assert await engine.should_mute_user(TTSSpeakFrame("anything")) is True
+
+    @pytest.mark.asyncio
+    async def test_audio_after_the_hold_was_released_does_not_mute_again(
+        self, simple_workflow: WorkflowGraph
+    ):
+        """Only the first audio frame hands the hold over.
+
+        ``play_audio`` sends one audio frame today. Were it ever chunked, a
+        chunk arriving after playback released the hold must not mute the
+        caller for an utterance that has already ended.
+        """
+        llm = MockLLMService(mock_steps=[], chunk_delay=0.001)
+        engine, _transport, _task, _strategy, _agg = await _build_engine_and_pipeline(
+            simple_workflow, llm
+        )
+        engine.set_transport_output(SimpleNamespace(queue_frame=AsyncMock()))
+
+        token = engine.acquire_queued_speech_mute()
+        sink = engine.queued_speech_frame_sink(token)
+        audio = TTSAudioRawFrame(audio=b"\x00\x00", sample_rate=16000, num_channels=1)
+
+        await sink(audio)
+        assert await engine.should_mute_user(TTSSpeakFrame("anything")) is True
+
+        await engine.should_mute_user(BotStoppedSpeakingFrame())
+        assert _mute_holds(engine) == set()
+
+        await sink(audio)
+
+        assert _mute_holds(engine) == set()
+        assert await engine.should_mute_user(TTSSpeakFrame("anything")) is False
 
     @pytest.mark.asyncio
     async def test_silent_tts_releases_the_hold_it_took(


### PR DESCRIPTION

Fixes #734.

`_queued_speech_mute_state` was set to `"waiting"` before knowing whether the transition recording (`pipecat_engine.py:357`) or the pre-tool recording (`pipecat_engine_custom_tools.py:425`) would actually play. When `_fetch_recording_audio` returned nothing or raised, no frame was queued, so the `BotStoppedSpeakingFrame` that resets the state (`pipecat_engine.py:1183-1191`) never arrived and `should_mute_user` kept returning `True` until the bot's next utterance — or until the idle timeout if it never spoke again.

Changes
- `try/finally` around fetch+play in both places; the mute is released if nothing was played (falsy result or exception). A successful play keeps `"waiting"` until the bot frames arrive, as before.
- `wait_for_speech_playback` releases the mute on both timeouts (start and playback).
- `api/tests/test_pipecat_engine_transition_mute.py`: three new cases (transition, HTTP tool, timeout). They fail on `main` with `AssertionError: assert 'waiting' == 'idle'` and pass with the fix.

Not changed: pre-existing ruff findings in the two engine files; behaviour when the recording plays successfully.

```
cd api && pytest tests/test_pipecat_engine_transition_mute.py -v   # 5 passed
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #734: queued-speech mute now releases when a recording can't be fetched or speech never plays, instead of leaving the user muted until the next bot utterance or idle timeout. Since function calls run in parallel, the mute is tracked per operation as holds, so a failed fetch only clears its own hold.

**Bug Fixes**

- Each operation takes its own hold, released only while that speech hasn't reached the transport; a hold already handed to playback is left for the `BotStoppedSpeakingFrame` that ends it.
- The hold is handed to playback on the audio frame, so a failure before any audio is queued still releases it, and audio arriving after release doesn't re-mute.
- Silent TTS (empty synthesis, provider error) can't mute the caller for the rest of the call; a 5s deadline drops any hold whose playback never starts.
- A stop frame can't tell which utterance ended, so a hold may release one boundary early — the deliberate bias toward unmuting too soon.
- `wait_for_speech_playback` no longer releases holds it doesn't own.
- Tests cover fetch failure/exception, queue failure before and after audio, both playback timeouts, silent TTS, parallel operations, and late audio after release.

<sup>Written for commit b06137eaac50ebca59b7a555afdbf230c80a52ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/dograh/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change replaces the shared queued-speech mute flag with operation-specific holds, adds cleanup for failed and silent audio, and expands focused coverage for concurrent speech operations. Two previously reported caller-muting defects remain outstanding and must be corrected before merging.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the outstanding caller-muting defects are fixed.

Two outstanding high-impact findings remain. A speech-stop notification clears every active playback hold, including holds for later queued utterances, which can unmute the caller while later audio is still playing. The silent-playback watchdog uses the global bot-speaking state rather than whether its own audio began, so a silent hold can remain active during unrelated speech and keep the caller muted. The earlier failed-fetch ownership finding was fixed, and the earlier cleanup-coverage concern was addressed with the added tests.

<sub>Reviews (4): Last reviewed commit: ["fix(api): hand the queued-speech hold ov..."](https://github.com/dograh-hq/dograh/commit/b06137eaac50ebca59b7a555afdbf230c80a52ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60957578)</sub>

<!-- /greptile_comment -->